### PR TITLE
Use GH_PAT for workflow dispatch and add token smoke test

### DIFF
--- a/.github/workflows/sync-brain.yml
+++ b/.github/workflows/sync-brain.yml
@@ -6,6 +6,10 @@ on:
     # 02:05 America/Denver ≈ 08:05 UTC (GitHub uses UTC)
     - cron: "5 8 * * *"
 
+permissions:
+  contents: write
+  actions: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -13,10 +17,8 @@ jobs:
 
     # Make all required credentials available
     env:
-      # --- GitHub auth: prefer GITHUB_PAT, then GH_PAT, then default token ---
-      GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+      # --- GitHub auth: GH_PAT only ---
       GH_PAT: ${{ secrets.GH_PAT }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_PAT || secrets.GH_PAT || secrets.GITHUB_TOKEN }}
 
       # --- Cloudflare / KV (names already present in repo secrets per screenshots) ---
       CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
@@ -32,7 +34,7 @@ jobs:
       - name: Checkout (with PAT)
         uses: actions/checkout@v4
         with:
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ env.GH_PAT }}
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/token-smoke.yml
+++ b/.github/workflows/token-smoke.yml
@@ -1,0 +1,34 @@
+name: Token Smoke
+on:
+  workflow_dispatch:
+permissions:
+  contents: read
+  actions: read
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if GH_PAT not set
+        run: |
+          if [ -z "${{ secrets.GH_PAT }}" ]; then
+            echo "GH_PAT is not configured in repo secrets"; exit 1
+          fi
+      - name: Call GitHub API with GH_PAT
+        run: |
+          set -e
+          # Show scopes (from response header) to verify 'workflow' is present
+          curl -sS -D headers.txt -o /dev/null \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${{ secrets.GH_PAT }}" \
+            https://api.github.com/user
+          echo "---- x-oauth-scopes ----"
+          grep -i '^x-oauth-scopes:' headers.txt || true
+          echo "---- rate-limit ----"
+          grep -i '^x-ratelimit-' headers.txt || true
+          # Try listing workflows (should be 200)
+          code=$(curl -sS -o /dev/null -w "%{http_code}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token ${{ secrets.GH_PAT }}" \
+            https://api.github.com/repos/${{ github.repository }}/actions/workflows)
+          echo "List workflows HTTP $code"
+          [ "$code" = "200" ] || (echo "Expected 200; got $code"; exit 1)


### PR DESCRIPTION
## Summary
- use GH_PAT for sync-brain workflow with explicit permissions
- add token-smoke workflow to verify PAT scopes

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68c760f242f48327919462b50a3a67ff