### PR TITLE
chore(kv): add KV seeder + workflow

### DIFF
--- a/.github/workflows/seed-kv.yml
+++ b/.github/workflows/seed-kv.yml
@@ -1,0 +1,47 @@
+name: Seed KV
+
+on:
+  workflow_dispatch:
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          check-latest: false
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+          run_install: false
+
+      - name: Enable PNPM via Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.0 --activate
+
+      - name: Enable PNPM cache
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Corepack version (non-blocking)
+        run: corepack --version || true
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile
+
+      - name: Seed KV
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_KV_POSTQ_NAMESPACE_ID: ${{ secrets.CF_KV_POSTQ_NAMESPACE_ID }}
+          THREAD_STATE_JSON: ${{ secrets.THREAD_STATE_JSON }}
+          BRAIN_DOC_MD: ${{ secrets.BRAIN_DOC_MD }}
+        run: pnpm run seed:kv

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
 
     "// --- Stripe ---": "-----------------------------------------------",
     "stripe:sync": "tsx scripts/stripe-sync.ts",
-    "seed:stripe": "tsx scripts/seed/stripe.ts"
+    "seed:stripe": "tsx scripts/seed/stripe.ts",
+    "seed:kv": "tsx scripts/seedKV.ts"
   },
   "dependencies": {
     "axios": "^1.6.7",

--- a/scripts/seedKV.ts
+++ b/scripts/seedKV.ts
@@ -1,0 +1,45 @@
+import process from 'node:process';
+
+async function putKV(account: string, token: string, namespaceId: string, key: string, value: string, contentType: string) {
+  const url = `https://api.cloudflare.com/client/v4/accounts/${account}/storage/kv/namespaces/${namespaceId}/values/${encodeURIComponent(key)}`;
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': contentType,
+    },
+    body: value,
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Failed to write ${key}: ${res.status} ${text}`);
+  }
+}
+
+async function main() {
+  const account = process.env.CF_ACCOUNT_ID;
+  const token = process.env.CF_API_TOKEN;
+  const namespaceId = process.env.CF_KV_POSTQ_NAMESPACE_ID;
+  const threadState = process.env.THREAD_STATE_JSON;
+  const brainDoc = process.env.BRAIN_DOC_MD;
+
+  if (!account || !token || !namespaceId) {
+    console.error('Missing CF_ACCOUNT_ID, CF_API_TOKEN, or CF_KV_POSTQ_NAMESPACE_ID');
+    process.exit(1);
+  }
+  if (!threadState || !brainDoc) {
+    console.error('Missing THREAD_STATE_JSON or BRAIN_DOC_MD');
+    process.exit(1);
+  }
+
+  await putKV(account, token, namespaceId, 'thread-state', threadState, 'application/json');
+  await putKV(account, token, namespaceId, 'PostQ:thread-state', brainDoc, 'text/markdown');
+  console.log('Seeded KV');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
## Summary
- add script to seed Cloudflare KV with thread-state and brain doc
- wire up seed:kv npm script and GitHub Action

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4595d0cd48327bca5ea34eae1765a