### PR TITLE
fix diag config wiring in worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,3 +109,6 @@ vite.config.ts.timestamp-*
 # --------------------
 .DS_Store
 Thumbs.db
+
+# Diagnostic artifacts
+diag-config.json

--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -91,7 +91,7 @@ export default {
       if (r && r.status !== 404) return r;
     }
     if (url.pathname === "/diag/config" && req.method === "GET") {
-      return (diagConfig as any)({ env });
+      return diagConfig(env);
     }
     if (url.pathname === "/diag/email" && req.method === "GET") {
       const { getEmailConfig } = await import("../utils/email");


### PR DESCRIPTION
## Summary
- fix `/diag/config` handler invocation so health check receives correct env
- ignore diagnostic JSON artifacts

## Testing
- `npm test`
- `npm run deploy:public` *(fails: missing CLOUDFLARE_API_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_68c3593932f48327a626d045ffca188f