### PR TITLE
chore: finalize Maggie brain sync to KV + docs

### DIFF
--- a/config/kv-state.json
+++ b/config/kv-state.json
@@ -1,6 +1,6 @@
 {
   "version": "v1",
-  "lastUpdated": "2025-09-20T19:33:46.418Z",
+  "lastUpdated": "auto",
   "profile": {
     "name": "Maggie",
     "role": "Full-stack assistant",

--- a/docs/brain.md
+++ b/docs/brain.md
@@ -4,12 +4,12 @@ This document describes the intake pipeline, worker integration, and sync helper
 
 ## KV Snapshot (PostQ/thread-state)
 
-The source of truth for Maggie's operational profile now lives in [`config/kv-state.json`](../config/kv-state.json). The JSON blob currently stored in Cloudflare KV (namespace **PostQ**, key **thread-state**) resolves to:
+The source of truth for Maggie's operational profile now lives in [`config/kv-state.json`](../config/kv-state.json). The JSON blob currently stored in Cloudflare KV (namespace **PostQ**, key **PostQ:thread-state**) resolves to:
 
 ```json
 {
   "version": "v1",
-  "lastUpdated": "2025-09-20T19:33:46.418Z",
+  "lastUpdated": "auto",
   "profile": {
     "name": "Maggie",
     "role": "Full-stack assistant",

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -1,5 +1,42 @@
 import { getConfig } from '../utils/config';
 
+type CloudflareCredentials = {
+  accountId: string;
+  namespaceId: string;
+  token: string;
+};
+
+function pickEnv(...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = process.env[key];
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function resolveCloudflareCredentials(
+  overrides: Partial<CloudflareCredentials> = {}
+): CloudflareCredentials {
+  const accountId =
+    overrides.accountId ||
+    pickEnv('CLOUDFLARE_ACCOUNT_ID', 'CF_ACCOUNT_ID', 'ACCOUNT_ID');
+  const token =
+    overrides.token ||
+    pickEnv('CLOUDFLARE_API_TOKEN', 'CF_API_TOKEN', 'API_TOKEN');
+  const namespaceId =
+    overrides.namespaceId ||
+    process.env.CF_KV_POSTQ_NAMESPACE_ID ||
+    process.env.CF_KV_NAMESPACE_ID;
+
+  if (!accountId || !token || !namespaceId) {
+    throw new Error(
+      'Missing Cloudflare KV credentials (account id, namespace id, or API token).'
+    );
+  }
+
+  return { accountId, namespaceId, token };
+}
+
 export async function saveToKV(key: string, value: any) {
   let base = process.env.WORKER_URL;
   let auth = process.env.WORKER_KEY;
@@ -33,5 +70,40 @@ export async function saveToKV(key: string, value: any) {
     throw new Error(`Failed to write to KV: ${res.status}`);
   }
   return { ok: true };
+}
+export interface PutConfigResult {
+  key: string;
+  accountId: string;
+  namespaceId: string;
+  size: number;
+}
+
+export async function putConfig(
+  key: string,
+  value: unknown,
+  options: Partial<CloudflareCredentials> & { contentType?: string } = {}
+): Promise<PutConfigResult> {
+  const { accountId, namespaceId, token } = resolveCloudflareCredentials(options);
+  const body = typeof value === 'string' ? value : JSON.stringify(value);
+  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/storage/kv/namespaces/${namespaceId}/values/${encodeURIComponent(
+    key
+  )}`;
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': options.contentType || 'application/json',
+    },
+    body,
+  });
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => res.statusText);
+    throw new Error(
+      `Failed to write ${key} to KV: ${res.status}${text ? ` ${text}` : ''}`
+    );
+  }
+
+  return { key, accountId, namespaceId, size: body.length };
 }
 export default saveToKV;

--- a/scripts/updateBrain.ts
+++ b/scripts/updateBrain.ts
@@ -1,56 +1,39 @@
 import fs from 'fs';
 import path from 'path';
+import { putConfig } from '../lib/kv';
 
-function getEnv(name: string): string | undefined {
-  return process.env[name];
+const KV_KEY = 'PostQ:thread-state';
+
+async function loadBrainConfig(filePath: string): Promise<string> {
+  const raw = await fs.promises.readFile(filePath, 'utf8');
+  const parsed = JSON.parse(raw);
+
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    const next = { ...parsed } as Record<string, any>;
+    if (next.lastUpdated === 'auto') {
+      next.lastUpdated = new Date().toISOString();
+    }
+    return JSON.stringify(next, null, 2);
+  }
+
+  return JSON.stringify(parsed);
 }
 
 async function main() {
-  const account =
-    getEnv('CLOUDFLARE_ACCOUNT_ID') ||
-    getEnv('CF_ACCOUNT_ID') ||
-    getEnv('ACCOUNT_ID');
-  const token =
-    getEnv('CLOUDFLARE_API_TOKEN') ||
-    getEnv('CF_API_TOKEN') ||
-    getEnv('API_TOKEN');
-  const namespaceId =
-    process.env.CF_KV_POSTQ_NAMESPACE_ID || process.env.CF_KV_NAMESPACE_ID;
-  if (!account || !token || !namespaceId) {
-    console.error(
-      'Missing CLOUDFLARE_ACCOUNT_ID/CF_ACCOUNT_ID, CLOUDFLARE_API_TOKEN/CF_API_TOKEN, or CF_KV_NAMESPACE_ID'
-    );
-    process.exit(1);
-  }
-
   const kvPath = path.join(process.cwd(), 'config', 'kv-state.json');
-  let body: string;
+  let serialized: string;
+
   try {
-    const raw = await fs.promises.readFile(kvPath, 'utf8');
-    body = JSON.stringify(JSON.parse(raw));
+    serialized = await loadBrainConfig(kvPath);
   } catch (err) {
     console.error(`Failed to read or parse ${kvPath}:`, err);
     process.exit(1);
   }
 
-  const url = `https://api.cloudflare.com/client/v4/accounts/${account}/storage/kv/namespaces/${namespaceId}/values/thread-state`;
-  const res = await fetch(url, {
-    method: 'PUT',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body,
-  });
-
-  if (!res.ok) {
-    const text = await res.text();
-    console.error('Failed to update brain:', res.status, text);
-    process.exit(1);
-  }
+  const result = await putConfig(KV_KEY, serialized);
 
   console.log(
-    `Brain updated: thread-state → namespace ${namespaceId} (account ${account})`
+    `✅ Synced brain to KV (namespace ${result.namespaceId}, key ${result.key})`
   );
 }
 

--- a/utils/config.ts
+++ b/utils/config.ts
@@ -1,0 +1,2 @@
+export { getConfig } from '../src/utils/getConfig';
+


### PR DESCRIPTION
## Summary
- set the canonical brain state JSON to use the shared `auto` timestamp placeholder and document the PostQ key
- add a Cloudflare KV `putConfig` helper plus a `utils/config` re-export so scripts can resolve configuration
- update the brain sync script to load the local JSON, auto-stamp `lastUpdated`, write to `PostQ:thread-state`, and report success

## Testing
- `pnpm tsx scripts/updateBrain.ts` *(fails: Missing Cloudflare KV credentials (account id, namespace id, or API token).)*

------
https://chatgpt.com/codex/tasks/task_e_68d038463b80832790058af68a73a9cc