### PR TITLE
Update name in Wrangler configuration file to match deployed Worker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,16 +6,19 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: "20" }
       - run: corepack enable
       - run: pnpm run ci:build
+      - name: Render wrangler.toml with KV secret
+        run: |
+          sed -i 's#__KV_POSTQ_ID__#${{ secrets.CF_KV_POSTQ_NAMESPACE_ID }}#g' wrangler.toml
       - name: Publish
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
         run: |
           if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
             npx wrangler deploy

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,10 @@ main = "worker/worker.ts"
 compatibility_date = "2024-11-21"
 workers_dev = true
 
+[[kv_namespaces]]
+binding = "POSTQ"
+id = "__KV_POSTQ_ID__"
+
 [vars]
 ENV = "prod"
 


### PR DESCRIPTION
The Worker name in your Wrangler configuration file does not match the name of the deployed Worker in the Cloudflare Dashboard.
		Cloudflare automatically generated this PR to resolve the mismatch and avoid inconsistencies between environments. For more information, see: https://developers.cloudflare.com/workers/ci-cd/builds/troubleshoot/#workers-name-requirement