### PR TITLE
feat: add kv state backup and sync helpers

### DIFF
--- a/.github/workflows/sync-brain.yml
+++ b/.github/workflows/sync-brain.yml
@@ -48,6 +48,9 @@ jobs:
       CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
       CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
       CF_KV_POSTQ_NAMESPACE_ID: ${{ secrets.CF_KV_POSTQ_NAMESPACE_ID }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID || secrets.ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN || secrets.CF_API_TOKEN || secrets.API_TOKEN }}
+      ACCOUNT_ID: ${{ secrets.ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID || secrets.CF_ACCOUNT_ID }}
 
       # --- Worker KV keys to read/write ---
       SECRET_BLOB: thread-state
@@ -91,7 +94,7 @@ jobs:
             -X POST "https://maggie.messyandmagnetic.com/init-blob" \
             -H "Authorization: Bearer ${{ secrets.POST_THREAD_SECRET }}" \
             -H "Content-Type: application/json" \
-            --data-binary @config/thread-state.json) || CODE=$?
+            --data-binary @config/kv-state.json) || CODE=$?
 
           if [[ "$CODE" == "22" ]]; then
             if [[ "$STATUS" == "409" ]]; then

--- a/config/kv-state.json
+++ b/config/kv-state.json
@@ -1,0 +1,32 @@
+{
+  "version": "v1",
+  "lastUpdated": "2025-09-20T19:33:46.418Z",
+  "profile": {
+    "name": "Maggie",
+    "role": "Full-stack assistant",
+    "subdomains": [
+      "maggie.messyandmagnetic.com",
+      "assistant.messyandmagnetic.com"
+    ],
+    "kvNamespace": "PostQ"
+  },
+  "services": {
+    "gmail": true,
+    "stripe": true,
+    "tally": true,
+    "notion": true,
+    "tikTok": true,
+    "n8n": true,
+    "googleDrive": true
+  },
+  "automation": {
+    "soulReadings": true,
+    "farmStand": true,
+    "postScheduler": true,
+    "readingDelivery": true,
+    "stripeAudit": true,
+    "magnetMatch": true
+  },
+  "notes": "Blob initialized from /init-blob",
+  "lastSynced": null
+}

--- a/docs/brain.md
+++ b/docs/brain.md
@@ -2,6 +2,47 @@ Maggie Brain
 
 This document describes the intake pipeline, worker integration, and sync helpers.
 
+## KV Snapshot (PostQ/thread-state)
+
+The source of truth for Maggie's operational profile now lives in [`config/kv-state.json`](../config/kv-state.json). The JSON blob currently stored in Cloudflare KV (namespace **PostQ**, key **thread-state**) resolves to:
+
+```json
+{
+  "version": "v1",
+  "lastUpdated": "2025-09-20T19:33:46.418Z",
+  "profile": {
+    "name": "Maggie",
+    "role": "Full-stack assistant",
+    "subdomains": [
+      "maggie.messyandmagnetic.com",
+      "assistant.messyandmagnetic.com"
+    ],
+    "kvNamespace": "PostQ"
+  },
+  "services": {
+    "gmail": true,
+    "stripe": true,
+    "tally": true,
+    "notion": true,
+    "tikTok": true,
+    "n8n": true,
+    "googleDrive": true
+  },
+  "automation": {
+    "soulReadings": true,
+    "farmStand": true,
+    "postScheduler": true,
+    "readingDelivery": true,
+    "stripeAudit": true,
+    "magnetMatch": true
+  },
+  "notes": "Blob initialized from /init-blob",
+  "lastSynced": null
+}
+```
+
+Use `pnpm tsx scripts/updateBrain.ts` (or the workflow outlined below) to sync edits back to KV.
+
 ⸻
 
 🔐 Secrets

--- a/scripts/updateBrain.ts
+++ b/scripts/updateBrain.ts
@@ -1,27 +1,44 @@
 import fs from 'fs';
 import path from 'path';
 
+function getEnv(name: string): string | undefined {
+  return process.env[name];
+}
+
 async function main() {
-  const account = process.env.CLOUDFLARE_ACCOUNT_ID;
-  const token = process.env.CLOUDFLARE_API_TOKEN;
+  const account =
+    getEnv('CLOUDFLARE_ACCOUNT_ID') ||
+    getEnv('CF_ACCOUNT_ID') ||
+    getEnv('ACCOUNT_ID');
+  const token =
+    getEnv('CLOUDFLARE_API_TOKEN') ||
+    getEnv('CF_API_TOKEN') ||
+    getEnv('API_TOKEN');
   const namespaceId =
     process.env.CF_KV_POSTQ_NAMESPACE_ID || process.env.CF_KV_NAMESPACE_ID;
   if (!account || !token || !namespaceId) {
     console.error(
-      'Missing CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN, or CF_KV_NAMESPACE_ID'
+      'Missing CLOUDFLARE_ACCOUNT_ID/CF_ACCOUNT_ID, CLOUDFLARE_API_TOKEN/CF_API_TOKEN, or CF_KV_NAMESPACE_ID'
     );
     process.exit(1);
   }
 
-  const brainPath = path.join(process.cwd(), 'docs', 'brain.md');
-  const body = await fs.promises.readFile(brainPath, 'utf8');
+  const kvPath = path.join(process.cwd(), 'config', 'kv-state.json');
+  let body: string;
+  try {
+    const raw = await fs.promises.readFile(kvPath, 'utf8');
+    body = JSON.stringify(JSON.parse(raw));
+  } catch (err) {
+    console.error(`Failed to read or parse ${kvPath}:`, err);
+    process.exit(1);
+  }
 
-  const url = `https://api.cloudflare.com/client/v4/accounts/${account}/storage/kv/namespaces/${namespaceId}/values/PostQ:thread-state`;
+  const url = `https://api.cloudflare.com/client/v4/accounts/${account}/storage/kv/namespaces/${namespaceId}/values/thread-state`;
   const res = await fetch(url, {
     method: 'PUT',
     headers: {
       Authorization: `Bearer ${token}`,
-      'Content-Type': 'text/plain',
+      'Content-Type': 'application/json',
     },
     body,
   });
@@ -32,7 +49,9 @@ async function main() {
     process.exit(1);
   }
 
-  console.log('Brain updated');
+  console.log(
+    `Brain updated: thread-state → namespace ${namespaceId} (account ${account})`
+  );
 }
 
 main().catch((err) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,10 +1,58 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+const FALLBACK_PATH = path.resolve(process.cwd(), 'config/kv-state.json');
+
+let fallbackCache: any | null | undefined;
+
+async function loadFallback(): Promise<any | null> {
+  if (fallbackCache !== undefined) return fallbackCache;
+
+  try {
+    const raw = await readFile(FALLBACK_PATH, 'utf8');
+    fallbackCache = JSON.parse(raw);
+  } catch (err) {
+    console.warn(
+      `[config] Failed to load fallback KV state from ${FALLBACK_PATH}:`,
+      err
+    );
+    fallbackCache = null;
+  }
+
+  return fallbackCache;
+}
+
+async function readFromKV(env: any, key: string): Promise<string | null> {
+  try {
+    if (env?.BRAIN && typeof env.BRAIN.get === 'function') {
+      return await env.BRAIN.get(key);
+    }
+  } catch (err) {
+    console.warn(`[config] KV fetch failed for key "${key}":`, err);
+  }
+  return null;
+}
+
 export async function getSecrets(env: any) {
   const k = env.SECRET_BLOB || 'thread-state';
-  const v = await env.BRAIN.get(k);
-  return v ? JSON.parse(v) : {};
+  const v = await readFromKV(env, k);
+  if (v) {
+    try {
+      return JSON.parse(v);
+    } catch (err) {
+      console.warn(`[config] Unable to parse KV payload for key "${k}":`, err);
+    }
+  }
+
+  const fallback = await loadFallback();
+  return fallback ?? {};
 }
 
 export async function getBrainDoc(env: any) {
   const k = env.BRAIN_DOC_KEY || 'PostQ:thread-state';
-  return (await env.BRAIN.get(k)) || '';
+  const v = await readFromKV(env, k);
+  if (typeof v === 'string' && v.length) return v;
+
+  const fallback = await loadFallback();
+  return fallback ? JSON.stringify(fallback) : '';
 }


### PR DESCRIPTION
## Summary
- store the latest validated PostQ/thread-state blob in config/kv-state.json and surface it in the brain docs
- update the KV sync script and workflow to publish that JSON to Cloudflare using the expected account/token secrets
- fall back to the checked-in kv-state.json during builds when KV access is unavailable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d03240467c832798d22e2bbb249814