### PR TITLE
chore(ci): run brain sync nightly and reusable

### DIFF
--- a/.github/workflows/brain-sync.yml
+++ b/.github/workflows/brain-sync.yml
@@ -2,6 +2,9 @@ name: Sync Brain to KV
 
 on:
   workflow_dispatch:
+  workflow_call:
+  schedule:
+    - cron: '0 0 * * *'
   push:
     branches: [ main ]
     paths:


### PR DESCRIPTION
## Summary
- run brain sync nightly at midnight UTC and allow reuse

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6ea5d8ba0832789ee8600018332f1