### PR TITLE
chore: add brain sync scripts

### DIFF
--- a/.github/workflows/brain-sync.yml
+++ b/.github/workflows/brain-sync.yml
@@ -1,0 +1,20 @@
+name: Sync Brain to KV
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  sync-brain:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: pnpm install --frozen-lockfile=false
+      - name: Update Brain KV
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: npx tsx scripts/updateBrain.ts

--- a/scripts/brainPing.ts
+++ b/scripts/brainPing.ts
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import path from 'path';
+
+async function main() {
+  const account = process.env.CF_ACCOUNT_ID;
+  const token = process.env.CF_API_TOKEN;
+  if (!account || !token) {
+    console.error('Missing CF_ACCOUNT_ID or CF_API_TOKEN');
+    process.exit(1);
+  }
+
+  const wrangler = await fs.promises.readFile('wrangler.toml', 'utf8');
+  const match = wrangler.match(/binding\s*=\s*"BRAIN"[\s\S]*?id\s*=\s*"([^"]+)"/);
+  if (!match) {
+    throw new Error('BRAIN kv namespace id not found in wrangler.toml');
+  }
+  const namespaceId = match[1];
+
+  const local = await fs.promises.readFile(path.join('docs', 'brain.md'), 'utf8');
+
+  const url = `https://api.cloudflare.com/client/v4/accounts/${account}/storage/kv/namespaces/${namespaceId}/values/PostQ:thread-state`;
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('Failed to fetch brain:', res.status, text);
+    process.exit(1);
+  }
+
+  const remote = await res.text();
+  const matches = remote.trim() === local.trim();
+  console.log(JSON.stringify({ matches, remoteBytes: remote.length, localBytes: local.length }));
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/updateBrain.ts
+++ b/scripts/updateBrain.ts
@@ -1,0 +1,44 @@
+import fs from 'fs';
+import path from 'path';
+
+async function main() {
+  const account = process.env.CF_ACCOUNT_ID;
+  const token = process.env.CF_API_TOKEN;
+  if (!account || !token) {
+    console.error('Missing CF_ACCOUNT_ID or CF_API_TOKEN');
+    process.exit(1);
+  }
+
+  const brainPath = path.join(process.cwd(), 'docs', 'brain.md');
+  const body = await fs.promises.readFile(brainPath, 'utf8');
+
+  const wrangler = await fs.promises.readFile('wrangler.toml', 'utf8');
+  const match = wrangler.match(/binding\s*=\s*"BRAIN"[\s\S]*?id\s*=\s*"([^"]+)"/);
+  if (!match) {
+    throw new Error('BRAIN kv namespace id not found in wrangler.toml');
+  }
+  const namespaceId = match[1];
+
+  const url = `https://api.cloudflare.com/client/v4/accounts/${account}/storage/kv/namespaces/${namespaceId}/values/PostQ:thread-state`;
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'text/plain',
+    },
+    body,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error('Failed to update brain:', res.status, text);
+    process.exit(1);
+  }
+
+  console.log('Brain updated');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add script to push docs/brain.md into Cloudflare KV
- add script to compare KV brain with repo
- auto-sync brain file to KV on pushes to main

## Testing
- `npm test`
- `npx tsx scripts/updateBrain.ts` *(fails: Missing CF_ACCOUNT_ID or CF_API_TOKEN)*
- `npx tsx scripts/brainPing.ts` *(fails: Missing CF_ACCOUNT_ID or CF_API_TOKEN)*
- `curl -s https://maggie.messyandmagnetic.com/health`

------
https://chatgpt.com/codex/tasks/task_e_68c2ef6f8edc8327b2b39c8c052ccc5a