### PR TITLE
Fix pnpm install in brain sync workflow

### DIFF
--- a/.github/workflows/sync-brain.yml
+++ b/.github/workflows/sync-brain.yml
@@ -24,13 +24,13 @@ jobs:
           node-version: 20
           cache: 'pnpm'
 
-      - name: Enable Corepack (pnpm)
-        run: |
-          corepack enable
-          pnpm -v || (npm i -g pnpm && pnpm -v)
+      - name: Enable Corepack
+        run: corepack enable
+
+      - run: pnpm --version
 
       - name: Install deps
-        run: pnpm install --frozen-lockfile=false
+        run: pnpm install --no-frozen-lockfile
 
       # ⬇ keep or merge any existing sync steps you had before
       - name: Update Brain KV


### PR DESCRIPTION
## Summary
- Ensure Node 20 is set up in brain sync workflow
- Enable Corepack and verify pnpm availability
- Install dependencies with `pnpm install --no-frozen-lockfile`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c6ffe98f90832786fe3ef7cd12749b