### PR TITLE
feat(gmail): add Apps Script proxy + hourly scan workflow with Telegram summaries

### DIFF
--- a/.github/workflows/gmail-scan.yml
+++ b/.github/workflows/gmail-scan.yml
@@ -1,0 +1,56 @@
+name: Gmail scan + summarize
+
+on:
+  schedule: [{ cron: "*/30 * * * *" }]
+  workflow_dispatch: {}
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install deps
+        run: pnpm install --frozen-lockfile=false
+
+      - name: Scan Gmail via GAS
+        id: scan
+        env:
+          GAS_GMAIL_URL: ${{ secrets.GAS_GMAIL_URL }}
+          GAS_SHARED_SECRET: ${{ secrets.GAS_SHARED_SECRET }}
+        run: |
+          node -e '
+            const https = require("https");
+            const payload = JSON.stringify({ action:"scan", secret:process.env.GAS_SHARED_SECRET, sinceDays:7, max:20 });
+            const url = new URL(process.env.GAS_GMAIL_URL);
+            const opts = { method:"POST", headers:{ "content-type":"application/json" } };
+            const req = https.request(url, opts, res => {
+              let data=""; res.on("data", d=>data+=d); res.on("end", ()=> {
+                if (res.statusCode >= 300) { console.error(res.statusCode, data); process.exit(0); }
+                console.log(data);
+              });
+            });
+            req.on("error", e=>{ console.error(e); process.exit(0); });
+            req.write(payload); req.end();
+          ' > scan.json || true
+
+      - name: Summarize & notify
+        if: always()
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          GAS_GMAIL_URL: ${{ secrets.GAS_GMAIL_URL }}
+          GAS_SHARED_SECRET: ${{ secrets.GAS_SHARED_SECRET }}
+          NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
+          HQ_DATABASE_ID: ${{ secrets.HQ_DATABASE_ID }}
+        run: |
+          pnpm tsx scripts/gmail_scan.mjs scan.json

--- a/apps-script/MagsGmailProxy/Code.gs
+++ b/apps-script/MagsGmailProxy/Code.gs
@@ -1,0 +1,116 @@
+const SHARED_SECRET = PropertiesService.getScriptProperties().getProperty('GAS_SHARED_SECRET');
+const MAX_THREADS = 20;
+const SEARCH_QUERIES = [
+  'from:(grants.gov OR foundation OR fund OR grant OR program) newer_than:7d',
+  'subject:(application OR proposal OR grant OR funding) newer_than:7d',
+  'in:inbox OR in:starred newer_than:7d'
+];
+const LABEL_NEW = 'Mags/New';
+const LABEL_REVIEW = 'Mags/Review';
+const LABEL_DRAFTED = 'Mags/Drafted';
+const LABEL_REPLIED = 'Mags/Replied';
+
+function doPost(e) {
+  try {
+    const body = e.postData ? e.postData.contents : '{}';
+    const data = JSON.parse(body);
+    const auth = e.parameter && e.parameter.Authorization;
+    const headerAuth = e.postData && e.postData.type === 'application/json' && e.headers && e.headers.Authorization;
+    const bearer = (auth || headerAuth || '').replace('Bearer ', '');
+    if (data.secret !== SHARED_SECRET && bearer !== SHARED_SECRET) {
+      return json({ ok: false, error: 'unauthorized' }, 401);
+    }
+    const action = data.action;
+    if (action === 'scan') return scanAction(data);
+    if (action === 'draft') return draftAction(data);
+    if (action === 'label') return labelAction(data);
+    return json({ ok: false, error: 'unknown action' });
+  } catch (err) {
+    return json({ ok: false, error: err.message });
+  }
+}
+
+function scanAction(data) {
+  const sinceDays = Number(data.sinceDays || 7);
+  const max = Math.min(Number(data.max || MAX_THREADS), MAX_THREADS);
+  const results = [];
+  const queries = SEARCH_QUERIES.map(q => q.replace(/newer_than:\d+d/g, '') + ` newer_than:${sinceDays}d`);
+  for (const q of queries) {
+    const threads = GmailApp.search(q, 0, max);
+    for (const thread of threads) {
+      if (results.length >= max) break;
+      const msg = pickMessage(thread);
+      const bodyHtml = msg.getBody();
+      const bodyPreview = plainText(bodyHtml).slice(0, 500);
+      results.push({
+        threadId: thread.getId(),
+        subject: thread.getFirstMessageSubject(),
+        from: msg.getFrom(),
+        date: msg.getDate().toISOString(),
+        snippet: msg.getPlainBody().slice(0, 100),
+        bodyPreview,
+        threadUrl: threadUrl(thread.getId())
+      });
+      thread.addLabel(getOrCreateLabel(LABEL_NEW));
+    }
+    if (results.length >= max) break;
+  }
+  return json({ ok: true, threads: results });
+}
+
+function draftAction(data) {
+  try {
+    const { threadId, subjectAddon, body } = data;
+    if (!threadId || !body) return json({ ok: false, error: 'missing fields' });
+    const thread = GmailApp.getThreadById(threadId);
+    const msg = pickMessage(thread);
+    const replySubject = (subjectAddon ? msg.getSubject() + ' ' + subjectAddon : msg.getSubject());
+    thread.createDraftReply(body, { subject: replySubject });
+    thread.addLabel(getOrCreateLabel(LABEL_DRAFTED));
+    return json({ ok: true });
+  } catch (err) {
+    return json({ ok: false, error: err.message });
+  }
+}
+
+function labelAction(data) {
+  try {
+    const { threadId, add, remove } = data;
+    if (!threadId) return json({ ok: false, error: 'threadId required' });
+    const thread = GmailApp.getThreadById(threadId);
+    if (add) thread.addLabel(getOrCreateLabel(add));
+    if (remove) thread.removeLabel(getOrCreateLabel(remove));
+    return json({ ok: true });
+  } catch (err) {
+    return json({ ok: false, error: err.message });
+  }
+}
+
+function getOrCreateLabel(name) {
+  const label = GmailApp.getUserLabelByName(name);
+  return label || GmailApp.createLabel(name);
+}
+
+function threadUrl(id) {
+  return `https://mail.google.com/mail/u/0/#inbox/${id}`;
+}
+
+function plainText(html) {
+  return html.replace(/<[^>]+>/g, ' ').replace(/&nbsp;/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+function pickMessage(thread) {
+  const me = Session.getActiveUser().getEmail();
+  const msgs = thread.getMessages();
+  for (let i = msgs.length - 1; i >= 0; i--) {
+    const m = msgs[i];
+    if (m.getFrom().indexOf(me) === -1) return m;
+  }
+  return msgs[msgs.length - 1];
+}
+
+function json(obj, code) {
+  const out = ContentService.createTextOutput(JSON.stringify(obj));
+  if (code) out.setResponseCode(code);
+  return out.setMimeType(ContentService.MimeType.JSON);
+}

--- a/docs/ops/gmail-scan.md
+++ b/docs/ops/gmail-scan.md
@@ -1,0 +1,32 @@
+# Gmail Scan
+
+Periodic Gmail scanning for grant/funding emails. Uses a Google Apps Script web app as a proxy and a GitHub Action that pings it every 30 minutes and summarizes results to Telegram.
+
+## Deploying the Apps Script
+1. Go to [script.google.com](https://script.google.com) and create a new project named **Mags Gmail Proxy**.
+2. Replace the default file with [`Code.gs`](../../apps-script/MagsGmailProxy/Code.gs).
+3. In **Project Settings → Script properties** add `GAS_SHARED_SECRET` with a long random string.
+4. Deploy: **Deploy → New deployment → Web app**. Execute as *Me* and grant access to *Anyone with the link*.
+5. Copy the web app URL and store it in the GitHub secret `GAS_GMAIL_URL`. Use the same secret value for `GAS_SHARED_SECRET`.
+
+## GitHub Secrets
+The workflow reads these secrets (missing ones are ignored):
+- `GAS_GMAIL_URL`
+- `GAS_SHARED_SECRET`
+- `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHAT_ID`
+- `OPENAI_API_KEY`
+- Optional: `NOTION_TOKEN`, `HQ_DATABASE_ID`
+
+## Gmail Labels
+- `Mags/New` – new threads found by the scanner
+- `Mags/Review` – needs human review
+- `Mags/Drafted` – draft reply created
+- `Mags/Replied` – reply sent
+
+## Customization
+- Search queries live in `Code.gs` (`SEARCH_QUERIES`). Adjust them or the `MAX_THREADS` limit as needed.
+- Scan frequency is controlled by the cron schedule in `.github/workflows/gmail-scan.yml` (currently every 30 minutes).
+- To change notification text or auto-drafting behavior, edit `scripts/gmail_scan.mjs`.
+
+## Notion Logging
+If `NOTION_TOKEN` and `HQ_DATABASE_ID` are set, each summary is appended to the Notion database with date, from, subject, summary, thread URL, and status.

--- a/scripts/gmail_scan.mjs
+++ b/scripts/gmail_scan.mjs
@@ -1,0 +1,152 @@
+import fs from 'fs';
+
+const file = process.argv[2] || 'scan.json';
+let threads = [];
+try {
+  const raw = fs.readFileSync(file, 'utf8');
+  const data = JSON.parse(raw);
+  threads = data.threads || [];
+} catch (err) {
+  console.error('Failed to read scan file:', err.message);
+}
+
+const {
+  OPENAI_API_KEY,
+  TELEGRAM_BOT_TOKEN,
+  TELEGRAM_CHAT_ID,
+  GAS_GMAIL_URL,
+  GAS_SHARED_SECRET,
+  NOTION_TOKEN,
+  HQ_DATABASE_ID,
+} = process.env;
+
+async function sendTelegram(text) {
+  if (!TELEGRAM_BOT_TOKEN || !TELEGRAM_CHAT_ID) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ chat_id: TELEGRAM_CHAT_ID, text })
+    });
+  } catch (err) {
+    console.error('Telegram send failed:', err.message);
+  }
+}
+
+async function callOpenAI(prompt) {
+  if (!OPENAI_API_KEY) return null;
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        Authorization: `Bearer ${OPENAI_API_KEY}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: prompt }],
+        temperature: 0.2
+      })
+    });
+    const json = await res.json();
+    const content = json.choices?.[0]?.message?.content;
+    return content;
+  } catch (err) {
+    console.error('OpenAI error:', err.message);
+    return null;
+  }
+}
+
+async function appendNotion(item, summary) {
+  if (!NOTION_TOKEN || !HQ_DATABASE_ID) return;
+  try {
+    await fetch('https://api.notion.com/v1/pages', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${NOTION_TOKEN}`,
+        'Content-Type': 'application/json',
+        'Notion-Version': '2022-06-28'
+      },
+      body: JSON.stringify({
+        parent: { database_id: HQ_DATABASE_ID },
+        properties: {
+          Name: { title: [{ text: { content: item.subject.slice(0, 200) } }] },
+          Date: { date: { start: item.date } },
+          From: { rich_text: [{ text: { content: item.from } }] },
+          Summary: { rich_text: [{ text: { content: summary.slice(0, 2000) } }] },
+          'Thread URL': { url: item.threadUrl },
+          Status: { select: { name: 'Scanned' } }
+        }
+      })
+    });
+  } catch (err) {
+    console.error('Notion error:', err.message);
+  }
+}
+
+async function draftViaGAS(threadId, body) {
+  if (!GAS_GMAIL_URL || !GAS_SHARED_SECRET) return false;
+  try {
+    const res = await fetch(GAS_GMAIL_URL, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ action: 'draft', secret: GAS_SHARED_SECRET, threadId, body })
+    });
+    const json = await res.json();
+    return json.ok;
+  } catch (err) {
+    console.error('Draft error:', err.message);
+    return false;
+  }
+}
+
+async function processThreads() {
+  if (!threads.length) {
+    await sendTelegram('No new grant/mail in last 30m');
+    return;
+  }
+
+  const out = [];
+  for (const t of threads.slice(0, 5)) {
+    const prompt = `Summarize and assess if this email is about grants, funding, or property. Return JSON {summary, shortReply?, longReply?, nextSteps?}.
+From: ${t.from}
+Subject: ${t.subject}
+Body: ${t.bodyPreview}`;
+    let summary = '';
+    let shortReply = '';
+    let longReply = '';
+    let nextSteps = [];
+    const ai = await callOpenAI(prompt);
+    if (ai) {
+      try {
+        const parsed = JSON.parse(ai);
+        summary = parsed.summary || '';
+        shortReply = parsed.shortReply || '';
+        longReply = parsed.longReply || '';
+        nextSteps = parsed.nextSteps || [];
+      } catch (err) {
+        summary = ai.slice(0, 500);
+      }
+    }
+    await appendNotion(t, summary);
+    out.push({ thread: t, summary, shortReply, longReply, nextSteps });
+  }
+
+  let drafted = false;
+  let message = `📬 Gmail Scan: ${threads.length} threads\n`;
+  for (const item of out) {
+    message += `• From: ${item.thread.from} — Subject: ${item.thread.subject} — ${item.thread.threadUrl}\n${item.summary}\n`;
+    if (item.nextSteps?.length) message += `Next: ${item.nextSteps.join('; ')}\n`;
+    if (!drafted && item.shortReply) {
+      const ok = await draftViaGAS(item.thread.threadId, item.shortReply);
+      if (ok) {
+        drafted = true;
+        message += 'Draft created ✅\n';
+      }
+    }
+  }
+
+  await sendTelegram(message.trim());
+}
+
+processThreads().then(() => process.exit(0));


### PR DESCRIPTION
## Summary
- add GAS proxy for Gmail scanning, drafting and labeling
- schedule Gmail scan workflow with Telegram summaries and optional Notion logging
- document Gmail scan deployment and labels

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6fc111c4c8327a28ed6c4a02b0612