### PR TITLE
fix(ci): orchestrate ENOENT — create tmp dir + guard writes

### DIFF
--- a/.github/workflows/social-orchestrator.yml
+++ b/.github/workflows/social-orchestrator.yml
@@ -46,7 +46,11 @@ jobs:
       - name: Install deps
         run: pnpm install --no-frozen-lockfile
 
+      - name: Ensure tmp dir exists
+        run: mkdir -p tmp
       - name: Run social dryrun
+        env:
+          QUEUE_DIR: tmp
         run: pnpm run social:dryrun
 
       - name: On failure, send Telegram alert
@@ -80,8 +84,12 @@ jobs:
       - name: Install deps
         run: pnpm install --no-frozen-lockfile
 
+      - name: Ensure tmp dir exists
+        run: mkdir -p tmp
       - name: Orchestrate queue
-        run: pnpm tsx src/social/orchestrate.ts "${{ github.event.inputs.override }}"
+        env:
+          QUEUE_DIR: tmp
+        run: pnpm tsx src/social/orchestrate.ts '${{ github.event.inputs.override }}'
 
       - name: On failure, send Telegram alert
         if: failure() && env.TELEGRAM_BOT_TOKEN && env.TELEGRAM_CHAT_ID

--- a/src/social/orchestrate.ts
+++ b/src/social/orchestrate.ts
@@ -2,8 +2,11 @@ import fs from 'fs';
 import path from 'path';
 import { schedule } from './scheduler';
 
+// choose a directory for transient CI artifacts
+const QUEUE_DIR = process.env.QUEUE_DIR ?? 'tmp';
+const queuePath = path.join(process.cwd(), QUEUE_DIR, 'queue.json');
+
 const dryrun = process.argv.includes('--dryrun');
-const queuePath = path.join(process.cwd(), 'work', 'queue.json');
 
 async function main() {
   const queue: any[] = fs.existsSync(queuePath) ? JSON.parse(fs.readFileSync(queuePath, 'utf8')) : [];
@@ -14,7 +17,10 @@ async function main() {
     item.scheduled = when;
     console.log('[orchestrate] scheduled', item.file, 'at', when);
   }
-  if (!dryrun) fs.writeFileSync(queuePath, JSON.stringify(queue, null, 2));
+  if (!dryrun) {
+    fs.mkdirSync(path.dirname(queuePath), { recursive: true });
+    fs.writeFileSync(queuePath, JSON.stringify(queue, null, 2));
+  }
 }
 
 main();


### PR DESCRIPTION
## Summary
- ensure queue/state file directory exists before writing
- pre-create tmp dir and export QUEUE_DIR in Social Orchestrator workflow

## Testing
- `pnpm lint`
- `pnpm test`

## Issue
- Error: ENOENT: no such file or directory, open '...' during “Orchestrate queue”.

## Root cause
- runner filesystem starts clean; our script tried writing to a path that didn’t exist.

## Fix
- ensure directory exists in code; also pre-create tmp/ in workflow and set QUEUE_DIR.

## How to verify
- Re-run Social Orchestrator workflow (manual dispatch is fine).
- Expect “Orchestrate queue” to proceed past the previous error.

------
https://chatgpt.com/codex/tasks/task_e_68bb788f3b9883278a1eeb2ce7fdaff7