### PR TITLE
chore: add Maggie KV brain config + sync script

### DIFF
--- a/config/kv-state.json
+++ b/config/kv-state.json
@@ -1,0 +1,32 @@
+{
+  "version": "v1",
+  "lastUpdated": "2025-09-20T19:33:46.418Z",
+  "profile": {
+    "name": "Maggie",
+    "role": "Full-stack assistant",
+    "subdomains": [
+      "maggie.messyandmagnetic.com",
+      "assistant.messyandmagnetic.com"
+    ],
+    "kvNamespace": "PostQ"
+  },
+  "services": {
+    "gmail": true,
+    "stripe": true,
+    "tally": true,
+    "notion": true,
+    "tikTok": true,
+    "n8n": true,
+    "googleDrive": true
+  },
+  "automation": {
+    "soulReadings": true,
+    "farmStand": true,
+    "postScheduler": true,
+    "readingDelivery": true,
+    "stripeAudit": true,
+    "magnetMatch": true
+  },
+  "notes": "Blob initialized from /init-blob",
+  "lastSynced": null
+}

--- a/docs/brain.md
+++ b/docs/brain.md
@@ -1,48 +1,31 @@
-Maggie Brain
+# 🧠 Maggie Brain Snapshot (PostQ:thread-state)
 
-This document describes the intake pipeline, worker integration, and sync helpers.
+**Version:** v1  
+**Last Updated:** 2025-09-20
 
-⸻
+## Profile
+- **Name:** Maggie  
+- **Role:** Full-stack assistant  
+- **Subdomains:**  
+  - maggie.messyandmagnetic.com  
+  - assistant.messyandmagnetic.com  
+- **KV Namespace:** PostQ
 
-🔐 Secrets
+## Connected Services
+✅ Gmail  
+✅ Stripe  
+✅ Tally  
+✅ Notion  
+✅ TikTok  
+✅ n8n  
+✅ Google Drive  
 
-Two core secret groups are always loaded from KV:
-	•	SECRET_BLOB → the main secret bundle (Stripe, TikTok, Notion, Gemini, Cloudflare, etc.)
-	•	BRAIN_DOC_KEY → the brain metadata doc (PostQ:thread-state, config flags, TikTok alias map, fundraising keys, etc.)
+## Automations Enabled
+✅ Soul Readings  
+✅ Farm Stand Sync  
+✅ Post Scheduler  
+✅ Reading Delivery  
+✅ Stripe Product Audit  
+✅ Magnet Match System  
 
-Worker health + diag always check and report both.
-
-⸻
-
-🔎 Worker Health
-
-The /diag/config endpoint:
-	•	Loads both SECRET_BLOB and BRAIN_DOC_KEY from KV.
-	•	Confirms presence with presence() (true/false per secret).
-	•	Returns:
-
-{
-  "present": { "STRIPE_SECRET_KEY": true, "TIKTOK_SESSION_MAIN": true, ... },
-  "secretBlobKey": "PostQ:thread-state",
-  "brainDocKey": "config:brain",
-  "hasSecrets": true,
-  "brainDocBytes": 12456
-}
-
-
-⸻
-
-🔄 Sync Rules
-	•	SECRETS_BLOB = always hydrated from .env → KV → GitHub
-	•	BRAIN_DOC_KEY = always hydrated from docs/brain.md → KV → GitHub
-	•	Both must be updated together to prevent drift.
-	•	Codex auto-resolves merge conflicts in worker/health.ts by always keeping both key paths.
-
-⸻
-
-📌 Usage
-	•	getConfig('stripe') → from SECRET_BLOB
-	•	getBrainDoc() → from BRAIN_DOC_KEY
-	•	Never hardcode keys; always call via helper.
-	•	Maggie reads BRAIN_DOC_KEY for instructions (modes, TikTok alias map, fundraising scope).
-
+> Notes: Blob initialized from `/init-blob`


### PR DESCRIPTION
## Summary
- add a KV brain state snapshot for Maggie with services and automations flags
- document the PostQ thread-state brain details in docs/brain.md
- add a Cloudflare KV sync helper and update the brain sync script to push the new JSON blob

## Testing
- pnpm tsx scripts/updateBrain.ts *(fails: Cloudflare credentials not configured in the environment, request returned 503)*

------
https://chatgpt.com/codex/tasks/task_e_68d0332de56c8327a133a84778fa4744