### PR TITLE
ops: email + outreach + stripe/tally + sync + admin surface (non-breaking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,11 @@ Backfill: provide `TALLY_API_KEY` and run the **Backfill Tally** sheet menu or t
 
 Docs: [Apps Script deploy](docs/apps-script-deploy.md) · [Sheet details](docs/tally-sheets.md) · [Curl tests](docs/tally-tests.md)
 
+### Email inbound
+
+Point your Gmail Apps Script WebApp to `https://assistant.messyandmagnetic.com/email/inbound` with JSON `{ from, to, subject, html?, text? }`.
+
+
 ### Smoke tests
 
 The `smoke` GitHub Action checks the worker `/health` endpoint and posts synthetic payloads to `/tally-intake`. View logs in the Actions tab and re-run the workflow as needed.

--- a/docs/INVENTORY-OPS.md
+++ b/docs/INVENTORY-OPS.md
@@ -1,0 +1,200 @@
+# Ops Inventory
+
+## Routes
+- GET /health → worker/health.ts
+- GET /diag/config → worker/health.ts
+- POST /webhooks/stripe → worker/orders/stripe.ts
+- POST /webhooks/tally → worker/orders/tally.ts
+- POST /telegram-webhook → worker/routes/telegram.ts
+- POST /email/inbound → worker/routes/email.ts
+- POST /email/reply → worker/routes/email.ts
+- GET /email/status → worker/routes/email.ts
+- POST /outreach/lead → worker/routes/outreach.ts
+- POST /outreach/enqueue → worker/routes/outreach.ts
+- GET /outreach/lead → worker/routes/outreach.ts
+- GET /outreach/leads → worker/routes/outreach.ts
+- POST /sync/notion → worker/routes/sync.ts
+- POST /sync/drive → worker/routes/sync.ts
+- POST /ops/enqueue → worker/routes/ops.ts
+- POST /ops/tick → worker/routes/ops.ts
+- GET /admin/status → worker/routes/admin.ts
+- POST /admin/trigger → worker/routes/admin.ts
+- /ai/* → worker/routes/ai (if present)
+- /api/appscript → worker/routes/appscript (if present)
+- /tiktok/* → worker/routes/tiktok (if present)
+- /tasks/* → worker/routes/tasks (if present)
+- /cron/* → worker/routes/cron (if present)
+- /api/browser → worker/routes/browser.ts
+- GET /ready → worker/routes/ready (if present)
+
+## Env vars
+- AI
+- ALLOWED_DOMAINS
+- ALLOWED_ORIGINS
+- API_BASE
+- BROWSERLESS_API_KEY
+- BROWSERLESS_API_URL
+- BROWSERLESS_BASE_URL
+- BROWSERLESS_TOKEN
+- BUFFER_ACCESS_TOKEN
+- BUFFER_PROFILE_ID
+- CAPCUT_EXPORT_FOLDER
+- CAPCUT_RAW_FOLDER
+- CAPCUT_TEMPLATE
+- CHAN_DRIVE_ROOT_ID
+- CHAT_PASSWORD
+- CLOUDFLARE_API_TOKEN
+- CODEX_MODEL
+- CONFIGS
+- COYOTE_DRIVE_FOLDER_ID
+- COYOTE_NOTION_PAGE_ID
+- CRON_SECRET
+- DALL_E_STYLE_PROMPT
+- DONORS_DATABASE_ID
+- DRIVE_INBOX_FOLDER_ID
+- DRIVE_PRODUCT_IMAGES_ROOT_ID
+- DRY_RUN
+- EXECUTION_PAUSED
+- FETCH_PASS
+- FILING_STATUS
+- FOLLOWUPS_DUE_COUNT
+- FORCE_API_UPLOAD
+- GAS_INTAKE_URL
+- GCP_DO_DISABLE
+- GCP_LOCATION
+- GCP_PROJECT_ID
+- GCP_SA_EMAIL
+- GCP_SA_KEY_JSON
+- GCP_SCOPES
+- GEMINI_API_KEY
+- GITHUB_REDEPLOY_TOKEN
+- GMAIL_SENDER
+- GOOGLE_APPLICATION_CREDENTIALS
+- GOOGLE_CLIENT_EMAIL
+- GOOGLE_CLIENT_ID
+- GOOGLE_CLIENT_SECRET
+- GOOGLE_CREDENTIALS_JSON
+- GOOGLE_KEY_URL
+- GOOGLE_PRIVATE_KEY
+- GOOGLE_REDIRECT_URI
+- GOOGLE_SHEET_ID
+- HOT_LEADS
+- INSTAGRAM_API_KEY
+- KV
+- LATEST_BUDGET_URL
+- LATEST_METRICS_URL
+- LATEST_ONEPAGER_URL
+- LATEST_SELLER_LETTER_URL
+- LINKEDIN_API_KEY
+- MAGGIE_LOG_TO_CONSOLE
+- MAGS_KEY
+- MASTER_MEMORY_SHEET_ID
+- MM_DRIVE_ARCHIVE_ID
+- MM_DRIVE_CHANCUB_PARENT_ID
+- MM_DRIVE_FAILED_ID
+- MM_DRIVE_INBOX_ID
+- MM_DRIVE_MM_PARENT_ID
+- MM_DRIVE_READY_ID
+- MM_DRIVE_REVIEW_ID
+- MM_DRIVE_ROOT_ID
+- NEUTER
+- NEXT_PUBLIC_FETCH_PASS
+- NEXT_PUBLIC_GITHUB_OWNER
+- NEXT_PUBLIC_GITHUB_REPO
+- NEXT_PUBLIC_SITE_URL
+- NODE_ENV
+- NOTIFY_EMAIL
+- NOTION_API_KEY
+- NOTION_DATABASE_ID
+- NOTION_DB_ID
+- NOTION_DB_RUNS_ID
+- NOTION_HQ_PAGE_ID
+- NOTION_INBOX_PAGE_ID
+- NOTION_ORDER_DB
+- NOTION_PROFILE_DB_ID
+- NOTION_QUEUE_DB
+- NOTION_QUEUE_DB_ID
+- NOTION_ROOT_PAGE_ID
+- NOTION_SOCIAL_DB
+- NOTION_STRIPE_DB_ID
+- NOTION_TOKEN
+- NOTION_TRACKER_LINK
+- OFFLINE_MODE
+- OPENAI_API_KEY
+- PINTEREST_API_KEY
+- PLEDGED_TOTAL
+- POSTQ
+- POST_INTERVAL_MS
+- POST_THREAD_SECRET
+- PREFERRED_OPENAI_MODEL
+- PRICE_HISTORY_SHEET_ID
+- PROD_DOMAIN
+- PROFILE_DB_ID
+- PROPERTY_STAGE
+- RECEIVED_TOTAL
+- RESEND_API_KEY
+- RESEND_FROM
+- SALES_TAX_STATE
+- SALES_TAX_ZIP
+- SCHEDULER
+- SCRAPER_PROVIDER
+- SECRETS_BLOB
+- SECRET_BLOB
+- SENDGRID_API_KEY
+- SHEETS_TRACKER_LINK
+- STRIPE_SECRET_KEY
+- STRIPE_WEBHOOK_SECRET
+- TALLY_API_KEY
+- TALLY_WEBHOOK_SECRET
+- TARGET_PRICE
+- TELEGRAM_BOT_TOKEN
+- TELEGRAM_CALLBACK_SECRET
+- TELEGRAM_CHAT_ID
+- TELEGRAM_DEV_ID
+- TIKTOK_ACCESS_TOKEN
+- TIKTOK_API_UPLOAD_URL
+- TIKTOK_APP_ID
+- TIKTOK_APP_SECRET
+- TIKTOK_CLIENT_KEY
+- TIKTOK_CLIENT_SECRET
+- TIKTOK_PROFILE_MAGGIE
+- TIKTOK_REDIRECT_URL
+- TIKTOK_REFRESH_TOKEN
+- TIKTOK_SESSION_MAGGIE
+- TIKTOK_SESSION_MARS
+- TIKTOK_SESSION_WILLOW
+- TWITTER_API_KEY
+- USE_CAPCUT
+- VERCEL_URL
+- WARM_LEADS
+- WORKER_BASE_URL
+- WORKER_KEY
+- WORKER_URL
+- YOUTUBE_API_KEY
+
+## KV keys
+- email:inbox:<id>
+- leads:<uuid>
+- stripe:evt:<id>
+- tally:evt:<id>
+- queue:ops
+- tiktok:queue
+- thread-state:persona
+- thread-state:boosters
+
+## Integrations
+- Email/CRM: Apps Script broker with /email/inbound and /email/reply
+- Stripe/Tally: webhook endpoints queue jobs
+- Telegram: /telegram-webhook with admin commands
+- Notion/Drive sync: /sync/notion and /sync/drive
+- Task queues: queue:ops (KV), tiktok:queue
+- Scheduler: Cloudflare cron via worker scheduled()
+
+## Roles checklist
+- [x] Email triage & reply
+- [x] Grants & donor outreach queue
+- [x] Stripe + Tally wiring sanity
+- [x] Notion & Drive sync
+- [x] Telegram controls
+- [x] Ops queue + scheduler
+- [x] Admin surface

--- a/docs/OPS-QUICKSTART.md
+++ b/docs/OPS-QUICKSTART.md
@@ -1,0 +1,42 @@
+# Ops Quickstart
+
+## Apps Script inbound
+Set your Gmail Apps Script WebApp to POST normalized messages to `https://assistant.messyandmagnetic.com/email/inbound`.
+
+## Curl examples
+```bash
+# send reply
+curl -XPOST https://assistant.messyandmagnetic.com/email/reply \
+  -H 'content-type: application/json' \
+  -d '{"to":"test@example.com","subject":"hi","text":"hello"}'
+
+# save lead
+curl -XPOST https://assistant.messyandmagnetic.com/outreach/lead \
+  -H 'content-type: application/json' \
+  -d '{"email":"a@b.com","tags":["grant"]}'
+
+# enqueue outreach
+curl -XPOST https://assistant.messyandmagnetic.com/outreach/enqueue \
+  -H 'content-type: application/json' \
+  -d '{"leadId":"<id>","templateId":"intro"}'
+
+# Notion sync
+curl -XPOST https://assistant.messyandmagnetic.com/sync/notion \
+  -H 'content-type: application/json' \
+  -d '{"props":{"Name":{"title":[{"text":{"content":"Test"}}]}}}'
+
+# Drive upload
+curl -XPOST https://assistant.messyandmagnetic.com/sync/drive \
+  -H 'content-type: application/json' \
+  -d '{"path":"notes.txt","content":"hello"}'
+
+# enqueue job
+curl -XPOST https://assistant.messyandmagnetic.com/ops/enqueue \
+  -H 'content-type: application/json' \
+  -d '{"job":{"kind":"email_inbound","id":"x"}}'
+
+# admin status
+curl https://assistant.messyandmagnetic.com/admin/status
+```
+
+Maggie acts as you; respect opt-out and consent requirements.

--- a/src/ops/email.ts
+++ b/src/ops/email.ts
@@ -1,0 +1,35 @@
+export async function handleInbound(job: any, env: any) {
+  const key = `email:inbox:${job.id}`;
+  const item = await env.BRAIN.get(key, { type: 'json' });
+  if (!item) return;
+  let reply = 'Thanks for reaching out!';
+  if (env.OPENAI_API_KEY) {
+    try {
+      const tone = (await env.BRAIN.get('thread-state:persona', { type: 'json' }))?.tone || 'friendly';
+      const prompt = `Reply in a ${tone} tone to: ${item.text || item.subject}`;
+      const r = await fetch('https://api.openai.com/v1/completions', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          Authorization: `Bearer ${env.OPENAI_API_KEY}`,
+        },
+        body: JSON.stringify({ model: 'gpt-3.5-turbo-instruct', prompt, max_tokens: 100 }),
+      });
+      const data = await r.json();
+      reply = data.choices?.[0]?.text?.trim() || reply;
+    } catch {}
+  }
+  item.reply = reply;
+  await env.BRAIN.put(key, JSON.stringify(item));
+}
+
+export async function sendReply(env: any, body: any) {
+  const url = env.APPS_SCRIPT_WEBAPP_URL;
+  if (!url) return { ok: false, message: 'apps script missing' };
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return { ok: res.ok };
+}

--- a/src/ops/orders.ts
+++ b/src/ops/orders.ts
@@ -1,0 +1,18 @@
+import { sendReply } from './email';
+
+export async function handle(job: any, env: any) {
+  if (job.kind === 'fulfill_order') {
+    const evt = await env.BRAIN.get(`stripe:evt:${job.id}`, { type: 'json' });
+    if (!evt) return;
+    const email = evt.data?.object?.customer_email || evt.data?.object?.receipt_email;
+    const body = `Thank you for your order of ${evt.data?.object?.amount_total}`;
+    await sendReply(env, { to: email, subject: 'Order received', text: body });
+  }
+  if (job.kind === 'process_form') {
+    const evt = await env.BRAIN.get(`tally:evt:${job.id}`, { type: 'json' });
+    if (!evt) return;
+    const email = evt.data?.email;
+    const body = 'Thanks for your submission';
+    await sendReply(env, { to: email, subject: 'Form received', text: body });
+  }
+}

--- a/src/ops/outreach.ts
+++ b/src/ops/outreach.ts
@@ -1,0 +1,41 @@
+import { sendReply } from './email';
+
+async function getTemplate(templateId: string, env: any) {
+  if (env.NOTION_API_KEY && env.NOTION_DB_ID) {
+    try {
+      const r = await fetch(`https://api.notion.com/v1/blocks/${templateId}/children`, {
+        headers: {
+          'Notion-Version': '2022-06-28',
+          Authorization: `Bearer ${env.NOTION_API_KEY}`,
+        },
+      });
+      const data = await r.json();
+      const text = data.results?.map((b: any) => b.paragraph?.text?.map((t: any) => t.plain_text).join('')).join('\n');
+      if (text) return text;
+    } catch {}
+  }
+  const fs = await import('node:fs');
+  try {
+    return fs.readFileSync(`templates/outreach/${templateId}.md`, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+export async function renderTemplate(templateId: string, context: any, env: any) {
+  let tpl = await getTemplate(templateId, env);
+  for (const [k, v] of Object.entries(context || {})) {
+    tpl = tpl.replace(new RegExp(`{{${k}}}`, 'g'), String(v));
+  }
+  return tpl;
+}
+
+export async function handle(job: any, env: any) {
+  const lead = await env.BRAIN.get(`leads:${job.leadId}`, { type: 'json' });
+  if (!lead) return;
+  const body = await renderTemplate(job.templateId, lead, env);
+  const res = await sendReply(env, { to: lead.email, subject: 'Hello', text: body });
+  lead.lastResult = res.ok ? 'sent' : 'error';
+  lead.lastSent = Date.now();
+  await env.BRAIN.put(`leads:${job.leadId}`, JSON.stringify(lead));
+}

--- a/src/ops/queue.ts
+++ b/src/ops/queue.ts
@@ -1,0 +1,14 @@
+export async function enqueue(env: any, job: any) {
+  const key = 'queue:ops';
+  const arr = (await env.BRAIN.get(key, { type: 'json' })) || [];
+  arr.push({ ...job, ts: Date.now() });
+  await env.BRAIN.put(key, JSON.stringify(arr));
+}
+
+export async function dequeue(env: any, max = 3) {
+  const key = 'queue:ops';
+  const arr = (await env.BRAIN.get(key, { type: 'json' })) || [];
+  const jobs = arr.splice(0, max);
+  await env.BRAIN.put(key, JSON.stringify(arr));
+  return jobs;
+}

--- a/src/ops/sync.ts
+++ b/src/ops/sync.ts
@@ -1,0 +1,28 @@
+export async function notionUpsert(env: any, body: any) {
+  if (!env.NOTION_API_KEY || !env.NOTION_DB_ID) return { ok: false };
+  const url = body.pageId
+    ? `https://api.notion.com/v1/pages/${body.pageId}`
+    : 'https://api.notion.com/v1/pages';
+  const method = body.pageId ? 'patch' : 'post';
+  const res = await fetch(url, {
+    method: method.toUpperCase(),
+    headers: {
+      'Notion-Version': '2022-06-28',
+      Authorization: `Bearer ${env.NOTION_API_KEY}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({ parent: { database_id: env.NOTION_DB_ID }, properties: body.props || {} }),
+  });
+  return { ok: res.ok };
+}
+
+export async function driveUpload(env: any, body: any) {
+  const url = env.APPS_SCRIPT_WEBAPP_URL;
+  if (!url) return { ok: false };
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ action: 'driveUpload', ...body }),
+  });
+  return { ok: res.ok };
+}

--- a/src/ops/telegram.ts
+++ b/src/ops/telegram.ts
@@ -1,0 +1,41 @@
+export async function handleUpdate(update: any, env: any, req: Request) {
+  const message = update.message?.text || '';
+  const chatId = update.message?.chat?.id;
+  if (!message || !chatId) return { ok: false };
+  const origin = new URL(req.url).origin;
+  const send = async (text: string) =>
+    fetch(`https://api.telegram.org/bot${env.TELEGRAM_BOT_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ chat_id: chatId, text }),
+    });
+  const [cmd, ...rest] = message.split(' ');
+  if (cmd === '/status') {
+    const r = await fetch(origin + '/admin/status');
+    const txt = await r.text();
+    await send(txt);
+  } else if (cmd === '/plan') {
+    const r = await fetch(origin + '/planner/today');
+    await send(r.ok ? await r.text() : 'no plan yet');
+  } else if (cmd === '/post') {
+    const handle = rest.shift();
+    const url = rest.shift();
+    const caption = rest.join(' ');
+    await fetch(origin + '/tiktok/post', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ handle, url, caption }),
+    });
+    await send('posted');
+  } else if (cmd === '/boost') {
+    const postUrl = rest.shift();
+    const boosters = (await env.BRAIN.get('thread-state:boosters', { type: 'json' }))?.boosters || [];
+    await fetch(origin + '/tiktok/eng/orchestrate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ postUrl, boosters }),
+    });
+    await send('boosting');
+  }
+  return { ok: true };
+}

--- a/templates/outreach/followup.md
+++ b/templates/outreach/followup.md
@@ -1,0 +1,2 @@
+Hello {{first_name}},
+Following up on {{project}} – let me know if questions. {{url}}

--- a/templates/outreach/intro.md
+++ b/templates/outreach/intro.md
@@ -1,0 +1,3 @@
+Hi {{first_name}},
+
+I'm reaching out about {{project}}. More at {{url}}.

--- a/worker/orders/stripe.ts
+++ b/worker/orders/stripe.ts
@@ -1,0 +1,12 @@
+import { enqueue } from '../../src/ops/queue';
+
+export async function onRequestPost({ request, env }: any) {
+  const sig = request.headers.get('stripe-signature');
+  if (env.STRIPE_WEBHOOK_SECRET && sig !== env.STRIPE_WEBHOOK_SECRET) {
+    return new Response('unauthorized', { status: 401 });
+  }
+  const event = await request.json();
+  await env.BRAIN.put(`stripe:evt:${event.id}`, JSON.stringify(event));
+  await enqueue(env, { kind: 'fulfill_order', id: event.id });
+  return new Response('ok');
+}

--- a/worker/orders/tally.ts
+++ b/worker/orders/tally.ts
@@ -1,0 +1,12 @@
+import { enqueue } from '../../src/ops/queue';
+
+export async function onRequestPost({ request, env }: any) {
+  const sig = request.headers.get('tally-signature');
+  if (env.TALLY_SIGNING_SECRET && sig !== env.TALLY_SIGNING_SECRET) {
+    return new Response('unauthorized', { status: 401 });
+  }
+  const event = await request.json();
+  await env.BRAIN.put(`tally:evt:${event.id || event.eventId || crypto.randomUUID()}`, JSON.stringify(event));
+  await enqueue(env, { kind: 'process_form', id: event.id || event.eventId });
+  return new Response('ok');
+}

--- a/worker/routes/admin.ts
+++ b/worker/routes/admin.ts
@@ -1,0 +1,32 @@
+export async function onRequestGet({ env }: any) {
+  const now = new Date();
+  const emailCount = (await env.BRAIN.list({ prefix: 'email:inbox:' })).keys.length;
+  const leadCount = (await env.BRAIN.list({ prefix: 'leads:' })).keys.length;
+  const opsCount = ((await env.BRAIN.get('queue:ops', { type: 'json' })) || []).length;
+  const tikTokCount = ((await env.BRAIN.get('tiktok:queue', { type: 'json' })) || []).length;
+  const secrets = ['OPENAI_API_KEY','NOTION_API_KEY','STRIPE_SECRET_KEY','TALLY_SIGNING_SECRET','APPS_SCRIPT_WEBAPP_URL','BROWSERLESS_TOKEN'];
+  const present = secrets.filter((k) => env[k]);
+  const routesCount = 10;
+  return new Response(
+    JSON.stringify({ ok: true, now: now.toISOString(), tz: Intl.DateTimeFormat().resolvedOptions().timeZone, kvCounts: { emails: emailCount, leads: leadCount, queueOps: opsCount, queueTikTok: tikTokCount }, secretsPresent: present, routesCount }),
+    { headers: { 'content-type': 'application/json' } }
+  );
+}
+
+export async function onRequestPost({ request, env }: any) {
+  const body = await request.json();
+  if (body.kind === 'ops') {
+    const mod: any = await import('./ops');
+    await mod.runScheduled(null, env);
+  }
+  if (body.kind === 'tick') {
+    try { const t: any = await import('./tiktok'); if (t.runScheduled) await t.runScheduled(null, env); } catch {}
+  }
+  if (body.kind === 'trends') {
+    try { const t: any = await import('./tiktok'); if (t.refreshTrends) await t.refreshTrends(env); } catch {}
+  }
+  if (body.kind === 'plan') {
+    await fetch(new URL('/planner/today', request.url).toString());
+  }
+  return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
+}

--- a/worker/routes/email.ts
+++ b/worker/routes/email.ts
@@ -1,0 +1,29 @@
+import { enqueue } from '../../src/ops/queue';
+import { sendReply } from '../../src/ops/email';
+
+export async function onRequestPost({ request, env }: any) {
+  const { pathname } = new URL(request.url);
+  if (pathname === '/email/inbound') {
+    const body = await request.json();
+    const id = crypto.randomUUID();
+    await env.BRAIN.put(`email:inbox:${id}`, JSON.stringify({ id, ...body, ts: Date.now(), status: 'new' }));
+    await enqueue(env, { kind: 'email_inbound', id });
+    return new Response(JSON.stringify({ ok: true, id }), { headers: { 'content-type': 'application/json' } });
+  }
+  if (pathname === '/email/reply') {
+    const body = await request.json();
+    const r = await sendReply(env, body);
+    return new Response(JSON.stringify(r), { headers: { 'content-type': 'application/json' } });
+  }
+  return new Response('not found', { status: 404 });
+}
+
+export async function onRequestGet({ request, env }: any) {
+  const { searchParams } = new URL(request.url);
+  const id = searchParams.get('id');
+  if (id) {
+    const item = await env.BRAIN.get(`email:inbox:${id}`, { type: 'json' });
+    return new Response(JSON.stringify(item || null), { headers: { 'content-type': 'application/json' } });
+  }
+  return new Response('missing id', { status: 400 });
+}

--- a/worker/routes/ops.ts
+++ b/worker/routes/ops.ts
@@ -1,0 +1,37 @@
+import { enqueue, dequeue } from '../../src/ops/queue';
+import { handle as outreachHandle } from '../../src/ops/outreach';
+import { handle as orderHandle } from '../../src/ops/orders';
+import { handleInbound } from '../../src/ops/email';
+
+async function run(env: any) {
+  const jobs = await dequeue(env, 5);
+  for (const job of jobs) {
+    try {
+      if (job.kind === 'email_outreach') await outreachHandle(job, env);
+      else if (job.kind === 'fulfill_order' || job.kind === 'process_form') await orderHandle(job, env);
+      else if (job.kind === 'email_inbound') await handleInbound(job, env);
+      console.log('ops', job.kind);
+    } catch (err) {
+      console.log('ops err', job.kind, err);
+    }
+  }
+  return { processed: jobs.length };
+}
+
+export async function onRequestPost({ request, env }: any) {
+  const { pathname } = new URL(request.url);
+  if (pathname === '/ops/enqueue') {
+    const body = await request.json();
+    await enqueue(env, body.job || body);
+    return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
+  }
+  if (pathname === '/ops/tick') {
+    const r = await run(env);
+    return new Response(JSON.stringify(r), { headers: { 'content-type': 'application/json' } });
+  }
+  return new Response('not found', { status: 404 });
+}
+
+export async function runScheduled(_event: any, env: any) {
+  await run(env);
+}

--- a/worker/routes/outreach.ts
+++ b/worker/routes/outreach.ts
@@ -1,0 +1,39 @@
+import { enqueue } from '../../src/ops/queue';
+
+export async function onRequestPost({ request, env }: any) {
+  const { pathname } = new URL(request.url);
+  if (pathname === '/outreach/lead') {
+    const body = await request.json();
+    const id = crypto.randomUUID();
+    await env.BRAIN.put(`leads:${id}`, JSON.stringify({ id, ...body, ts: Date.now() }));
+    return new Response(JSON.stringify({ ok: true, id }), { headers: { 'content-type': 'application/json' } });
+  }
+  if (pathname === '/outreach/enqueue') {
+    const body = await request.json();
+    await enqueue(env, { kind: 'email_outreach', ...body });
+    return new Response(JSON.stringify({ ok: true }), { headers: { 'content-type': 'application/json' } });
+  }
+  return new Response('not found', { status: 404 });
+}
+
+export async function onRequestGet({ request, env }: any) {
+  const { pathname, searchParams } = new URL(request.url);
+  if (pathname === '/outreach/lead') {
+    const id = searchParams.get('id');
+    if (id) {
+      const item = await env.BRAIN.get(`leads:${id}`, { type: 'json' });
+      return new Response(JSON.stringify(item || null), { headers: { 'content-type': 'application/json' } });
+    }
+  }
+  if (pathname === '/outreach/leads') {
+    const tag = searchParams.get('tag');
+    const list = await env.BRAIN.list({ prefix: 'leads:' });
+    const items = [];
+    for (const k of list.keys) {
+      const v = await env.BRAIN.get(k.name, { type: 'json' });
+      if (!tag || v.tags?.includes(tag)) items.push(v);
+    }
+    return new Response(JSON.stringify(items), { headers: { 'content-type': 'application/json' } });
+  }
+  return new Response('not found', { status: 404 });
+}

--- a/worker/routes/sync.ts
+++ b/worker/routes/sync.ts
@@ -1,0 +1,15 @@
+import { notionUpsert, driveUpload } from '../../src/ops/sync';
+
+export async function onRequestPost({ request, env }: any) {
+  const { pathname } = new URL(request.url);
+  const body = await request.json();
+  if (pathname === '/sync/notion') {
+    const r = await notionUpsert(env, body);
+    return new Response(JSON.stringify(r), { headers: { 'content-type': 'application/json' } });
+  }
+  if (pathname === '/sync/drive') {
+    const r = await driveUpload(env, body);
+    return new Response(JSON.stringify(r), { headers: { 'content-type': 'application/json' } });
+  }
+  return new Response('not found', { status: 404 });
+}

--- a/worker/routes/telegram.ts
+++ b/worker/routes/telegram.ts
@@ -1,0 +1,7 @@
+import { handleUpdate } from '../../src/ops/telegram';
+
+export async function onRequestPost({ request, env }: any) {
+  const update = await request.json();
+  await handleUpdate(update, env, request);
+  return new Response('ok');
+}

--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -109,6 +109,36 @@ export default {
       if (r && r.status !== 404) return r;
     }
 
+    // Email routes
+    {
+      const r = await tryRoute("/email/", "./routes/email", null, req, env, ctx);
+      if (r && r.status !== 404) return r;
+    }
+
+    // Outreach routes
+    {
+      const r = await tryRoute("/outreach/", "./routes/outreach", null, req, env, ctx);
+      if (r && r.status !== 404) return r;
+    }
+
+    // Sync routes
+    {
+      const r = await tryRoute("/sync/", "./routes/sync", null, req, env, ctx);
+      if (r && r.status !== 404) return r;
+    }
+
+    // Ops queue endpoints
+    {
+      const r = await tryRoute("/ops/", "./routes/ops", null, req, env, ctx);
+      if (r && r.status !== 404) return r;
+    }
+
+    // Admin surface
+    {
+      const r = await tryRoute("/admin/", "./routes/admin", null, req, env, ctx);
+      if (r && r.status !== 404) return r;
+    }
+
     // AI endpoints (e.g., /ai/ping, /ai/json, etc.)
     {
       const r = await tryRoute("/ai/", "./routes/ai", null, req, env, ctx);
@@ -186,6 +216,18 @@ export default {
     try {
       const tasks: any = await import("./routes/tasks");
       if (typeof tasks.onScheduled === "function") ctx.waitUntil(tasks.onScheduled(event, env));
+    } catch {}
+
+    // Ops queue processing
+    try {
+      const ops: any = await import("./routes/ops");
+      if (typeof ops.runScheduled === "function") ctx.waitUntil(ops.runScheduled(event, env));
+    } catch {}
+
+    // TikTok queue & trends if present
+    try {
+      const tt: any = await import("./routes/tiktok");
+      if (typeof tt.runScheduled === "function") ctx.waitUntil(tt.runScheduled(event, env));
     } catch {}
   },
 };


### PR DESCRIPTION
## Summary
- add email triage endpoints and smart reply hooks
- queue-based outreach, webhook order handlers, and admin status surface
- notion/drive sync helpers, telegram command parsing, and ops scheduler

## Testing
- `npm test`

No deploy/workflow changes required.

------
https://chatgpt.com/codex/tasks/task_e_68b9d53ccca883279d62173539175e2d