### PR TITLE
chore(worker): add safe /health and /diag/config, bind BRAIN KV, prevent 1101s

### DIFF
--- a/worker/diag.ts
+++ b/worker/diag.ts
@@ -1,0 +1,42 @@
+import { presenceReport, Env } from './lib/env';
+
+export async function handleDiagConfig(env: Env): Promise<Response> {
+  try {
+    const report = presenceReport(env);
+
+    let brainDocBytes: number | null = null;
+    let secretBlobBytes: number | null = null;
+
+    if (report.bindings.BRAIN) {
+      if (env.BRAIN_DOC_KEY) {
+        const v = await env.BRAIN.get(env.BRAIN_DOC_KEY);
+        brainDocBytes = v ? new TextEncoder().encode(v).length : 0;
+      }
+      if (env.SECRET_BLOB) {
+        const s = await env.BRAIN.get(env.SECRET_BLOB);
+        secretBlobBytes = s ? new TextEncoder().encode(s).length : 0;
+      }
+    }
+
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        ...report,
+        kv: {
+          probed: report.bindings.BRAIN,
+          brainDocKey: env.BRAIN_DOC_KEY || null,
+          brainDocBytes,
+          secretBlobKey: env.SECRET_BLOB || null,
+          secretBlobBytes,
+        },
+      }),
+      { headers: { 'content-type': 'application/json' } },
+    );
+  } catch (err: any) {
+    console.error('[/diag/config] crash:', err?.stack || err);
+    return new Response(JSON.stringify({ ok: false, error: 'diag-failed' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+}

--- a/worker/health.ts
+++ b/worker/health.ts
@@ -1,63 +1,16 @@
-// worker/health.ts
-type DiagResult = {
-  ok: boolean;
-  notes: string[];
-  errors: string[];
-  kv: {
-    binding: boolean;
-    read: boolean;
-    namespaceHint?: string;
-  };
-  keys: {
-    blobKey: string;
-    brainDocKey: string;
-  };
-  present: Record<string, boolean>;
-};
+import { presenceReport, Env } from './lib/env';
 
-export const diagConfig = async (_req: Request, env: any) => {
-  const res: DiagResult = {
-    ok: true,
-    notes: [],
-    errors: [],
-    kv: { binding: false, read: false },
-    keys: {
-      blobKey: env?.SECRET_BLOB || "thread-state",
-      brainDocKey: env?.BRAIN_DOC_KEY || "PostQ:thread-state",
-    },
-    present: {},
-  };
-
-  // 1) Ensure KV binding exists
-  if (!env || !("BRAIN" in env) || !env.BRAIN) {
-    res.ok = false;
-    res.errors.push("KV binding 'BRAIN' is missing (check wrangler.toml).");
-    return new Response(JSON.stringify(res), {
-      headers: { "content-type": "application/json" },
-      status: 200,
+export async function handleHealth(env: Env): Promise<Response> {
+  try {
+    const report = presenceReport(env);
+    return new Response(JSON.stringify({ ok: true, ...report }), {
+      headers: { 'content-type': 'application/json' },
+    });
+  } catch (err: any) {
+    console.error('[/health] crash:', err?.stack || err);
+    return new Response(JSON.stringify({ ok: false, error: 'health-failed' }), {
+      status: 500,
+      headers: { 'content-type': 'application/json' },
     });
   }
-  res.kv.binding = true;
-
-  // 2) Try reading keys; never throw
-  try {
-    const [blob, brain] = await Promise.all([
-      env.BRAIN.get(res.keys.blobKey, "text"),
-      env.BRAIN.get(res.keys.brainDocKey, "text"),
-    ]);
-    res.kv.read = true;
-    res.present[res.keys.blobKey] = !!blob;
-    res.present[res.keys.brainDocKey] = !!brain;
-
-    if (!blob) res.notes.push(`KV missing '${res.keys.blobKey}' (ok if not initialized).`);
-    if (!brain) res.notes.push(`KV missing '${res.keys.brainDocKey}' (ok if not initialized).`);
-  } catch (e: any) {
-    res.ok = false;
-    res.errors.push(`KV read failed: ${e?.message || String(e)}`);
-  }
-
-  return new Response(JSON.stringify(res), {
-    headers: { "content-type": "application/json" },
-    status: 200,
-  });
-};
+}

--- a/worker/lib/env.ts
+++ b/worker/lib/env.ts
@@ -1,0 +1,20 @@
+export type Env = {
+  BRAIN: KVNamespace;
+  SECRET_BLOB?: string;        // e.g., "thread-state"
+  BRAIN_DOC_KEY?: string;      // e.g., "PostQ:thread-state"
+  [k: string]: unknown;
+};
+
+export function presenceReport(env: Env) {
+  const keys = ['SECRET_BLOB','BRAIN_DOC_KEY'];
+
+  const hasBRAIN =
+    !!env.BRAIN &&
+    typeof (env.BRAIN as any).get === 'function' &&
+    typeof (env.BRAIN as any).put === 'function';
+
+  const vars: Record<string, boolean> = {};
+  for (const k of keys) vars[k] = !!(env as any)[k];
+
+  return { ok: true, bindings: { BRAIN: hasBRAIN }, vars };
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -21,8 +21,7 @@ BRAIN_DOC_KEY = "PostQ:thread-state"  # the human-readable brain doc key in KV
 # This avoids hard-coding IDs in the repo.
 [[kv_namespaces]]
 binding = "BRAIN"
-# prefer env-provided namespace id if available; otherwise use the one that already holds our keys
-id = "${CF_KV_POSTQ_NAMESPACE_ID:-${CF_KV_NAMESPACE_ID}}"
+id = "1b8cbbc4a2f8426194368cb39baded79"
 
 # === Routes (Worker only) ===
 [[routes]]


### PR DESCRIPTION
## Summary
- add Env helper and presence report for KV and vars
- add safe /health and /diag/config handlers
- update worker to route through new handlers and default to JSON 404s
- configure wrangler.toml with BRAIN binding and vars

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5cf069f8c8327ba6ff315595601d9