### PR TITLE
chore: finalize Maggie Brain config + resolve sync conflicts

### DIFF
--- a/docs/brain.md
+++ b/docs/brain.md
@@ -1,89 +1,36 @@
-Maggie Brain
+# Maggie Brain Snapshot
 
-This document describes the intake pipeline, worker integration, and sync helpers.
+> Version: `v1` • Last Updated: `2025-09-20T19:33:46.418Z`
 
-## KV Snapshot (PostQ/thread-state)
+## Profile
+- **Name:** Maggie
+- **Role:** Full-stack assistant
+- **KV Namespace:** `PostQ`
+- **Subdomains:**
+  - `maggie.messyandmagnetic.com`
+  - `assistant.messyandmagnetic.com`
 
-The source of truth for Maggie's operational profile now lives in [`config/kv-state.json`](../config/kv-state.json). The JSON blob currently stored in Cloudflare KV (namespace **PostQ**, key **thread-state**) resolves to:
+## Connected Services
+- ✅ Gmail
+- ✅ Stripe
+- ✅ Tally
+- ✅ Notion
+- ✅ TikTok
+- ✅ n8n
+- ✅ Google Drive
 
-```json
-{
-  "version": "v1",
-  "lastUpdated": "2025-09-20T19:33:46.418Z",
-  "profile": {
-    "name": "Maggie",
-    "role": "Full-stack assistant",
-    "subdomains": [
-      "maggie.messyandmagnetic.com",
-      "assistant.messyandmagnetic.com"
-    ],
-    "kvNamespace": "PostQ"
-  },
-  "services": {
-    "gmail": true,
-    "stripe": true,
-    "tally": true,
-    "notion": true,
-    "tikTok": true,
-    "n8n": true,
-    "googleDrive": true
-  },
-  "automation": {
-    "soulReadings": true,
-    "farmStand": true,
-    "postScheduler": true,
-    "readingDelivery": true,
-    "stripeAudit": true,
-    "magnetMatch": true
-  },
-  "notes": "Blob initialized from /init-blob",
-  "lastSynced": null
-}
-```
+## Automations
+- ✅ Soul Readings
+- ✅ Farm Stand
+- ✅ Post Scheduler
+- ✅ Reading Delivery
+- ✅ Stripe Audit
+- ✅ Magnet Match
 
-Use `pnpm tsx scripts/updateBrain.ts` (or the workflow outlined below) to sync edits back to KV.
+## Notes
+- Blob initialized from `/init-blob`
+- Last synced: `null`
 
-⸻
+---
 
-🔐 Secrets
-
-Two core secret groups are always loaded from KV:
-	•	SECRET_BLOB → the main secret bundle (Stripe, TikTok, Notion, Gemini, Cloudflare, etc.)
-	•	BRAIN_DOC_KEY → the brain metadata doc (PostQ:thread-state, config flags, TikTok alias map, fundraising keys, etc.)
-
-Worker health + diag always check and report both.
-
-⸻
-
-🔎 Worker Health
-
-The /diag/config endpoint:
-	•	Loads both SECRET_BLOB and BRAIN_DOC_KEY from KV.
-	•	Confirms presence with presence() (true/false per secret).
-	•	Returns:
-
-{
-  "present": { "STRIPE_SECRET_KEY": true, "TIKTOK_SESSION_MAIN": true, ... },
-  "secretBlobKey": "PostQ:thread-state",
-  "brainDocKey": "config:brain",
-  "hasSecrets": true,
-  "brainDocBytes": 12456
-}
-
-
-⸻
-
-🔄 Sync Rules
-	•	SECRETS_BLOB = always hydrated from .env → KV → GitHub
-	•	BRAIN_DOC_KEY = always hydrated from docs/brain.md → KV → GitHub
-	•	Both must be updated together to prevent drift.
-	•	Codex auto-resolves merge conflicts in worker/health.ts by always keeping both key paths.
-
-⸻
-
-📌 Usage
-	•	getConfig('stripe') → from SECRET_BLOB
-	•	getBrainDoc() → from BRAIN_DOC_KEY
-	•	Never hardcode keys; always call via helper.
-	•	Maggie reads BRAIN_DOC_KEY for instructions (modes, TikTok alias map, fundraising scope).
-
+_This snapshot is auto-synced from [`config/kv-state.json`](../config/kv-state.json)._ 

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -1,4 +1,35 @@
-import { getConfig } from '../utils/config';
+type GetConfigFn = ((scope: string) => Promise<any>) | undefined;
+
+let resolvedGetConfig: GetConfigFn | null = null;
+
+async function loadGetConfig(): Promise<GetConfigFn> {
+  if (resolvedGetConfig !== null) {
+    return resolvedGetConfig;
+  }
+
+  const candidates = ['../utils/config.js', '../utils/config.ts'];
+  for (const candidate of candidates) {
+    try {
+      const mod = await import(candidate);
+      if (typeof mod.getConfig === 'function') {
+        resolvedGetConfig = mod.getConfig;
+        return resolvedGetConfig;
+      }
+    } catch {
+      // Ignore resolution errors and continue to the next candidate.
+    }
+  }
+
+  resolvedGetConfig = undefined;
+  return resolvedGetConfig;
+}
+
+export interface PutConfigOptions {
+  accountId?: string;
+  apiToken?: string;
+  namespaceId?: string;
+  contentType?: string;
+}
 
 export async function saveToKV(key: string, value: any) {
   let base = process.env.WORKER_URL;
@@ -7,9 +38,12 @@ export async function saveToKV(key: string, value: any) {
   // Fallback to config lookup if env vars missing
   if (!base || !auth) {
     try {
-      const cfg = await getConfig('cloudflare');
-      base ||= cfg.worker_url || cfg.workerUrl;
-      auth ||= cfg.worker_key || cfg.workerKey;
+      const getConfig = await loadGetConfig();
+      if (getConfig) {
+        const cfg = await getConfig('cloudflare');
+        base ||= cfg.worker_url || cfg.workerUrl;
+        auth ||= cfg.worker_key || cfg.workerKey;
+      }
     } catch {
       // ignore and rely on env vars
     }
@@ -33,5 +67,55 @@ export async function saveToKV(key: string, value: any) {
     throw new Error(`Failed to write to KV: ${res.status}`);
   }
   return { ok: true };
+}
+
+export async function putConfig(
+  key: string,
+  value: unknown,
+  options: PutConfigOptions = {}
+) {
+  const accountId =
+    options.accountId ||
+    process.env.CLOUDFLARE_ACCOUNT_ID ||
+    process.env.CF_ACCOUNT_ID ||
+    process.env.ACCOUNT_ID;
+  const apiToken =
+    options.apiToken ||
+    process.env.CLOUDFLARE_API_TOKEN ||
+    process.env.CF_API_TOKEN ||
+    process.env.API_TOKEN;
+  const namespaceId =
+    options.namespaceId ||
+    process.env.CF_KV_POSTQ_NAMESPACE_ID ||
+    process.env.CF_KV_NAMESPACE_ID;
+
+  if (!accountId || !apiToken || !namespaceId) {
+    throw new Error(
+      'putConfig requires Cloudflare credentials (CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN, CF_KV_POSTQ_NAMESPACE_ID)'
+    );
+  }
+
+  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/storage/kv/namespaces/${namespaceId}/values/${encodeURIComponent(
+    key
+  )}`;
+  const body = typeof value === 'string' ? value : JSON.stringify(value);
+  const contentType = options.contentType || 'application/json';
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+      'Content-Type': contentType,
+    },
+    body,
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(
+      `Failed to put config for ${key}: ${res.status}${text ? ` ${text}` : ''}`
+    );
+  }
+
+  return { ok: true } as const;
 }
 export default saveToKV;

--- a/scripts/updateBrain.ts
+++ b/scripts/updateBrain.ts
@@ -1,60 +1,42 @@
 import fs from 'fs';
 import path from 'path';
 
-function getEnv(name: string): string | undefined {
-  return process.env[name];
-}
+import { putConfig } from '../lib/kv';
 
 async function main() {
-  const account =
-    getEnv('CLOUDFLARE_ACCOUNT_ID') ||
-    getEnv('CF_ACCOUNT_ID') ||
-    getEnv('ACCOUNT_ID');
-  const token =
-    getEnv('CLOUDFLARE_API_TOKEN') ||
-    getEnv('CF_API_TOKEN') ||
-    getEnv('API_TOKEN');
-  const namespaceId =
-    process.env.CF_KV_POSTQ_NAMESPACE_ID || process.env.CF_KV_NAMESPACE_ID;
-  if (!account || !token || !namespaceId) {
-    console.error(
-      'Missing CLOUDFLARE_ACCOUNT_ID/CF_ACCOUNT_ID, CLOUDFLARE_API_TOKEN/CF_API_TOKEN, or CF_KV_NAMESPACE_ID'
-    );
-    process.exit(1);
-  }
-
   const kvPath = path.join(process.cwd(), 'config', 'kv-state.json');
-  let body: string;
+  let payload: unknown;
+
   try {
     const raw = await fs.promises.readFile(kvPath, 'utf8');
-    body = JSON.stringify(JSON.parse(raw));
+    payload = JSON.parse(raw);
   } catch (err) {
-    console.error(`Failed to read or parse ${kvPath}:`, err);
+    console.error(`Failed to read or parse ${kvPath}.`);
+    console.error(err);
     process.exit(1);
   }
 
-  const url = `https://api.cloudflare.com/client/v4/accounts/${account}/storage/kv/namespaces/${namespaceId}/values/thread-state`;
-  const res = await fetch(url, {
-    method: 'PUT',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body,
-  });
-
-  if (!res.ok) {
-    const text = await res.text();
-    console.error('Failed to update brain:', res.status, text);
+  try {
+    await putConfig('PostQ:thread-state', payload, {
+      contentType: 'application/json',
+    });
+    console.log(
+      '✅ Synced PostQ:thread-state from config/kv-state.json to Cloudflare KV.'
+    );
+  } catch (err) {
+    console.error('❌ Failed to sync Maggie brain config to Cloudflare KV.');
+    if (err instanceof Error) {
+      console.error(err.message);
+      if (err.message.includes('credentials')) {
+        console.error(
+          'Double-check CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN, and CF_KV_POSTQ_NAMESPACE_ID.'
+        );
+      }
+    } else {
+      console.error(err);
+    }
     process.exit(1);
   }
-
-  console.log(
-    `Brain updated: thread-state → namespace ${namespaceId} (account ${account})`
-  );
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+main();


### PR DESCRIPTION
## Summary
- replace the brain snapshot doc with the latest Maggie profile, service, and automation status sourced from config/kv-state.json
- update the Cloudflare KV helper to expose putConfig and resolve worker credential fallbacks without a hard config dependency
- switch the brain sync script to read config/kv-state.json and push to PostQ:thread-state via putConfig with clearer logging

## Testing
- pnpm tsx scripts/updateBrain.ts *(fails without Cloudflare credentials)*

------
https://chatgpt.com/codex/tasks/task_e_68d0351a0ccc8327b009b02edcd0dbeb