### PR TITLE
fix: resolve UI + worker conflicts; finalize intake + orders routes

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -2,7 +2,7 @@ name: Deploy UI
 
 on:
   push:
-    branches: [main]
+    branches: [ main ]
     paths:
       - "ui/**"
       - ".github/workflows/deploy-ui.yml"
@@ -12,28 +12,29 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          cache: pnpm
 
-      - name: Enable Corepack & pnpm
+      - name: Enable PNPM via Corepack
         run: |
           corepack enable
           corepack prepare pnpm@10.15.0 --activate
           pnpm --version
 
       - name: Build UI
-        run: pnpm -C ui install --no-frozen-lockfile && pnpm -C ui build
+        run: |
+          pnpm -C ui install --no-frozen-lockfile
+          pnpm -C ui build
 
       - name: Deploy to Cloudflare Pages
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CF_ACCOUNT_ID:        ${{ secrets.CF_ACCOUNT_ID }}
+          CF_ACCOUNT_ID:       ${{ secrets.CF_ACCOUNT_ID }}
         run: |
           wrangler pages deploy ui/dist --project-name=mags-site
+

--- a/ui/src/components/FormEmbed.tsx
+++ b/ui/src/components/FormEmbed.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React from "react";
 
-export default function FormEmbed({ formId }: { formId?: string }) {
+export function FormEmbed({ formId }: { formId?: string }) {
   if (!formId) return <p className="text-center">Form unavailable.</p>;
   const src = `https://tally.so/embed/${formId}?transparent=1`;
   return <iframe src={src} className="w-full h-screen" title="Tally Form" />;
 }
+
+export default FormEmbed;

--- a/ui/src/pages/intake.tsx
+++ b/ui/src/pages/intake.tsx
@@ -1,22 +1,29 @@
-import React, { useEffect, useState } from 'react';
-import FormEmbed from '../components/FormEmbed';
+import { useEffect, useState } from "react";
+import { FormEmbed } from "../components/FormEmbed";
 
-type FormMap = Record<string, string>;
+type FormMap = Record<string, string>; // label -> formId
 
 export default function IntakePage() {
   const [forms, setForms] = useState<FormMap>({});
-  const [formId, setFormId] = useState<string | undefined>();
+  const [formId, setFormId] = useState<string | null>(null);
+
   useEffect(() => {
-    const product = new URLSearchParams(window.location.search).get('product');
-    fetch('/admin/config')
+    const product = new URLSearchParams(window.location.search).get("product") ?? "";
+
+    fetch("/admin/config")
       .then((r) => r.json())
       .then((cfg) => {
-        const map: FormMap = cfg.tally || cfg['blueprint:tally'] || {};
+        const map: FormMap = cfg?.forms || {};
         setForms(map);
+
+        // If product provided and exists in map, select it; otherwise pick first entry
+        const keys = Object.keys(map);
         if (product && map[product]) setFormId(map[product]);
+        else if (keys.length) setFormId(map[keys[0]]);
       })
       .catch(() => {});
   }, []);
+
   return (
     <div className="p-4 space-y-4">
       <div className="flex gap-2 flex-wrap">
@@ -24,13 +31,15 @@ export default function IntakePage() {
           <button
             key={label}
             onClick={() => setFormId(id)}
-            className={`px-2 py-1 border rounded ${formId === id ? 'bg-rose-200' : ''}`}
+            className="px-2 py-1 border rounded"
           >
             {label}
           </button>
         ))}
       </div>
-      <FormEmbed formId={formId} />
+
+      {formId ? <FormEmbed formId={formId} /> : <p>Loading…</p>}
     </div>
   );
 }
+

--- a/worker/routes/orders.ts
+++ b/worker/routes/orders.ts
@@ -1,21 +1,47 @@
-function json(data: any, status = 200) {
-  return new Response(JSON.stringify(data, null, 2), {
-    status,
-    headers: { 'content-type': 'application/json' },
-  });
-}
-
-export async function onRequestGet({ env, request }: { env: any; request: Request }) {
+export async function onRequestGet({ request, env }: { request: Request; env: any }) {
   const url = new URL(request.url);
-  if (url.pathname !== '/orders/links') return json({ ok: false }, 404);
+  if (url.pathname !== "/orders/list") return json({ ok: false }, 404);
 
-  const email = url.searchParams.get('email');
+  const email = url.searchParams.get("email")?.trim();
   if (!email) return json([]);
 
   try {
-    const stored = await env.BRAIN.get(`checkout:${email}`, 'json');
-    return json(stored ? [stored] : []);
+    const key = `order:${await sha(email)}`;
+    const stored = await env.BRAIN.get(key);
+    return json(stored ? JSON.parse(stored) : []);
   } catch {
     return json([]);
   }
 }
+
+export async function onRequestPost(ctx: any) {
+  // expects a ctx.waitUntil + dynamic import to keep bundle light
+  const body = await ctx.request.json().catch(() => ({}));
+  const ctxObj = { ...body, env: undefined, url: ctx.request.url }; // pass only needed bits
+
+  try {
+    ctx.waitUntil((async () => {
+      const mod: any = await import("../orders/fulfill");
+      if (typeof mod.fulfill === "function") await mod.fulfill(ctxObj, ctx.env);
+    })());
+  } catch {}
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** util */
+async function sha(input: string): Promise<string> {
+  const enc = new TextEncoder();
+  const buf = await crypto.subtle.digest("SHA-256", enc.encode(input));
+  return [...new Uint8Array(buf)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function json(data: any, status = 200) {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+


### PR DESCRIPTION
## Summary
- use Corepack + pnpm 10.15 in UI deploy workflow and deploy with Wrangler
- finish intake page with product preselect and dynamic Tally forms
- restore /orders routes and Tally webhook using KV storage

## Testing
- `pnpm i`
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68c0aad9d1408327aef9dddb7cd07248