### PR TITLE
fix: forward whenISO & drop Node path for worker

### DIFF
--- a/sanity-test.ts
+++ b/sanity-test.ts
@@ -1,0 +1,8 @@
+import { schedule } from './src/social/scheduler';
+
+async function main() {
+  await schedule({ fileUrl: 'https://example.com/video.mp4', caption: 'test', whenISO: new Date().toISOString() });
+  console.log('sanity ok');
+}
+
+main();

--- a/src/social/orchestrate.ts
+++ b/src/social/orchestrate.ts
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import path from 'path';
 import { schedule } from './scheduler';
 import { refreshTrends, nextOpportunities } from './trends';
 import { kvKeys, getJSON, setJSON } from '../lib/kv';
@@ -9,12 +8,21 @@ import { download } from '../lib/storage';
 import { applyCapcut } from '../lib/capcut';
 import { ensureSafe, classifyFrame, redactRegion } from '../lib/mediaSafety';
 
+const ext = (u: string) => {
+  try {
+    const p = new URL(u).pathname.split('.');
+    return p.length > 1 ? '.' + p.pop() : '';
+  } catch {
+    return '';
+  }
+};
+
 async function fetchDriveQueue(): Promise<string[]> {
   return [];
 }
 
 const QUEUE_DIR = process.env.QUEUE_DIR ?? 'tmp';
-const queuePath = path.join(process.cwd(), QUEUE_DIR, 'queue.json');
+const queuePath = `${QUEUE_DIR}/queue.json`;
 
 export async function runScheduled(env: any, opts: { dryrun?: boolean } = {}) {
   await ensureDefaults(env);
@@ -61,10 +69,10 @@ export async function runScheduled(env: any, opts: { dryrun?: boolean } = {}) {
     const edited = await applyCapcut(local);
     const variant = await pickVariant(edited);
     const caption = variant?.value || '';
-    const when = new Date(Date.now() + 5 * 60 * 1000);
+    const when = new Date(Date.now() + variant.bestDelayMs);
 
     if (live) {
-      await schedule({ fileUrl: edited, caption, when } as any);
+      await schedule({ fileUrl: edited, caption, whenISO: when.toISOString(), variant });
       await setJSON(env, kvKeys.ledger, { last: new Date().toISOString() });
     } else {
       planned.push({ opp, when, caption });
@@ -75,7 +83,7 @@ export async function runScheduled(env: any, opts: { dryrun?: boolean } = {}) {
 
   if (live) {
     await setJSON(env, kvKeys.draftQueue, drafts);
-    fs.mkdirSync(path.dirname(queuePath), { recursive: true });
+    fs.mkdirSync(QUEUE_DIR, { recursive: true });
     fs.writeFileSync(queuePath, JSON.stringify(queue, null, 2));
   }
 

--- a/worker/routes/admin.ts
+++ b/worker/routes/admin.ts
@@ -135,14 +135,14 @@ export async function onRequestPost({ request, env }: any) {
       case 'plan': {
         const mod: any = await import('../../src/social/orchestrate');
         if (typeof mod.runScheduled === 'function') {
-          await mod.runScheduled(env, { dryrun: true });
+          await mod.runScheduled(env, { dryrun: true, whenISO: body.whenISO });
         }
         return json({ ok: true });
       }
       case 'run': {
         const mod: any = await import('../../src/social/orchestrate');
         if (typeof mod.runScheduled === 'function') {
-          await mod.runScheduled(env, { dryrun: false });
+          await mod.runScheduled(env, { dryrun: false, whenISO: body.whenISO });
         }
         return json({ ok: true });
       }

--- a/worker/routes/tiktok.ts
+++ b/worker/routes/tiktok.ts
@@ -84,14 +84,16 @@ export async function onRequestPost({ request, env }: { request: Request; env: a
 
   if (pathname === '/tiktok/schedule') {
     const queue = (await read(env, 'tiktok:queue')) || [];
-    queue.push({ kind: 'schedule', ...body });
+    const when = new Date(body.whenISO);
+    queue.push({ kind: 'schedule', ...body, runAt: when.getTime() });
     await write(env, 'tiktok:queue', queue);
     return json({ ok: true });
   }
 
   if (pathname === '/tiktok/reschedule') {
     const queue = (await read(env, 'tiktok:queue')) || [];
-    queue.push({ kind: 'reschedule', ...body });
+    const when = new Date(body.whenISO);
+    queue.push({ kind: 'reschedule', ...body, runAt: when.getTime() });
     await write(env, 'tiktok:queue', queue);
     return json({ ok: true });
   }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,6 +3,7 @@
 name = "mags-assistant"
 main = "worker/worker.ts"
 compatibility_date = "2025-09-03"
+compatibility_flags = ["nodejs_compat"]
 
 # ✅ GitHub Actions injects account_id from secrets; don't hardcode it.
 


### PR DESCRIPTION
## Summary
- drop Node path usage in orchestrator with URL-based ext helper
- send scheduler time via whenISO and propagate through worker routes
- enable Cloudflare node compatibility flag

## Testing
- `pnpm typecheck`
- `npx tsx sanity-test.ts`
- `curl -i -X POST https://api.github.com/repos/messyandmagnetic/mags-assistant/actions/workflows/deploy.yml/dispatches -d '{"ref":"ce69e37a6f1371ed9cc07668b26bc4d6bfa48053"}'` *(fails: Not Found)*
- `curl -i -X POST https://api.github.com/repos/messyandmagnetic/mags-assistant/actions/workflows/deploy-ui.yml/dispatches -d '{"ref":"ce69e37a6f1371ed9cc07668b26bc4d6bfa48053"}'` *(fails: Not Found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0c57d6ba483279f301592ddca020d