### PR TITLE
feat(ci): add nightly Stripe audit + donate button health

### DIFF
--- a/.github/workflows/stripe-audit.yml
+++ b/.github/workflows/stripe-audit.yml
@@ -1,0 +1,43 @@
+name: Stripe Audit
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: "45 3 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          pnpm -v || npm i -g pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile=false
+
+      - name: Run audit
+        run: pnpm tsx scripts/stripe_audit.mjs
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PROD_URL: ${{ secrets.PROD_URL }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: stripe_audit
+          path: stripe_audit.json

--- a/docs/ops/stripe-audit.md
+++ b/docs/ops/stripe-audit.md
@@ -1,0 +1,28 @@
+# Stripe Audit
+
+Nightly job verifying Stripe products and donate button health.
+
+## What it checks
+- Lists active Stripe products and their prices.
+- Ensures each product has an active price and a currency.
+- Cross-checks donate button amounts and price IDs on the live site.
+- Optionally posts a Telegram summary.
+
+## How to run
+1. Go to **Actions → Stripe Audit**.
+2. Click **Run workflow** to start a manual run.
+
+## Secrets
+- `STRIPE_SECRET_KEY`
+- `PROD_URL`
+- optional: `OPENAI_API_KEY`
+- optional: `TELEGRAM_BOT_TOKEN`
+- optional: `TELEGRAM_CHAT_ID`
+
+## Exit codes
+- `0` – no issues.
+- `78` – warnings only (e.g., unused prices).
+- `1` – errors (missing active price, currency mismatch, broken link, etc.).
+
+## Output
+The workflow uploads `stripe_audit.json` as an artifact containing the full report.

--- a/scripts/stripe_audit.mjs
+++ b/scripts/stripe_audit.mjs
@@ -1,0 +1,155 @@
+import fs from 'fs';
+import Stripe from 'stripe';
+
+const {
+  STRIPE_SECRET_KEY,
+  OPENAI_API_KEY,
+  PROD_URL,
+  TELEGRAM_BOT_TOKEN,
+  TELEGRAM_CHAT_ID,
+} = process.env;
+
+if (!STRIPE_SECRET_KEY) {
+  console.error('STRIPE_SECRET_KEY is required');
+  process.exit(1);
+}
+
+const stripe = new Stripe(STRIPE_SECRET_KEY, { apiVersion: '2023-10-16' });
+
+async function listAll(listFn, params = {}) {
+  const items = [];
+  let hasMore = true;
+  let starting_after;
+  while (hasMore) {
+    const resp = await listFn({ limit: 100, starting_after, ...params });
+    items.push(...resp.data);
+    hasMore = resp.has_more;
+    starting_after = resp.data[resp.data.length - 1]?.id;
+  }
+  return items;
+}
+
+async function fetchStripe() {
+  const products = await listAll(stripe.products.list.bind(stripe.products), { active: true });
+  const productInfos = [];
+  const issues = [];
+  const warnings = [];
+  let priceCount = 0;
+
+  for (const p of products) {
+    const prices = await listAll(stripe.prices.list.bind(stripe.prices), { product: p.id });
+    priceCount += prices.length;
+    const normPrices = prices.map(pr => ({
+      id: pr.id,
+      unit_amount: pr.unit_amount,
+      currency: pr.currency,
+      recurring_interval: pr.recurring?.interval || null,
+      active: pr.active,
+    }));
+    if (!prices.some(pr => pr.active)) {
+      issues.push(`Product ${p.id} has no active price`);
+    }
+    prices.forEach(pr => {
+      if (!pr.currency) issues.push(`Price ${pr.id} missing currency`);
+      if (!pr.active) warnings.push(`Price ${pr.id} is inactive`);
+    });
+    productInfos.push({
+      id: p.id,
+      name: p.name,
+      active: p.active,
+      metadata: p.metadata,
+      prices: normPrices,
+    });
+  }
+  return { productInfos, issues, warnings, totals: { products: products.length, prices: priceCount } };
+}
+
+function parseSite(html) {
+  const priceIds = new Set();
+  const amounts = new Set();
+  for (const m of html.matchAll(/data-price-id=["'](price_[^"']+)["']/g)) {
+    priceIds.add(m[1]);
+  }
+  for (const m of html.matchAll(/\$\s*(\d+(?:\.\d{2})?)/g)) {
+    amounts.add(m[1]);
+  }
+  return { priceIds, amounts };
+}
+
+async function fetchSite() {
+  if (!PROD_URL) throw new Error('PROD_URL required');
+  const res = await fetch(PROD_URL);
+  if (!res.ok) throw new Error(`Site fetch failed: ${res.status}`);
+  const html = await res.text();
+  return parseSite(html);
+}
+
+async function sendTelegram(text) {
+  if (!TELEGRAM_BOT_TOKEN || !TELEGRAM_CHAT_ID) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ chat_id: TELEGRAM_CHAT_ID, text })
+    });
+  } catch (err) {
+    console.error('Telegram send failed:', err.message);
+  }
+}
+
+(async () => {
+  const { productInfos, issues, warnings, totals } = await fetchStripe();
+  let site;
+  try {
+    site = await fetchSite();
+  } catch (err) {
+    issues.push(err.message);
+  }
+
+  if (site) {
+    for (const p of productInfos) {
+      for (const pr of p.prices.filter(x => x.active)) {
+        const dollars = (pr.unit_amount ?? 0) / 100;
+        const amtStr = dollars.toFixed(2).replace(/\.00$/, '');
+        const foundId = site.priceIds.has(pr.id);
+        const foundAmt = site.amounts.has(amtStr) || site.amounts.has(dollars.toFixed(2));
+        if (!foundId && !foundAmt) {
+          issues.push(`Donate button amount missing on site for $${amtStr}`);
+        }
+      }
+    }
+
+    for (const amt of site.amounts) {
+      const cents = Math.round(parseFloat(amt) * 100);
+      const hasPrice = productInfos.some(p => p.prices.some(pr => pr.active && pr.unit_amount === cents));
+      if (!hasPrice) issues.push(`Site references amount $${amt} not found in Stripe`);
+    }
+
+    for (const id of site.priceIds) {
+      const hasPrice = productInfos.some(p => p.prices.some(pr => pr.id === id));
+      if (!hasPrice) issues.push(`Site references unknown price ${id}`);
+    }
+  }
+
+  const data = {
+    ts: new Date().toISOString(),
+    products: productInfos,
+    totals,
+    issues: issues.concat(warnings),
+  };
+  fs.writeFileSync('stripe_audit.json', JSON.stringify(data, null, 2));
+
+  const status = issues.length ? 'FAIL' : warnings.length ? 'WARN' : 'OK';
+  const summary = `${status}: ${totals.products} products, ${totals.prices} prices | issues: ${issues.length + warnings.length}`;
+  console.log(summary);
+  if (issues.length || warnings.length) {
+    for (const msg of issues.concat(warnings)) console.log(`- ${msg}`);
+  }
+
+  const teleMsg = `Mags Stripe Audit: ${issues.length ? '❌ FAIL' : '✅ OK'} (${totals.products} products, ${totals.prices} prices) | ❌ Issues: ${issues.length + warnings.length}`;
+  await sendTelegram(teleMsg);
+
+  if (issues.length) process.exit(1);
+  else if (warnings.length) process.exit(78);
+  else process.exit(0);
+})();


### PR DESCRIPTION
## Summary
- add scheduled `Stripe Audit` workflow to verify products/prices nightly and via dispatch
- implement `scripts/stripe_audit.mjs` to fetch Stripe data, cross-check donate buttons, and send optional Telegram summary
- document how to run the audit and interpret results

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6f755cff083278d2aae43358fb786