### PR TITLE
feat(core): task queue + cron routes

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,25 @@
+name: Maggie Cron
+
+on:
+  schedule:
+    - cron: '*/10 * * * *'
+    - cron: '0 * * * *'
+    - cron: '30 23 * * *'
+  workflow_dispatch:
+
+jobs:
+  cron:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Minute tick
+        if: github.event.schedule == '*/10 * * * *'
+        run: |
+          curl -sS "https://maggie.messyandmagnetic.com/cron/minute?key=${{ secrets.WORKER_CRON_KEY }}" || exit 1
+      - name: Hourly tick
+        if: github.event.schedule == '0 * * * *'
+        run: |
+          curl -sS "https://maggie.messyandmagnetic.com/cron/hourly?key=${{ secrets.WORKER_CRON_KEY }}" || exit 1
+      - name: Daily tick
+        if: github.event.schedule == '30 23 * * *'
+        run: |
+          curl -sS "https://maggie.messyandmagnetic.com/cron/daily?key=${{ secrets.WORKER_CRON_KEY }}" || exit 1

--- a/README.md
+++ b/README.md
@@ -189,6 +189,18 @@ Example schedules (configure in Cloudflare Dashboard):
 0 8 * * 1 https://maggie-worker.messyandmagnetic.workers.dev/land/summary
 ```
 
+### Worker cron & task queue
+
+The public worker exposes a small FIFO queue backed by the `BRAIN` KV store.
+
+Routes:
+
+- `POST /tasks/enqueue` – add a task `{ type, payload }`
+- `GET /tasks/size` – current queue depth
+- `GET /cron/minute`, `/cron/hourly`, `/cron/daily` – process up to five queued tasks
+
+Supported task types (stubs): `tiktok.post`, `orders.fulfill`, `summary.daily`.
+
 Example curl for /start:
 
 ```sh

--- a/worker/lib/queue.ts
+++ b/worker/lib/queue.ts
@@ -1,0 +1,60 @@
+export interface QueueEnv {
+  BRAIN: KVNamespace;
+}
+
+export interface QueueItem {
+  type: string;
+  payload: any;
+}
+
+const MAIN_KEY = 'q:main';
+const LOCK_KEY = 'q:lock';
+
+async function withLock<T>(env: QueueEnv, fn: () => Promise<T>): Promise<T> {
+  const start = Date.now();
+  while (true) {
+    const locked = await env.BRAIN.get(LOCK_KEY);
+    if (!locked) {
+      await env.BRAIN.put(LOCK_KEY, String(Date.now()), { expirationTtl: 30 });
+      break;
+    }
+    if (Date.now() - start > 1000) {
+      throw new Error('lock timeout');
+    }
+    await new Promise((res) => setTimeout(res, 50));
+  }
+  try {
+    return await fn();
+  } finally {
+    await env.BRAIN.delete(LOCK_KEY).catch(() => {});
+  }
+}
+
+export async function enqueue(env: QueueEnv, type: string, payload: any) {
+  await withLock(env, async () => {
+    const raw = (await env.BRAIN.get(MAIN_KEY)) || '[]';
+    const list: QueueItem[] = JSON.parse(raw);
+    list.push({ type, payload });
+    await env.BRAIN.put(MAIN_KEY, JSON.stringify(list));
+  });
+}
+
+export async function dequeue(env: QueueEnv): Promise<QueueItem[]> {
+  return withLock(env, async () => {
+    const raw = (await env.BRAIN.get(MAIN_KEY)) || '[]';
+    const list: QueueItem[] = JSON.parse(raw);
+    const items = list.splice(0, 5); // process max 5 items per tick
+    await env.BRAIN.put(MAIN_KEY, JSON.stringify(list));
+    return items;
+  });
+}
+
+export async function size(env: QueueEnv): Promise<number> {
+  const raw = (await env.BRAIN.get(MAIN_KEY)) || '[]';
+  try {
+    const list: QueueItem[] = JSON.parse(raw);
+    return list.length;
+  } catch {
+    return 0;
+  }
+}

--- a/worker/routes/cron.ts
+++ b/worker/routes/cron.ts
@@ -1,0 +1,43 @@
+import { dequeue, QueueEnv, QueueItem } from '../lib/queue';
+
+function cors(extra: Record<string, string> = {}) {
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+    'Access-Control-Allow-Headers':
+      'Content-Type,Authorization,Stripe-Signature,X-Requested-With',
+    ...extra,
+  };
+}
+
+async function runTask(_env: QueueEnv, _item: QueueItem) {
+  // Supported task stubs
+  switch (_item.type) {
+    case 'tiktok.post':
+    case 'orders.fulfill':
+    case 'summary.daily':
+      // real implementation would go here
+      break;
+    default:
+      break;
+  }
+}
+
+async function tick(env: QueueEnv, label: string): Promise<Response> {
+  const items = await dequeue(env);
+  for (const item of items) {
+    await runTask(env, item);
+  }
+  return new Response(
+    JSON.stringify({ ok: true, tick: label, processed: items.length, types: items.map(i => i.type) }),
+    { headers: { 'content-type': 'application/json', ...cors() } }
+  );
+}
+
+export async function handleCron(request: Request, env: QueueEnv): Promise<Response | null> {
+  const url = new URL(request.url);
+  if (url.pathname === '/cron/minute') return tick(env, 'minute');
+  if (url.pathname === '/cron/hourly') return tick(env, 'hourly');
+  if (url.pathname === '/cron/daily') return tick(env, 'daily');
+  return null;
+}

--- a/worker/routes/tasks.ts
+++ b/worker/routes/tasks.ts
@@ -1,0 +1,40 @@
+import { enqueue, size, QueueEnv } from '../lib/queue';
+
+function cors(extra: Record<string, string> = {}) {
+  return {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+    'Access-Control-Allow-Headers':
+      'Content-Type,Authorization,Stripe-Signature,X-Requested-With',
+    ...extra,
+  };
+}
+
+export async function handleTasks(request: Request, env: QueueEnv): Promise<Response | null> {
+  const url = new URL(request.url);
+
+  if (request.method === 'POST' && url.pathname === '/tasks/enqueue') {
+    try {
+      const { type, payload } = await request.json();
+      await enqueue(env, String(type), payload);
+      return new Response(JSON.stringify({ ok: true }), {
+        headers: { 'content-type': 'application/json', ...cors() },
+      });
+    } catch (e: any) {
+      return new Response(
+        JSON.stringify({ ok: false, error: String(e?.message ?? e) }),
+        { status: 400, headers: { 'content-type': 'application/json', ...cors() } }
+      );
+    }
+  }
+
+  if (request.method === 'GET' && url.pathname === '/tasks/size') {
+    const n = await size(env);
+    return new Response(
+      JSON.stringify({ ok: true, size: n }),
+      { headers: { 'content-type': 'application/json', ...cors() } }
+    );
+  }
+
+  return null;
+}

--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -15,9 +15,12 @@
 // in your POSTQ namespace (binding name must be POSTQ).
 
 import { handleTelegramCommand } from '../src/telegram/handleCommand';
+import { handleCron } from './routes/cron';
+import { handleTasks } from './routes/tasks';
 
 export interface Env {
   POSTQ: KVNamespace; // KV binding defined in wrangler.toml
+  BRAIN: KVNamespace;
 }
 
 /* ---------------- Apps Script URL (static) ---------------- */
@@ -277,6 +280,16 @@ export default {
       return new Response(JSON.stringify({ ok: true, present }, null, 2), {
         headers: { 'content-type': 'application/json', ...cors() },
       });
+    }
+
+    // Cron + task queue endpoints
+    {
+      const res = await handleCron(request, env);
+      if (res) return res;
+    }
+    {
+      const res = await handleTasks(request, env);
+      if (res) return res;
     }
 
     // --- AI endpoints (fully KV-driven) ---


### PR DESCRIPTION
## Summary
- add KV-backed FIFO task queue and route handlers
- expose cron endpoints to process queued tasks
- document task queue and configure scheduled curl workflow

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5ea3830fc8327a66a3dcc0c5e0476