### PR TITLE
finalize Maggie KV sync (clean merge)

### DIFF
--- a/docs/brain.md
+++ b/docs/brain.md
@@ -1,36 +1,38 @@
 # Maggie Brain Snapshot
 
-> Version: `v1` • Last Updated: `2025-09-20T19:33:46.418Z`
+> Auto-synced from [`config/kv-state.json`](../config/kv-state.json).
 
-## Profile
-- **Name:** Maggie
-- **Role:** Full-stack assistant
-- **KV Namespace:** `PostQ`
-- **Subdomains:**
-  - `maggie.messyandmagnetic.com`
-  - `assistant.messyandmagnetic.com`
-
-## Connected Services
-- ✅ Gmail
-- ✅ Stripe
-- ✅ Tally
-- ✅ Notion
-- ✅ TikTok
-- ✅ n8n
-- ✅ Google Drive
-
-## Automations
-- ✅ Soul Readings
-- ✅ Farm Stand
-- ✅ Post Scheduler
-- ✅ Reading Delivery
-- ✅ Stripe Audit
-- ✅ Magnet Match
-
-## Notes
-- Blob initialized from `/init-blob`
-- Last synced: `null`
-
----
-
-_This snapshot is auto-synced from [`config/kv-state.json`](../config/kv-state.json)._ 
+```json
+{
+  "version": "v1",
+  "lastUpdated": "2025-09-20T19:33:46.418Z",
+  "profile": {
+    "name": "Maggie",
+    "role": "Full-stack assistant",
+    "subdomains": [
+      "maggie.messyandmagnetic.com",
+      "assistant.messyandmagnetic.com"
+    ],
+    "kvNamespace": "PostQ"
+  },
+  "services": {
+    "gmail": true,
+    "stripe": true,
+    "tally": true,
+    "notion": true,
+    "tikTok": true,
+    "n8n": true,
+    "googleDrive": true
+  },
+  "automation": {
+    "soulReadings": true,
+    "farmStand": true,
+    "postScheduler": true,
+    "readingDelivery": true,
+    "stripeAudit": true,
+    "magnetMatch": true
+  },
+  "notes": "Blob initialized from /init-blob",
+  "lastSynced": null
+}
+```

--- a/scripts/updateBrain.ts
+++ b/scripts/updateBrain.ts
@@ -1,27 +1,77 @@
-import fs from 'fs';
+import { promises as fs } from 'fs';
 import path from 'path';
 
 import { putConfig } from '../lib/kv';
+import { loadBrainConfig } from '../maggie.config';
 
-async function main() {
-  const kvPath = path.join(process.cwd(), 'config', 'kv-state.json');
-  let payload: unknown;
+interface BrainState extends Record<string, unknown> {
+  lastUpdated?: string;
+}
+
+function normalizeValue(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim().length > 0) {
+    return value;
+  }
+  return undefined;
+}
+
+async function run() {
+  const kvPath = path.resolve(process.cwd(), 'config', 'kv-state.json');
+  let payload: BrainState;
 
   try {
-    const raw = await fs.promises.readFile(kvPath, 'utf8');
-    payload = JSON.parse(raw);
+    const raw = await fs.readFile(kvPath, 'utf8');
+    payload = JSON.parse(raw) as BrainState;
   } catch (err) {
     console.error(`Failed to read or parse ${kvPath}.`);
     console.error(err);
     process.exit(1);
   }
 
+  const timestamp = new Date().toISOString();
+  payload.lastUpdated = timestamp;
+
+  try {
+    await fs.writeFile(kvPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  } catch (err) {
+    console.warn(`Failed to persist updated timestamp to ${kvPath}.`, err);
+  }
+
+  let cloudflareConfig: Record<string, unknown> = {};
+  try {
+    cloudflareConfig = (await loadBrainConfig()) ?? {};
+  } catch (err) {
+    console.warn('Unable to load brain config for Cloudflare credentials, falling back to env.', err);
+  }
+
+  const accountId =
+    normalizeValue(cloudflareConfig.cloudflareAccountId) ||
+    normalizeValue(cloudflareConfig.accountId) ||
+    normalizeValue(process.env.CLOUDFLARE_ACCOUNT_ID) ||
+    normalizeValue(process.env.CF_ACCOUNT_ID) ||
+    normalizeValue(process.env.ACCOUNT_ID);
+  const apiToken =
+    normalizeValue(cloudflareConfig.cloudflareApiToken) ||
+    normalizeValue(cloudflareConfig.apiToken) ||
+    normalizeValue(process.env.CLOUDFLARE_API_TOKEN) ||
+    normalizeValue(process.env.CF_API_TOKEN) ||
+    normalizeValue(process.env.API_TOKEN);
+  const namespaceId =
+    normalizeValue(cloudflareConfig.kvNamespaceId) ||
+    normalizeValue(cloudflareConfig.cloudflareKvNamespaceId) ||
+    normalizeValue(cloudflareConfig.namespaceId) ||
+    normalizeValue(process.env.CF_KV_POSTQ_NAMESPACE_ID) ||
+    normalizeValue(process.env.CF_KV_NAMESPACE_ID);
+
   try {
     await putConfig('PostQ:thread-state', payload, {
+      accountId,
+      apiToken,
+      namespaceId,
       contentType: 'application/json',
     });
     console.log(
-      '✅ Synced PostQ:thread-state from config/kv-state.json to Cloudflare KV.'
+      `✅ Synced PostQ:thread-state from config/kv-state.json to Cloudflare KV at ${timestamp}.`
     );
   } catch (err) {
     console.error('❌ Failed to sync Maggie brain config to Cloudflare KV.');
@@ -39,4 +89,8 @@ async function main() {
   }
 }
 
-main();
+run().catch((err) => {
+  console.error('❌ Unexpected error while syncing Maggie brain config.');
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- normalize Cloudflare credential resolution in `putConfig` so the helper can fall back to the shared config export
- refresh the `updateBrain.ts` sync script to stamp `lastUpdated`, reuse `loadBrainConfig()`, and persist the canonical JSON payload
- collapse `docs/brain.md` to the KV snapshot mirror generated from `config/kv-state.json`

## Testing
- pnpm lint
- pnpm test


------
https://chatgpt.com/codex/tasks/task_e_68d0430248a0832787eedcca5aa19a47