### PR TITLE
wire: SECRET_BLOB + BRAIN_DOC_KEY + diag

### DIFF
--- a/.github/workflows/kv-smoke.yml
+++ b/.github/workflows/kv-smoke.yml
@@ -1,0 +1,17 @@
+name: KV smoke test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Call diag/config
+        env:
+          WORKER_URL: ${{ secrets.WORKER_URL }}
+        run: |
+          set -e
+          resp=$(curl -fsS "$WORKER_URL/diag/config")
+          echo "$resp"
+          echo "$resp" | jq -e '.hasSecrets == true' > /dev/null

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,10 @@
+export async function getSecrets(env: any) {
+  const k = env.SECRET_BLOB || 'thread-state';
+  const v = await env.BRAIN.get(k);
+  return v ? JSON.parse(v) : {};
+}
+
+export async function getBrainDoc(env: any) {
+  const k = env.BRAIN_DOC_KEY || 'PostQ:thread-state';
+  return (await env.BRAIN.get(k)) || '';
+}

--- a/worker/health.ts
+++ b/worker/health.ts
@@ -1,4 +1,4 @@
-import { loadConfig, presence } from "./lib/config";
+import { getSecrets, getBrainDoc } from "../src/config";
 
 export const onRequestGet = async ({ env }: any) => {
   return new Response(JSON.stringify({ ok: true, time: new Date().toISOString() }), {
@@ -7,56 +7,23 @@ export const onRequestGet = async ({ env }: any) => {
 };
 
 /**
- * /diag/config — true/false presence check for the EXACT keys already in use.
- * Reads KV (POSTQ:thread-state) first, then env as fallback. No renames.
+ * /diag/config — sanity check for KV wiring.
+ * Returns key names and basic presence metrics.
  */
 export const diagConfig = async ({ env }: any) => {
-  const cfg = await loadConfig(env);
+  const secretBlobKey = env.SECRET_BLOB || "thread-state";
+  const brainDocKey = env.BRAIN_DOC_KEY || "PostQ:thread-state";
 
-  const keys = [
-    // === STRIPE ===
-    "STRIPE_SECRET_KEY","STRIPE_WEBHOOK_SECRET",
-    // === TALLY ===
-    "TALLY_API_KEY","TALLY_SIGNING_SECRET","TALLY_WEBHOOK_FEEDBACK_ID","TALLY_WEBHOOK_QUIZ_ID",
-    // === TELEGRAM ===
-    "TELEGRAM_BOT_TOKEN","TELEGRAM_CHAT_ID",
-    // === NOTION ===
-    "NOTION_API_KEY","NOTION_DB_ID","NOTION_TOKEN","NOTION_DB_LOGS",
-    // === TIKTOK SESSIONS ===
-    "TIKTOK_SESSION_MAIN","TIKTOK_SESSION_WILLOW","TIKTOK_SESSION_MAGGIE","TIKTOK_SESSION_MARS",
-    // === TIKTOK PROFILES ===
-    "TIKTOK_PROFILE_MAIN","TIKTOK_PROFILE_WILLOW","TIKTOK_PROFILE_MAGGIE","TIKTOK_PROFILE_MARS",
-    // === ALT EMAILS ===
-    "ALT_TIKTOK_EMAIL_1","ALT_TIKTOK_EMAIL_2","ALT_TIKTOK_EMAIL_3",
-    // === MAGGIE / INTERNAL ===
-    "MAGS_ASSISTANT_TOKEN","POST_THREAD_SECRET","SECRET_BLOB",
-    // === GOOGLE INTEGRATIONS ===
-    "GOOGLE_OAUTH_CLIENT_ID","GOOGLE_OAUTH_CLIENT_SECRET","GOOGLE_MAPS_API_KEY","GOOGLE_GEOCODING_API_KEY",
-    // === OPENAI / GEMINI ===
-    "OPENAI_API_KEY","CODEX_AUTH_TOKEN",
-    // === BROWSERLESS ===
-    "BROWSERLESS_API_KEY","BROWSERLESS_BASE_URL",
-    // === GITHUB ===
-    "GITHUB_TOKEN","GITHUB_PAT",
-    // === CLOUDFLARE ===
-    "CLOUDFLARE_ACCOUNT_ID","CLOUDFLARE_ZONE_ID","CLOUDFLARE_API_TOKEN",
-    "CLOUDFLARE_KV_POSTQ_NAMESPACE_ID","CLOUDFLARE_KV_POSTQ_HUMAN_NAME",
-    // === VERCEL (optional) ===
-    "VERCEL_API_TOKEN","VERCEL_PROJECT_ID","VERCEL_ORG_ID",
-    // === WORKER URL ===
-    "WORKER_URL",
-    // === APPS SCRIPT ===
-    "APPS_SCRIPT_WEBAPP_URL","APPS_SCRIPT_DEPLOYMENT_ID","APPS_SCRIPT_SCRIPT_ID","APPS_SCRIPT_EXEC",
-    // === EXTRA FLAGS ===
-    "USE_CAPCUT","CAPCUT_TEMPLATE","CAPCUT_EXPORT_FOLDER","CAPCUT_RAW_FOLDER","MAGGIE_LOG_TO_CONSOLE",
-    // === BACKUPS / MISC ===
-    "FETCH_PASS","PASS_WORD","WORKER_CRON_KEY","ADMIN_KEY"
-  ];
+  const secrets = await getSecrets(env);
+  const brainDoc = await getBrainDoc(env);
 
-  const present = presence(cfg, keys);
-  const using = cfg.SECRET_BLOB || "PostQ:thread-state";
-
-  return new Response(JSON.stringify({ present, kvFirst: true, kvKey: using }), {
-    headers: { "content-type": "application/json" },
-  });
+  return new Response(
+    JSON.stringify({
+      secretBlobKey,
+      brainDocKey,
+      hasSecrets: Object.keys(secrets).length > 0,
+      brainDocBytes: brainDoc ? brainDoc.length : 0,
+    }),
+    { headers: { "content-type": "application/json" } }
+  );
 };

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -11,6 +11,8 @@ compatibility_flags = ["nodejs_compat"]
 # === Worker env vars ===
 [vars]
 ENV = "prod"
+SECRET_BLOB = "thread-state"
+BRAIN_DOC_KEY = "PostQ:thread-state"
 
 # === KV ===
 [[kv_namespaces]]


### PR DESCRIPTION
## Summary
- add SECRET_BLOB and BRAIN_DOC_KEY vars to wrangler config
- provide helper functions to load secrets and brain doc from KV
- expose /diag/config endpoint and GitHub smoke test

## Testing
- `npm test`
- `npx eslint worker/health.ts src/config.ts` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68c22dc1649883278fe8775b84a63f41