### PR TITLE
chore: fix GH_PAT usage in orchestrator workflows

### DIFF
--- a/.github/workflows/debug-gh-pat.yml
+++ b/.github/workflows/debug-gh-pat.yml
@@ -9,23 +9,33 @@ permissions:
 jobs:
   debug:
     runs-on: ubuntu-latest
+    env:
+      GH_PAT: ${{ secrets.GH_PAT }}
+      GITHUB_TOKEN: ${{ secrets.GH_PAT }}
     steps:
+      - name: Diagnostics
+        shell: bash
+        env:
+          GH_TOKEN: ${{ env.GH_PAT }}
+        run: |
+          echo "Actor: $GITHUB_ACTOR"
+          echo "Using PAT for repo: $GITHUB_REPOSITORY"
+          gh auth status || true
+
       - name: Check GH_PAT presence
         run: |
-          if [ -z "${{ secrets.GH_PAT }}" ]; then
+          if [ -z "$GH_PAT" ]; then
             echo "GH_PAT is NOT set"; exit 2
           else
             echo "GH_PAT is set"
           fi
       - name: GET /user headers with GH_PAT (redacted)
-        env: { GH_PAT: ${{ secrets.GH_PAT }} }
         run: |
           set -e
           curl -sI -H "Authorization: Bearer $GH_PAT" https://api.github.com/user \
           | tr -d '\r' | awk 'BEGIN{IGNORECASE=1}/^x-oauth-scopes|^status|^date/ {print}'
       - name: Try workflow dispatch for token-smoke (expect 204)
         env:
-          GH_PAT: ${{ secrets.GH_PAT }}
           OWNER: messyandmagneticassistant
           REPO: mags-assistant
         run: |

--- a/.github/workflows/orchestrator.yml
+++ b/.github/workflows/orchestrator.yml
@@ -16,24 +16,33 @@ permissions:
 jobs:
   run:
     runs-on: ubuntu-latest
+    env:
+      GH_PAT: ${{ secrets.GH_PAT }}
+      GITHUB_TOKEN: ${{ secrets.GH_PAT }}
     steps:
+      - name: Diagnostics
+        shell: bash
+        env:
+          GH_TOKEN: ${{ env.GH_PAT }}
+        run: |
+          echo "Actor: $GITHUB_ACTOR"
+          echo "Using PAT for repo: $GITHUB_REPOSITORY"
+          gh auth status || true
+
       - name: Confirm GH_PAT presence
         run: |
-          if [ -z "${{ secrets.GH_PAT }}" ]; then
+          if [ -z "$GH_PAT" ]; then
             echo "GH_PAT is NOT set"; exit 2
           else
             echo "GH_PAT is set"
           fi
 
       - name: Print token scopes header (redacted)
-        env: { GH_PAT: ${{ secrets.GH_PAT }} }
         run: |
           curl -sI -H "Authorization: Bearer $GH_PAT" https://api.github.com/user \
           | tr -d '\r' | awk 'BEGIN{IGNORECASE=1}/^x-oauth-scopes|^date|^status/ {print}'
 
       - name: Dispatch GH_PAT Smoke (expect 204)
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
             -H "Authorization: Bearer $GH_PAT" \
@@ -44,8 +53,6 @@ jobs:
           test "$CODE" = "204" || { echo "Expected 204"; exit 3; }
 
       - name: Dispatch Sync Brain with reason post-smoke (expect 204)
-        env:
-          GH_PAT: ${{ secrets.GH_PAT }}
         run: |
           CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
             -H "Authorization: Bearer $GH_PAT" \
@@ -57,7 +64,6 @@ jobs:
 
       - name: Post summary to PR
         env:
-          GH_PAT: ${{ secrets.GH_PAT }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         if: ${{ github.event_name == 'pull_request' && env.PR_NUMBER != '' }}
         run: |

--- a/.github/workflows/sync-brain.yml
+++ b/.github/workflows/sync-brain.yml
@@ -28,6 +28,8 @@ jobs:
 
     # Make all required credentials available
     env:
+      GH_PAT: ${{ secrets.GH_PAT }}
+      GITHUB_TOKEN: ${{ secrets.GH_PAT }}
       # --- GitHub auth: GH_PAT only ---
       GH_TOKEN: ${{ secrets.GH_PAT }}
 
@@ -42,6 +44,15 @@ jobs:
       BRAIN_DOC_KEY: PostQ:thread-state
 
     steps:
+      - name: Diagnostics
+        shell: bash
+        env:
+          GH_TOKEN: ${{ env.GH_PAT }}
+        run: |
+          echo "Actor: $GITHUB_ACTOR"
+          echo "Using PAT for repo: $GITHUB_REPOSITORY"
+          gh auth status || true
+
       - name: Log dispatch reason
         env:
           DISPATCH_REASON: ${{ github.event.inputs.reason || '' }}
@@ -56,7 +67,7 @@ jobs:
       - name: Checkout (with PAT)
         uses: actions/checkout@v4
         with:
-          token: ${{ env.GH_TOKEN }}
+          token: ${{ env.GH_PAT }}
 
       - name: Setup Node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- ensure orchestrator, sync-brain, and debug workflows set GH_PAT/GITHUB_TOKEN env vars at the job level
- add diagnostic output and update dispatch/auth steps to use the PAT consistently

## Testing
- not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cdc9e5c14083279ce6b48cb00b6213