### PR TITLE
Fix sync-brain workflow seeding via worker

### DIFF
--- a/.github/workflows/sync-brain.yml
+++ b/.github/workflows/sync-brain.yml
@@ -7,6 +7,10 @@ on:
         description: "Why are we running this?"
         required: false
         default: "manual"
+  push:
+    branches:
+      - main
+  pull_request:
   schedule:
     - cron: "30 3 * * *"   # 03:30 UTC (~9:30pm ABQ during DST)
 
@@ -68,6 +72,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ env.GH_PAT }}
+
+      - name: Seed KV via Worker
+        run: |
+          curl -X POST "https://maggie.messyandmagnetic.com/init-blob" \
+            -H "Authorization: Bearer ${{ secrets.POST_THREAD_SECRET }}" \
+            -H "Content-Type: application/json" \
+            --data-binary @config/thread-state.json
+
+      - name: Smoke test KV
+        run: |
+          curl -s "https://maggie.messyandmagnetic.com/diag/config" \
+            -H "Authorization: Bearer ${{ secrets.POST_THREAD_SECRET }}"
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/config/thread-state.json
+++ b/config/thread-state.json
@@ -1,0 +1,33 @@
+{
+  "version": "v1",
+  "lastUpdated": "2025-09-20T00:00:00Z",
+  "profile": {
+    "name": "Maggie",
+    "role": "Full-stack assistant"
+  },
+  "subdomains": [
+    "maggie.messyandmagnetic.com",
+    "assistant.messyandmagnetic.com"
+  ],
+  "email": "messyandmagnetic@gmail.com",
+  "kvNamespace": "PostQ",
+  "kvKey": "thread-state",
+  "services": {
+    "gmail": true,
+    "stripe": true,
+    "tally": true,
+    "notion": true,
+    "tikTok": true,
+    "n8n": true,
+    "googleDrive": true
+  },
+  "automation": {
+    "soulReadings": true,
+    "farmStand": true,
+    "postScheduler": true,
+    "readingDelivery": true,
+    "stripeAudit": true,
+    "magnetMatch": true
+  },
+  "notes": "Blob initialized"
+}


### PR DESCRIPTION
## Summary
- add the committed thread-state blob under config/thread-state.json for seeding
- update sync-brain workflow to trigger on pushes, PRs, schedule, and to seed KV via the worker with a smoke test

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68cf4ead95b4832799e8db89931a4eba