### PR TITLE
feat: wire intake flow and diagnostics

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -28,17 +28,12 @@ jobs:
           corepack prepare pnpm@10.15.0 --activate
           pnpm --version
 
-      # Install only the UI’s dependencies (your workspace excludes "ui")
-      - name: Install deps (ui)
-        run: pnpm --filter "./ui" install --no-frozen-lockfile
-
       - name: Build UI
-        run: pnpm --filter "./ui" run build
+        run: pnpm -C ui install --no-frozen-lockfile && pnpm -C ui build
 
       - name: Deploy to Cloudflare Pages
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_ACCOUNT_ID:        ${{ secrets.CF_ACCOUNT_ID }}
         run: |
-          # uses wrangler.toml [pages] config and the built folder
-          npx wrangler pages deploy ui/dist --project-name assistant-ui --branch main
+          wrangler pages deploy ui/dist --project-name=mags-site

--- a/ui/src/pages/intake.tsx
+++ b/ui/src/pages/intake.tsx
@@ -1,17 +1,35 @@
 import React, { useEffect, useState } from 'react';
 import FormEmbed from '../components/FormEmbed';
 
+type FormMap = Record<string, string>;
+
 export default function IntakePage() {
+  const [forms, setForms] = useState<FormMap>({});
   const [formId, setFormId] = useState<string | undefined>();
   useEffect(() => {
     const product = new URLSearchParams(window.location.search).get('product');
-    fetch('/admin/config').then((r) => r.json()).then((cfg) => {
-      const map = cfg.tally || cfg['blueprint:tally'] || {};
-      if (product && map[product]) setFormId(map[product]);
-    }).catch(() => {});
+    fetch('/admin/config')
+      .then((r) => r.json())
+      .then((cfg) => {
+        const map: FormMap = cfg.tally || cfg['blueprint:tally'] || {};
+        setForms(map);
+        if (product && map[product]) setFormId(map[product]);
+      })
+      .catch(() => {});
   }, []);
   return (
-    <div className="p-4">
+    <div className="p-4 space-y-4">
+      <div className="flex gap-2 flex-wrap">
+        {Object.entries(forms).map(([label, id]) => (
+          <button
+            key={label}
+            onClick={() => setFormId(id)}
+            className={`px-2 py-1 border rounded ${formId === id ? 'bg-rose-200' : ''}`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
       <FormEmbed formId={formId} />
     </div>
   );

--- a/worker/orders/fulfill.ts
+++ b/worker/orders/fulfill.ts
@@ -1,0 +1,33 @@
+import { OrderContext } from '../../src/forms/schema';
+
+export async function fulfill(order: OrderContext, env: any) {
+  const key = env.STRIPE_SECRET_KEY;
+  if (!key || !order.productId) return;
+
+  try {
+    const params = new URLSearchParams();
+    params.append('mode', 'payment');
+    params.append('success_url', 'https://maggie.messyandmagnetic.com/downloads');
+    params.append('cancel_url', 'https://maggie.messyandmagnetic.com/');
+    params.append('line_items[0][price]', order.productId);
+    params.append('line_items[0][quantity]', '1');
+
+    const res = await fetch('https://api.stripe.com/v1/checkout/sessions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${key}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: params.toString(),
+    });
+    const data: any = await res.json().catch(() => ({}));
+    if (data?.url) {
+      await env.BRAIN.put(
+        `checkout:${order.email}`,
+        JSON.stringify({ url: data.url, productId: order.productId, created: Date.now() })
+      );
+    }
+  } catch (e) {
+    console.log('[fulfill] error', e);
+  }
+}

--- a/worker/orders/tally.ts
+++ b/worker/orders/tally.ts
@@ -42,7 +42,7 @@ export async function onRequestPost({ request, env, ctx }: { request: Request; e
   await env.BRAIN.put(key, JSON.stringify({ ...ctxObj, receivedAt: Date.now() }));
   try {
     const mod: any = await import('./fulfill');
-    if (typeof mod.fulfill === 'function') ctx.waitUntil(mod.fulfill(ctxObj));
+    if (typeof mod.fulfill === 'function') ctx.waitUntil(mod.fulfill(ctxObj, env));
   } catch {}
   return new Response(JSON.stringify({ ok: true }), {
     status: 200,

--- a/worker/routes/email.ts
+++ b/worker/routes/email.ts
@@ -1,0 +1,22 @@
+import { sendEmail } from '../../utils/email';
+
+function json(data: any, status = 200) {
+  return new Response(JSON.stringify(data, null, 2), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+export async function onRequestPost({ env, request }: { env: any; request: Request }) {
+  const url = new URL(request.url);
+  if (url.pathname !== '/diag/email/test') return json({ ok: false }, 404);
+  const body = await request.json().catch(() => ({}));
+  const to = body.to;
+  if (!to) return json({ ok: false, error: 'missing to' }, 400);
+  try {
+    const res = await sendEmail({ to, subject: body.subject || 'Test Email', text: body.text || 'hello' }, env);
+    return json({ ok: true, id: res.id });
+  } catch (e: any) {
+    return json({ ok: false, error: e.message }, 500);
+  }
+}

--- a/worker/routes/orders.ts
+++ b/worker/routes/orders.ts
@@ -1,0 +1,21 @@
+function json(data: any, status = 200) {
+  return new Response(JSON.stringify(data, null, 2), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+export async function onRequestGet({ env, request }: { env: any; request: Request }) {
+  const url = new URL(request.url);
+  if (url.pathname !== '/orders/links') return json({ ok: false }, 404);
+
+  const email = url.searchParams.get('email');
+  if (!email) return json([]);
+
+  try {
+    const stored = await env.BRAIN.get(`checkout:${email}`, 'json');
+    return json(stored ? [stored] : []);
+  } catch {
+    return json([]);
+  }
+}

--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -113,6 +113,11 @@ export default {
       );
     }
 
+    if (url.pathname === "/diag/email/test" && req.method === "POST") {
+      const r = await tryRoute("/diag/email/test", "./routes/email", null, req, env, ctx);
+      if (r && r.status !== 404) return r;
+    }
+
     // --- Admin special-casing to match admin.ts signatures ---
     if (url.pathname === "/admin/status" && req.method === "GET") {
       try {
@@ -141,6 +146,12 @@ export default {
     }
     if (url.pathname === "/webhooks/tally") {
       const r = await tryRoute("/webhooks/tally", "./orders/tally", null, req, env, ctx);
+      if (r && r.status !== 404) return r;
+    }
+
+    // Orders links
+    {
+      const r = await tryRoute("/orders", "./routes/orders", null, req, env, ctx);
       if (r && r.status !== 404) return r;
     }
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -27,5 +27,5 @@ crons = ["*/5 * * * *"]
 
 # === Cloudflare Pages (for the /ui app) ===
 [pages]
-project_name = "assistant-ui"
+project_name = "mags-site"
 build_output_dir = "ui/dist"


### PR DESCRIPTION
## Summary
- deploy UI to Cloudflare Pages project `mags-site`
- add Tally intake form toggle and stub order download flow
- add Stripe fulfillment stub and Resend test email endpoint

## Testing
- `pnpm test`
- `pnpm -C ui build`


------
https://chatgpt.com/codex/tasks/task_e_68c0a6574f5c8327ae308dbdf2b3e30f