### PR TITLE
Add Run All orchestration workflow

### DIFF
--- a/.github/workflows/debug-gh-pat.yml
+++ b/.github/workflows/debug-gh-pat.yml
@@ -3,6 +3,10 @@ on:
   workflow_dispatch: {}
   repository_dispatch:
     types: [kick-gh-pat-debug]
+  workflow_call:
+    secrets:
+      GH_PAT:
+        required: true
 permissions:
   contents: read
   actions: write

--- a/.github/workflows/run-all.yml
+++ b/.github/workflows/run-all.yml
@@ -1,0 +1,196 @@
+name: Run All
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'Optional note for this run'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  gh_pat_debug:
+    name: GH_PAT Debug
+    uses: ./.github/workflows/debug-gh-pat.yml
+    secrets: inherit
+
+  worker_kv:
+    name: Seed and verify Worker KV
+    needs: gh_pat_debug
+    runs-on: ubuntu-latest
+    outputs:
+      social_seed: ${{ steps.seed.outputs.summary }}
+      worker_status: ${{ steps.status.outputs.summary }}
+      brain_check: ${{ steps.brain.outputs.summary }}
+    steps:
+      - name: Seed social defaults via Worker
+        id: seed
+        env:
+          API_KEY: ${{ secrets.POST_THREAD_SECRET }}
+        run: |
+          set -euo pipefail
+          RESP=$(curl --fail-with-body -sS -X POST \
+            -H "x-api-key: $API_KEY" \
+            -H "content-type: application/json" \
+            https://maggie.messyandmagnetic.com/admin/social/seed)
+          echo "Seed response (sanitized):"
+          echo "$RESP" | jq '{ok, configKeys: (.config // {} | keys)}'
+          SUMMARY=$(echo "$RESP" | jq -c '{ok, configKeys: (.config // {} | keys)}')
+          echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"
+
+      - name: Worker status snapshot
+        id: status
+        run: |
+          set -euo pipefail
+          RESP=$(curl --fail-with-body -sS https://maggie.messyandmagnetic.com/admin/status)
+          echo "Worker status snapshot:"
+          echo "$RESP" | jq '{ok, routesCount, kvKeysSample: (.kvKeysSample // []), queueSize, accountsCount, posts24h: .["24hPosts"]}'
+          SUMMARY=$(echo "$RESP" | jq -c '{ok, routesCount, kvSample: (.kvKeysSample // []), queueSize, accountsCount, posts24h: .["24hPosts"]}')
+          echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"
+
+      - name: Brain KV snapshot
+        id: brain
+        run: |
+          set -euo pipefail
+          RESP=$(curl --fail-with-body -sS https://maggie.messyandmagnetic.com/brain/get)
+          echo "Brain KV snapshot:"
+          echo "$RESP" | jq '{ok, exists, size}'
+          SUMMARY=$(echo "$RESP" | jq -c '{ok, exists, size}')
+          echo "summary=$SUMMARY" >> "$GITHUB_OUTPUT"
+
+  sync_brain:
+    name: Sync Brain
+    needs: worker_kv
+    uses: ./.github/workflows/sync-brain.yml
+    secrets: inherit
+    with:
+      reason: "${{ inputs.reason != '' && format('Run All: {0}', inputs.reason) || format('Run All triggered by {0}', github.actor) }}"
+
+  summarize:
+    name: Run summary
+    needs: [gh_pat_debug, worker_kv, sync_brain]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build summary
+        id: build
+        env:
+          RUN_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GH_PAT_RESULT: ${{ needs.gh_pat_debug.result }}
+          SEED_JSON: ${{ needs.worker_kv.outputs.social_seed }}
+          STATUS_JSON: ${{ needs.worker_kv.outputs.worker_status }}
+          BRAIN_JSON: ${{ needs.worker_kv.outputs.brain_check }}
+          SYNC_RESULT: ${{ needs.sync_brain.result }}
+          RUN_REASON: ${{ inputs.reason }}
+        run: |
+          set -euo pipefail
+          python <<'PY'
+import json
+import os
+from pathlib import Path
+
+def load(name: str) -> dict:
+    raw = os.environ.get(name, '')
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+
+seed = load('SEED_JSON')
+status = load('STATUS_JSON')
+brain = load('BRAIN_JSON')
+lines = []
+reason = os.environ.get('RUN_REASON', '').strip()
+if reason:
+    lines.append(f"- Reason: {reason}")
+lines.append(f"- GH_PAT Debug: {os.environ.get('GH_PAT_RESULT', 'unknown')}")
+if seed:
+    keys = seed.get('configKeys') or []
+    keys_display = ', '.join(keys) if keys else 'none'
+    lines.append(f"- Worker social seed: ok={seed.get('ok')}, keys={keys_display}")
+else:
+    lines.append('- Worker social seed: no data')
+if status:
+    sample = status.get('kvSample') or []
+    sample_display = ', '.join(sample[:3]) if sample else 'none'
+    lines.append(f"- Worker status: ok={status.get('ok')}, routes={status.get('routesCount')}, sample={sample_display}")
+else:
+    lines.append('- Worker status: no data')
+if brain:
+    lines.append(f"- Brain KV: ok={brain.get('ok')}, exists={brain.get('exists')}, size={brain.get('size')}")
+else:
+    lines.append('- Brain KV: no data')
+lines.append(f"- Sync Brain workflow: {os.environ.get('SYNC_RESULT', 'unknown')}")
+links = [
+    f"- [Actions run]({os.environ['RUN_URL']})",
+    "- [Worker status](https://maggie.messyandmagnetic.com/admin/status)",
+    "- [Brain snapshot](https://maggie.messyandmagnetic.com/brain/get)",
+]
+summary = '### Run All Summary\n' + '\n'.join(lines) + '\n\nLinks:\n' + '\n'.join(links)
+Path('summary.md').write_text(summary)
+print(summary)
+PY
+          SUMMARY=$(cat summary.md)
+          echo "$SUMMARY"
+          echo "$SUMMARY" >> "$GITHUB_STEP_SUMMARY"
+          {
+            echo 'body<<EOF'
+            cat summary.md
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Detect PR for this commit
+        id: pr
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SHA: ${{ github.sha }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          RESP=$(curl -sS \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.groot-preview+json" \
+            https://api.github.com/repos/$REPO/commits/$SHA/pulls)
+          NUMBER=$(echo "$RESP" | jq -r '.[0].number // empty')
+          if [ -n "$NUMBER" ]; then
+            echo "Found PR #$NUMBER for $SHA"
+            echo "number=$NUMBER" >> "$GITHUB_OUTPUT"
+          else
+            echo "No PR found for $SHA"
+          fi
+
+      - name: Comment on PR
+        if: ${{ steps.pr.outputs.number && steps.build.outputs.body != '' }}
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          python <<'PY'
+import json
+import os
+import urllib.request
+from pathlib import Path
+
+body = Path('summary.md').read_text()
+req = urllib.request.Request(
+    f"https://api.github.com/repos/{os.environ['REPO']}/issues/{os.environ['PR_NUMBER']}/comments",
+    data=json.dumps({'body': body}).encode(),
+    method='POST',
+    headers={
+        'Authorization': f"Bearer {os.environ['TOKEN']}",
+        'Accept': 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+    },
+)
+with urllib.request.urlopen(req) as resp:
+    print(f"Comment posted to PR #{os.environ['PR_NUMBER']} (status {resp.status})")
+PY

--- a/.github/workflows/sync-brain.yml
+++ b/.github/workflows/sync-brain.yml
@@ -9,6 +9,12 @@ on:
         default: "manual"
   schedule:
     - cron: "30 3 * * *"   # 03:30 UTC (~9:30pm ABQ during DST)
+  workflow_call:
+    inputs:
+      reason:
+        required: false
+        type: string
+        default: "manual"
 
 permissions:
   contents: write
@@ -55,7 +61,7 @@ jobs:
 
       - name: Log dispatch reason
         env:
-          DISPATCH_REASON: ${{ github.event.inputs.reason || '' }}
+          DISPATCH_REASON: ${{ inputs.reason || github.event.inputs.reason || '' }}
           TRIGGER: ${{ github.event_name }}
         run: |
           if [ -n "$DISPATCH_REASON" ]; then


### PR DESCRIPTION
## Summary
- add `workflow_call` to the GH_PAT debug and Sync Brain workflows so they can be reused
- introduce a "Run All" workflow that seeds KV over the Worker API, reuses the debug + sync jobs, and generates a run summary/PR comment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf4f27c1688327a0ddc1a7f8ee277e