### PR TITLE
feat(diag): harden /diag/config to never throw; report KV presence safely

### DIFF
--- a/worker/health.ts
+++ b/worker/health.ts
@@ -20,7 +20,7 @@ export const diagConfig = async (_req: Request, env: any) => {
     ok: true,
     notes: [],
     errors: [],
-    kv: { binding: false, read: false },
+    kv: { binding: false, read: false, namespaceHint: env?.BRAIN?.namespace },
     keys: {
       blobKey: env?.SECRET_BLOB || "thread-state",
       brainDocKey: env?.BRAIN_DOC_KEY || "PostQ:thread-state",

--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -91,7 +91,7 @@ export default {
       if (r && r.status !== 404) return r;
     }
     if (url.pathname === "/diag/config" && req.method === "GET") {
-      return diagConfig(env);
+      return diagConfig(req, env);
     }
     if (url.pathname === "/diag/email" && req.method === "GET") {
       const { getEmailConfig } = await import("../utils/email");


### PR DESCRIPTION
## Summary
- ensure /diag/config handler never throws and reports KV presence
- route /diag/config requests to diagConfig(request, env)

## Testing
- `npm test`

Please enable auto-merge if all checks pass.

------
https://chatgpt.com/codex/tasks/task_e_68c45702dba48327ab32d7a2f21f35fc