### PR TITLE
feat: automate worker health merge resolution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+worker/health.ts merge=worker-health

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "sync:push": "git add -A && git commit -m \"update\" || echo \"(no changes)\" && git push origin main",
     "save-deploy": "npm run sync:pull && npm run deploy",
     "pull-deploy": "git pull origin main && npm run deploy",
+    "setup:merge-driver": "node scripts/setup-merge-driver.js",
 
     "cf:whoami": "wrangler whoami",
     "cf:deploy": "wrangler deploy -c wrangler.toml --minify && wrangler deploy -c mags-runner/wrangler.toml --minify",

--- a/scripts/resolve-worker-health-conflict.js
+++ b/scripts/resolve-worker-health-conflict.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+
+const file = process.argv[2];
+if (!file) process.exit(0);
+
+let content = fs.readFileSync(file, 'utf8');
+
+// If we detect conflict markers or old key names, replace with canonical function
+if (content.includes('<<<<<<<') || content.includes('blobKey') || content.includes('brainKey')) {
+  const resolved = `/**
+ * /diag/config — sanity check for config
+ * Returns key names and basic presence flags
+ */
+export const diagConfig = async (env: Env) => {
+  const secretBlobKey = env.SECRET_BLOB;
+  const brainDocKey = env.BRAIN_DOC_KEY;
+
+  let kvReadOk = false;
+  try {
+    kvReadOk = !!(await env.BRAIN_DOC_KV.get(brainDocKey));
+  } catch {}
+
+  const cfg = await loadConfig(env);
+
+  const secrets = await getSecrets(env);
+  const brainDoc = await getBrainDoc(env);
+
+  const present = presence(cfg, secrets);
+
+  return new Response(
+    JSON.stringify({
+      present,
+      secretBlobKey,
+      brainDocKey,
+      hasSecrets: Object.keys(secrets).length > 0,
+      brainDocBytes: brainDoc ? brainDoc.length : 0,
+    }),
+    { headers: { "content-type": "application/json" } }
+  );
+};
+`;
+  fs.writeFileSync(file, resolved, 'utf8');
+}

--- a/scripts/setup-merge-driver.js
+++ b/scripts/setup-merge-driver.js
@@ -1,0 +1,11 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+
+try {
+  execSync("git config merge.worker-health.driver 'node scripts/resolve-worker-health-conflict.js %A'");
+  execSync("git config merge.worker-health.name 'worker health merge driver'");
+  console.log('Configured worker/health.ts merge driver');
+} catch (err) {
+  console.error(err);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- add gitattributes entry and merge-driver script to auto-resolve worker/health.ts conflicts
- script writes canonical diagConfig with both secretBlobKey and brainDocKey
- npm script to set up merge driver locally

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2580313108327a0462857c870581a