### PR TITLE
chore: integrate scheduler safety with KV

### DIFF
--- a/sanity-test.ts
+++ b/sanity-test.ts
@@ -1,33 +1,13 @@
-import { onRequestGet, onRequestPost } from './worker/routes/admin';
+import { schedule } from './src/social/scheduler';
 
-const env: any = {
-  ENABLE_SOCIAL_POSTING: 'false',
-  BRAIN: {
-    get: async (_: string) => null,
-    put: async (_: string, __: string) => {},
-    list: async () => ({ keys: [] }),
-  },
-  POSTQ: {
-    get: async (_: string) => null,
-    put: async (_: string, __: string) => {},
-  },
-};
-
-async function run() {
-  let res = await onRequestGet({ request: new Request('http://x/health'), env });
-  console.log('GET /health', await res.json());
-
-  res = await onRequestGet({ request: new Request('http://x/admin/social-mode'), env });
-  console.log('GET /admin/social-mode', await res.json());
-
-  res = await onRequestPost({ request: new Request('http://x/admin/trigger', { method: 'POST', body: JSON.stringify({ kind: 'trends' }) }), env });
-  console.log('POST /admin/trigger trends', await res.json());
-
-  res = await onRequestPost({ request: new Request('http://x/admin/trigger', { method: 'POST', body: JSON.stringify({ kind: 'plan' }) }), env });
-  console.log('POST /admin/trigger plan', await res.json());
-
-  res = await onRequestPost({ request: new Request('http://x/admin/trigger', { method: 'POST', body: JSON.stringify({ kind: 'run' }) }), env });
-  console.log('POST /admin/trigger run', await res.json());
+async function main() {
+  const whenISO = new Date(Date.now() + 2 * 60 * 1000).toISOString();
+  await schedule({
+    fileUrl: 'https://example.com/demo.mp4',
+    caption: 'sanity test',
+    whenISO,
+  });
+  console.log('sanity ok');
 }
 
-run();
+main();

--- a/src/social/kv.ts
+++ b/src/social/kv.ts
@@ -8,6 +8,7 @@ export const kvKeys = {
   boostRules: 'tiktok:boost:rules',
   draftQueue: 'tiktok:drafts',
   health: 'tiktok:health',
+  lastScheduled: 'tiktok:lastScheduled',
 };
 
 export async function getJSON<T>(env: any, key: string, fallback: T): Promise<T> {

--- a/src/social/lib/capcut.ts
+++ b/src/social/lib/capcut.ts
@@ -1,0 +1,1 @@
+export { applyCapcut } from '../../lib/capcut';

--- a/src/social/lib/telegram.ts
+++ b/src/social/lib/telegram.ts
@@ -1,0 +1,1 @@
+export { tgSend } from '../../lib/telegram';

--- a/src/social/lib/utils.ts
+++ b/src/social/lib/utils.ts
@@ -1,0 +1,8 @@
+export { ensureDefaults } from '../defaults';
+export { pickVariant } from '../ab';
+export { kvKeys, getJSON, setJSON } from '../kv';
+export { classifyFrame, ensureSafe as baseEnsureSafe } from '../../lib/mediaSafety';
+
+export async function ensureSafe(env: any, file: string) {
+  return baseEnsureSafe(file);
+}

--- a/src/worker/types.ts
+++ b/src/worker/types.ts
@@ -1,0 +1,8 @@
+export interface Env {
+  ENABLE_SOCIAL_POSTING?: boolean;
+  BRAIN: {
+    get(key: string): Promise<string | null>;
+    put(key: string, value: string): Promise<void>;
+  };
+  [key: string]: any;
+}

--- a/worker/routes/tiktok.ts
+++ b/worker/routes/tiktok.ts
@@ -83,17 +83,19 @@ export async function onRequestPost({ request, env }: { request: Request; env: a
   }
 
   if (pathname === '/tiktok/schedule') {
-    const queue = (await read(env, 'tiktok:queue')) ?? [];
-    const whenISO = body.whenISO ?? new Date(Date.now() + 5 * 60 * 1000).toISOString();
-    queue.push({ kind: 'schedule', whenISO, meta: body.meta ?? {} });
+    const queue = (await read(env, 'tiktok:queue')) || [];
+    const whenISO: string = String(body.whenISO || '');
+    if (!whenISO) return json({ ok: false, error: 'whenISO required' }, 400);
+    queue.push({ kind: 'schedule', whenISO, payload: body.payload || {} });
     await write(env, 'tiktok:queue', queue);
     return json({ ok: true });
   }
 
   if (pathname === '/tiktok/reschedule') {
-    const queue = (await read(env, 'tiktok:queue')) ?? [];
-    const whenISO = body.whenISO ?? new Date(Date.now() + 10 * 60 * 1000).toISOString();
-    queue.push({ kind: 'reschedule', whenISO, id: body.id });
+    const queue = (await read(env, 'tiktok:queue')) || [];
+    const whenISO: string = String(body.whenISO || '');
+    if (!whenISO) return json({ ok: false, error: 'whenISO required' }, 400);
+    queue.push({ kind: 'reschedule', whenISO, payload: body.payload || {} });
     await write(env, 'tiktok:queue', queue);
     return json({ ok: true });
   }


### PR DESCRIPTION
## Summary
- Refactor social orchestrator to use KV-backed queues, run media safety checks, and schedule with ISO timestamps
- Add Worker endpoints to enqueue schedule/reschedule requests using whenISO strings
- Introduce KV key for last scheduled post and sanity scheduler test

## Testing
- `pnpm run typecheck`
- `pnpm test`
- `npx wrangler build -c wrangler.toml`
- `pnpm --filter assistant-ui build`
- `npx tsx sanity-test.ts`
- `npx tsc -p tsconfig.json` *(fails: Cannot find type definition file for '@cloudflare/workers-types')*


------
https://chatgpt.com/codex/tasks/task_e_68c2191b849c8327a1b4f505a6f52b0a