### PR TITLE
chore(ci): install pnpm and stabilize sync-brain

### DIFF
--- a/.github/workflows/brain-sync.yml
+++ b/.github/workflows/brain-sync.yml
@@ -1,20 +1,54 @@
 name: Sync Brain to KV
 
 on:
+  workflow_dispatch:
   push:
-    branches: [main]
+    branches: [ main ]
+    paths:
+      - 'docs/brain.md'
+      - 'scripts/updateBrain.ts'
 
 jobs:
   sync-brain:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
         with:
           node-version: 20
-      - run: pnpm install --frozen-lockfile=false
+          cache: 'pnpm'
+
+      # Fix: pnpm was missing -> install it explicitly
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile=false
+
       - name: Update Brain KV
         env:
-          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: npx tsx scripts/updateBrain.ts
+          # Cloudflare / KV
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_KV_POSTQ_NAMESPACE_ID: ${{ secrets.CF_KV_POSTQ_NAMESPACE_ID }}
+          # Brain keys (worker reads these names)
+          SECRET_BLOB: thread-state
+          BRAIN_DOC_KEY: PostQ:thread-state
+          # (Optional) JSON mirror of secrets if script needs it
+          THREAD_STATE_JSON: ${{ secrets.THREAD_STATE_JSON }}
+        run: pnpm tsx scripts/updateBrain.ts
+
+      - name: Verify parity
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_KV_POSTQ_NAMESPACE_ID: ${{ secrets.CF_KV_POSTQ_NAMESPACE_ID }}
+          SECRET_BLOB: thread-state
+          BRAIN_DOC_KEY: PostQ:thread-state
+        run: pnpm tsx scripts/brainPing.ts


### PR DESCRIPTION
## Summary
- fix sync-brain workflow by installing pnpm and adding verification steps

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5d73d1d588327b4b220827c90ed20