### PR TITLE
Use GH_PAT for sync-brain dispatch smoke

### DIFF
--- a/.github/workflows/sync-brain.yml
+++ b/.github/workflows/sync-brain.yml
@@ -2,6 +2,11 @@ name: Sync Brain to KV
 
 on:
   workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Optional note surfaced when dispatching via API/PAT.'
+        required: false
+        default: ''
   schedule:
     # 02:05 America/Denver ≈ 08:05 UTC (GitHub uses UTC)
     - cron: "5 8 * * *"
@@ -9,6 +14,13 @@ on:
 permissions:
   contents: write
   actions: write
+
+# Manual dispatch via PAT (requires repo + workflow scopes on GH_PAT):
+# curl -sS -X POST \
+#   -H "Accept: application/vnd.github+json" \
+#   -H "Authorization: token ${{ secrets.GH_PAT }}" \
+#   "https://api.github.com/repos/${{ github.repository }}/actions/workflows/sync-brain.yml/dispatches" \
+#   -d '{"ref":"main"}'
 
 jobs:
   sync:
@@ -31,6 +43,10 @@ jobs:
       BRAIN_DOC_KEY: PostQ:thread-state
 
     steps:
+      - name: Show dispatch reason
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.reason != '' }}
+        run: echo "Dispatch reason: ${{ github.event.inputs.reason }}"
+
       - name: Checkout (with PAT)
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/token-smoke.yml
+++ b/.github/workflows/token-smoke.yml
@@ -7,28 +7,45 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    env:
+      GH_PAT: ${{ secrets.GH_PAT }}
     steps:
       - name: Fail if GH_PAT not set
         run: |
-          if [ -z "${{ secrets.GH_PAT }}" ]; then
+          if [ -z "$GH_PAT" ]; then
             echo "GH_PAT is not configured in repo secrets"; exit 1
           fi
       - name: Call GitHub API with GH_PAT
         run: |
-          set -e
+          set -euo pipefail
           # Show scopes (from response header) to verify 'workflow' is present
           curl -sS -D headers.txt -o /dev/null \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token ${{ secrets.GH_PAT }}" \
+            -H "Authorization: token $GH_PAT" \
             https://api.github.com/user
           echo "---- x-oauth-scopes ----"
-          grep -i '^x-oauth-scopes:' headers.txt || true
+          grep -i '^x-oauth-scopes:' headers.txt || echo "(header missing)"
           echo "---- rate-limit ----"
-          grep -i '^x-ratelimit-' headers.txt || true
+          grep -i '^x-ratelimit-' headers.txt || echo "(headers missing)"
           # Try listing workflows (should be 200)
           code=$(curl -sS -o /dev/null -w "%{http_code}" \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token ${{ secrets.GH_PAT }}" \
+            -H "Authorization: token $GH_PAT" \
             https://api.github.com/repos/${{ github.repository }}/actions/workflows)
           echo "List workflows HTTP $code"
           [ "$code" = "200" ] || (echo "Expected 200; got $code"; exit 1)
+          rm -f headers.txt
+      - name: Dispatch sync-brain.yml (permission check)
+        run: |
+          set -euo pipefail
+          echo "Dispatching sync-brain.yml via GH_PAT for verification"
+          status=$(curl -sS -o /dev/null -w "%{http_code}" \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: token $GH_PAT" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/workflows/sync-brain.yml/dispatches" \
+            -d '{"ref":"main","inputs":{"reason":"token-smoke"}}')
+          echo "Dispatch returned HTTP $status"
+          if [ "$status" != "204" ]; then
+            echo "Expected HTTP 204 when dispatching sync-brain.yml"; exit 1
+          fi


### PR DESCRIPTION
## Summary
- document the GH_PAT-based dispatch command and allow tagging manual runs via a `reason` input in `sync-brain.yml`
- extend the token smoke workflow to validate GH_PAT scopes and POST the sync-brain dispatch endpoint using the PAT

## Testing
- not run (workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68cc2f21d240832798f26a85002cb46c