### PR TITLE
Add init blob endpoint for worker

### DIFF
--- a/worker/lib/env.ts
+++ b/worker/lib/env.ts
@@ -1,5 +1,6 @@
 export type Env = {
   BRAIN: KVNamespace;
+  PostQ?: KVNamespace;
   SECRET_BLOB?: string;        // e.g., "thread-state"
   BRAIN_DOC_KEY?: string;      // e.g., "PostQ:thread-state"
   [k: string]: unknown;


### PR DESCRIPTION
## Summary
- add a dedicated `/init-blob` worker route that seeds the Maggie brain document in KV
- allow the worker environment to expose an optional `PostQ` KV binding for compatibility

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68cef9e467d8832797ec6de0ff8ce4b9