### PR TITLE
Route mags-assistant to maggie.messyandmagnetic.com

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
-# .github/workflows/deploy.yml
 name: Deploy Worker
 
 on:
   workflow_dispatch:
   push:
+    branches: [ main ]
 
 concurrency:
   group: deploy-worker
@@ -14,29 +14,24 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-
       - name: Enable Corepack & pnpm
         run: |
           corepack enable
           corepack prepare pnpm@10.15.0 --activate
           pnpm --version
-
       - name: Install deps
         run: pnpm install --no-frozen-lockfile
-
       - name: Show Wrangler version
         run: npx wrangler --version
-
       - name: Publish (main) or upload version (branches)
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
         run: |
           if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
             npx wrangler deploy --config wrangler.toml

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,13 +1,16 @@
-# wrangler.toml
 name = "mags-assistant"
 main = "worker/worker.ts"
 compatibility_date = "2025-09-03"
 
-account_id = "5ff52dc210a86ff34a0dd3664bacb237"  # <-- your account id
-
 [vars]
 ENV = "prod"
 
+# Keep this section and DO NOT change the id value.
 [[kv_namespaces]]
 binding = "BRAIN"
-id = "1b8cbbc4a2f8426194368cb39baded79"
+id = "1b8cbbc4a2f8426194368cb39baded79"   # <-- keep my current value
+
+# Route my Worker to the custom domain
+routes = [
+  { pattern = "maggie.messyandmagnetic.com/*", zone_name = "messyandmagnetic.com" }
+]


### PR DESCRIPTION
## Summary
- route `mags-assistant` Worker to `maggie.messyandmagnetic.com/*`
- wire `Deploy Worker` workflow with CF_ACCOUNT_ID and pnpm setup

## Testing
- `pnpm lint`
- `pnpm test` *(fails: No test files found)*
- `curl -s -o /tmp/health_body -w "%{http_code}" https://maggie.messyandmagnetic.com/health`

------
https://chatgpt.com/codex/tasks/task_e_68b9ca5c752c83278da428d1b57a8f67