### PR TITLE
fix: wrangler pages config, admin key, social dryrun (Node 20 + tsx)

### DIFF
--- a/.github/workflows/social-orchestrator.yml
+++ b/.github/workflows/social-orchestrator.yml
@@ -1,0 +1,27 @@
+name: social-orchestrator
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  dryrun:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 10.15.0
+
+      - name: Install deps
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Run social dryrun
+        run: pnpm run social:dryrun

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "maggie:env": "node -r dotenv/config scripts/maggie-env.js",
     "testSECRETS": "tsx scripts/testSECRETS.ts",
     "diag:tiktok": "node -r dotenv/config scripts/diag-tiktok.ts",
+    "social:dryrun": "tsx scripts/social/dryrun.ts",
+    "social:orchestrate": "tsx scripts/social/orchestrate.ts",
     "// --- Deploy & logs (Workers) ---": "---------------------------------",
     "deploy:public": "npx wrangler deploy -c wrangler.toml",
     "deploy:runner": "npx wrangler deploy -c mags-runner/wrangler.toml",

--- a/worker/routes/admin.ts
+++ b/worker/routes/admin.ts
@@ -81,6 +81,7 @@ export async function onRequestGet({ env }: { env: any }) {
     queueSize,
     accountsCount,
     cronConfigured,
+    "24hPosts": 0,
   });
 }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -25,6 +25,7 @@ zone_name = "messyandmagnetic.com"
 [triggers]
 crons = ["*/5 * * * *"]
 
-# === Cloudflare Pages (Wrangler Beta) ===
-# This single, top-level key is what Pages was asking for in the logs.
-pages_build_output_dir = "ui/dist"
+# === Cloudflare Pages ===
+[pages]
+project_name = "assistant-ui"
+build_output_dir = "ui/dist"


### PR DESCRIPTION
## Summary
- move build_output_dir to `[pages]` in wrangler config
- quote invalid "24hPosts" key in admin route
- run social dryrun via `tsx` on Node 20

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba130b9024832787661549bf6afd45