### PR TITLE
Add uptime monitoring workflow

### DIFF
--- a/.github/workflows/uptime.yml
+++ b/.github/workflows/uptime.yml
@@ -1,0 +1,48 @@
+name: uptime-monitor
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check endpoints & alert on failure
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          alert() {
+            local msg="$1"
+            echo "::warning::$msg"
+            if [[ -n "${TELEGRAM_BOT_TOKEN:-}" && -n "${TELEGRAM_CHAT_ID:-}" ]]; then
+              curl -s "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+                -d "chat_id=${TELEGRAM_CHAT_ID}" \
+                --data-urlencode "text=${msg}" >/dev/null || true
+            else
+              echo "Telegram secrets missing; skipping alert."
+            fi
+          }
+
+          check() {
+            local url="$1" name="$2"
+            echo "Checking $name -> $url"
+            code=$(curl -sS -o /tmp/body -w "%{http_code}" "$url" || echo "000")
+            if [[ "$code" != "200" ]]; then
+              alert "❌ ${name} is DOWN (${code}) — ${url}"
+            else
+              echo "✅ ${name} OK (${code})"
+            fi
+          }
+
+          check "https://maggie.messyandmagnetic.com/health"      "Maggie /health"
+          check "https://maggie.messyandmagnetic.com/diag/config" "Maggie /diag/config"
+          check "https://maggie.messyandmagnetic.com/ready"       "Maggie /ready"
+          check "https://assistant.messyandmagnetic.com/"         "Assistant UI /"
+
+          echo "Done."


### PR DESCRIPTION
## Summary
- monitor key endpoints every 5 minutes
- send Telegram alerts on failure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f4e575688327b66bd2c757fb0c76