### PR TITLE
feat: add “Run All” workflow (PAT Debug → Sync Brain → Report)

### DIFF
--- a/.github/workflows/debug-gh-pat.yml
+++ b/.github/workflows/debug-gh-pat.yml
@@ -3,6 +3,7 @@ on:
   workflow_dispatch: {}
   repository_dispatch:
     types: [kick-gh-pat-debug]
+  workflow_call:
 permissions:
   contents: read
   actions: write
@@ -10,29 +11,26 @@ jobs:
   debug:
     runs-on: ubuntu-latest
     env:
-      GH_PAT: ${{ secrets.GH_PAT }}
-      GITHUB_TOKEN: ${{ secrets.GH_PAT }}
+      GH_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Diagnostics
-        shell: bash
-        env:
-          GH_TOKEN: ${{ env.GH_PAT }}
         run: |
           echo "Actor: $GITHUB_ACTOR"
-          echo "Using PAT for repo: $GITHUB_REPOSITORY"
+          echo "Using GitHub token for repo: $GITHUB_REPOSITORY"
           gh auth status || true
 
-      - name: Check GH_PAT presence
+      - name: Check GitHub token presence
         run: |
-          if [ -z "$GH_PAT" ]; then
-            echo "GH_PAT is NOT set"; exit 2
+          if [ -z "$GITHUB_TOKEN" ]; then
+            echo "GITHUB_TOKEN is NOT set"; exit 2
           else
-            echo "GH_PAT is set"
+            echo "GITHUB_TOKEN is set"
           fi
-      - name: GET /user headers with GH_PAT (redacted)
+      - name: GET /user headers with GITHUB_TOKEN (redacted)
         run: |
           set -e
-          curl -sI -H "Authorization: Bearer $GH_PAT" https://api.github.com/user \
+          curl -sI -H "Authorization: Bearer $GH_TOKEN" https://api.github.com/user \
           | tr -d '\r' | awk 'BEGIN{IGNORECASE=1}/^x-oauth-scopes|^status|^date/ {print}'
       - name: Try workflow dispatch for token-smoke (expect 204)
         env:
@@ -40,7 +38,7 @@ jobs:
           REPO: mags-assistant
         run: |
           CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
-            -H "Authorization: Bearer $GH_PAT" \
+            -H "Authorization: Bearer $GH_TOKEN" \
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/$OWNER/$REPO/actions/workflows/token-smoke.yml/dispatches \
             -d '{"ref":"main"}')

--- a/.github/workflows/run-all.yml
+++ b/.github/workflows/run-all.yml
@@ -1,0 +1,51 @@
+name: Run All (PAT Debug + Sync Brain + Report)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  pat_debug:
+    name: GH_PAT Debug
+    uses: ./.github/workflows/debug-gh-pat.yml
+
+  sync_brain:
+    name: Sync Brain
+    needs: pat_debug
+    uses: ./.github/workflows/sync-brain.yml
+    secrets:
+      POST_THREAD_SECRET: ${{ secrets.POST_THREAD_SECRET }}
+
+  report:
+    name: Report
+    needs: sync_brain
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Worker config
+        id: cfg
+        run: |
+          set -e
+          curl -sS "https://maggie.messyandmagnetic.com/diag/config" \
+            -H "Authorization: Bearer ${{ secrets.POST_THREAD_SECRET }}" \
+            -o cfg.json
+          echo "cfg=$(cat cfg.json | tr -d '\n' | sed 's/"/\\"/g')" >> $GITHUB_OUTPUT
+
+      - name: Pretty print summary
+        run: |
+          echo "=== Maggie Worker /diag/config ==="
+          cat cfg.json | jq '.profile, .subdomains, .kvNamespace, .kvKey, .notes // empty'
+
+      - name: (Optional) Comment on PR
+        if: ${{ github.event.pull_request.number != '' }}
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          body="✅ Run All finished.
+
+          • PAT Debug ✅
+          • Sync Brain ✅
+          • Worker: \`https://maggie.messyandmagnetic.com/diag/config\`
+          • Subdomains: \`$(jq -r '.subdomains | join(", ")' cfg.json)\`
+          • KV: \`$(jq -r '.kvNamespace')\` / \`$(jq -r '.kvKey')\`"
+
+          gh pr comment "$PR_NUMBER" -b "$body"

--- a/.github/workflows/sync-brain.yml
+++ b/.github/workflows/sync-brain.yml
@@ -13,124 +13,31 @@ on:
   pull_request:
   schedule:
     - cron: "30 3 * * *"   # 03:30 UTC (~9:30pm ABQ during DST)
+  workflow_call:
+    secrets:
+      POST_THREAD_SECRET:
+        required: true
 
 permissions:
-  contents: write
-  actions: write
-
-# Manual dispatch via PAT (requires repo + workflow scopes on GH_PAT):
-# curl -sS -X POST \
-#   -H "Accept: application/vnd.github+json" \
-#   -H "Authorization: Bearer ${{ secrets.GH_PAT }}" \
-#   "https://api.github.com/repos/${{ github.repository }}/actions/workflows/sync-brain.yml/dispatches" \
-#   -d '{"ref":"main","inputs":{"reason":"manual"}}'
+  contents: read
 
 jobs:
   sync:
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
-    # Make all required credentials available
-    env:
-      GH_PAT: ${{ secrets.GH_PAT }}
-      GITHUB_TOKEN: ${{ secrets.GH_PAT }}
-      # --- GitHub auth: GH_PAT only ---
-      GH_TOKEN: ${{ secrets.GH_PAT }}
-
-      # --- Cloudflare / KV (names already present in repo secrets per screenshots) ---
-      CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-      CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
-      CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
-      CF_KV_POSTQ_NAMESPACE_ID: ${{ secrets.CF_KV_POSTQ_NAMESPACE_ID }}
-
-      # --- Worker KV keys to read/write ---
-      SECRET_BLOB: thread-state
-      BRAIN_DOC_KEY: PostQ:thread-state
-
     steps:
-      - name: Diagnostics
-        shell: bash
-        env:
-          GH_TOKEN: ${{ env.GH_PAT }}
-        run: |
-          echo "Actor: $GITHUB_ACTOR"
-          echo "Using PAT for repo: $GITHUB_REPOSITORY"
-          gh auth status || true
-
-      - name: Log dispatch reason
-        env:
-          DISPATCH_REASON: ${{ github.event.inputs.reason || '' }}
-          TRIGGER: ${{ github.event_name }}
-        run: |
-          if [ -n "$DISPATCH_REASON" ]; then
-            echo "Dispatch reason: $DISPATCH_REASON"
-          else
-            echo "Dispatch reason: (none provided; trigger=$TRIGGER)"
-          fi
-
-      - name: Checkout (with PAT)
+      - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          token: ${{ env.GH_PAT }}
 
-      - name: Seed KV via Worker
+      - name: Seed KV
         run: |
-          curl -X POST "https://maggie.messyandmagnetic.com/init-blob" \
+          curl -X POST https://maggie.messyandmagnetic.com/init-blob \
             -H "Authorization: Bearer ${{ secrets.POST_THREAD_SECRET }}" \
             -H "Content-Type: application/json" \
             --data-binary @config/thread-state.json
 
-      - name: Smoke test KV
+      - name: Smoke Test
         run: |
-          curl -s "https://maggie.messyandmagnetic.com/diag/config" \
+          curl -sS https://maggie.messyandmagnetic.com/diag/config \
             -H "Authorization: Bearer ${{ secrets.POST_THREAD_SECRET }}"
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Setup Node + pnpm (corepack)
-        run: |
-          corepack enable
-          corepack prepare pnpm@latest --activate
-          node -v && pnpm -v
-
-      # Only install if package.json exists (mono/support both)
-      - name: Install deps (if package.json)
-        run: |
-          if [ -f package.json ]; then
-            pnpm install --frozen-lockfile=false
-          else
-            echo "No package.json at repo root; skipping install."
-          fi
-
-      # === Brain → KV upload ===
-      - name: Update Brain KV
-        run: |
-          if [ -f scripts/updateBrain.ts ]; then
-            npx tsx scripts/updateBrain.ts
-          else
-            echo "scripts/updateBrain.ts not found"; exit 1
-          fi
-
-      # === Verify parity / reachability ===
-      - name: Ping / verify Brain
-        run: |
-          if [ -f scripts/brainPing.ts ]; then
-            npx tsx scripts/brainPing.ts
-          else
-            echo "scripts/brainPing.ts not found"; exit 1
-          fi
-
-      # === Sanity check the live worker ===
-      - name: Sanity: /health
-        run: |
-          set -e
-          curl -sS -i https://maggie.messyandmagnetic.com/health | sed -n '1,20p'
-
-      - name: Sanity: /diag/config
-        run: |
-          set -e
-          curl -sS -i https://maggie.messyandmagnetic.com/diag/config | sed -n '1,80p'


### PR DESCRIPTION
## Summary
- make the GH_PAT debug workflow reusable and rely solely on the default GITHUB_TOKEN
- simplify the sync-brain workflow into a reusable Worker KV seed + smoke test action
- add a Run All orchestrator workflow that chains PAT debug, sync brain, and a Worker health report

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cf4fd74bd48327a78321ef2398ff10