### PR TITLE
Implement Maggie self-healing telemetry and fallback automation

### DIFF
--- a/data/fallbacks/schedule.json
+++ b/data/fallbacks/schedule.json
@@ -1,0 +1,31 @@
+{
+  "title": "Soul-aligned Posting Rhythm",
+  "generatedAt": "2024-12-01T12:00:00Z",
+  "timezone": "America/Los_Angeles",
+  "days": [
+    {
+      "day": "Monday",
+      "focus": "Energy forecast + soul tip",
+      "slots": ["08:30", "14:00", "19:00"],
+      "notes": "Lead with intention and invite engagement questions."
+    },
+    {
+      "day": "Wednesday",
+      "focus": "Behind-the-scenes + product spotlight",
+      "slots": ["09:15", "16:30"],
+      "notes": "Show the messy magic process and tie to offers."
+    },
+    {
+      "day": "Friday",
+      "focus": "Community share + call-to-action",
+      "slots": ["11:00", "18:45"],
+      "notes": "Amplify testimonials and remind of booking links."
+    },
+    {
+      "day": "Sunday",
+      "focus": "Reset ritual + blueprint teaser",
+      "slots": ["10:00"],
+      "notes": "Prime audience for the week and mention upcoming launches."
+    }
+  ]
+}

--- a/fallback.ts
+++ b/fallback.ts
@@ -1,0 +1,219 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+import { runWithCodex } from './lib/codex.ts';
+import {
+  getBlueprintSections,
+  generateIconBundleFromReading,
+} from './content/loader/blueprint';
+import type { BlueprintTier } from './content/validators/blueprint-schema';
+
+type AttemptLog = {
+  provider: string;
+  ok: boolean;
+  startedAt: string;
+  error?: string;
+};
+
+export interface MaggieFallbackResult {
+  provider: string;
+  output: unknown;
+  attempts: AttemptLog[];
+  notes?: string;
+}
+
+const SCHEDULE_FALLBACK_PATH = path.resolve('data', 'fallbacks', 'schedule.json');
+
+function serializePayload(payload: Record<string, unknown>): string {
+  try {
+    return JSON.stringify(payload, null, 2);
+  } catch {
+    return String(payload);
+  }
+}
+
+function buildPrompt(taskName: string, payload: Record<string, unknown>): string {
+  switch (taskName) {
+    case 'blueprint': {
+      const tier = String(payload.tier || 'lite').toLowerCase();
+      const name = payload.name || payload.email || 'the client';
+      const notes = payload.notes ? `Notes: ${payload.notes}` : '';
+      return `Create a soul blueprint for ${name}. Tier: ${tier}. Emphasize mission, rhythm, and aligned offers. ${notes}`.trim();
+    }
+    case 'schedule': {
+      const cadence = payload.cadence || 'daily';
+      const focus = payload.focus || 'soul business visibility';
+      return `Produce a ${cadence} content schedule for Maggie that advances ${focus}. Use warm, encouraging tone and include timing blocks with descriptions.`;
+    }
+    case 'icon': {
+      return `Design icon bundle suggestions aligned to this reading context:\n${serializePayload(payload)}`;
+    }
+    default:
+      return `Complete the task "${taskName}" using the following context:\n${serializePayload(payload)}`;
+  }
+}
+
+function summarizeError(error: unknown): string {
+  if (!error) return 'unknown';
+  if (typeof error === 'string') return error;
+  if (error instanceof Error) return error.message;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+async function callClaude(prompt: string): Promise<string> {
+  const key = process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
+  if (!key) {
+    throw new Error('Missing ANTHROPIC_API_KEY');
+  }
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': key,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-3-sonnet-20240229',
+      max_tokens: 1024,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(`Claude error ${res.status}: ${JSON.stringify(json)}`);
+  }
+  const text = json?.content?.[0]?.text || json?.content?.map?.((p: any) => p?.text)?.join('\n');
+  if (!text) {
+    throw new Error('Claude returned empty response');
+  }
+  return text;
+}
+
+async function callGemini(prompt: string): Promise<string> {
+  const key = process.env.GEMINI_API_KEY;
+  if (!key) {
+    throw new Error('Missing GEMINI_API_KEY');
+  }
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent?key=${key}`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      contents: [{ parts: [{ text: prompt }] }],
+      generationConfig: { temperature: 0.4 },
+    }),
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    throw new Error(`Gemini error ${res.status}: ${JSON.stringify(json)}`);
+  }
+  const text =
+    json?.candidates?.[0]?.content?.parts?.map((part: any) => part?.text || '').join('\n') || '';
+  if (!text.trim()) {
+    throw new Error('Gemini returned empty response');
+  }
+  return text.trim();
+}
+
+async function loadScheduleFallback() {
+  try {
+    const raw = await fs.readFile(SCHEDULE_FALLBACK_PATH, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function loadBlueprintFallback(tier: BlueprintTier) {
+  try {
+    const sections = getBlueprintSections(tier);
+    return { tier, sections };
+  } catch (err) {
+    return { tier, error: summarizeError(err) };
+  }
+}
+
+async function loadIconFallback(payload: Record<string, unknown>) {
+  try {
+    const bundle = generateIconBundleFromReading((payload.reading || {}) as any);
+    return {
+      bundle,
+      note: 'Fallback icon bundle generated from last saved reading.',
+    };
+  } catch (err) {
+    return {
+      icons: Array.isArray(payload.icons) ? payload.icons : [],
+      note: `Fallback icon bundle failed to generate: ${summarizeError(err)}`,
+    };
+  }
+}
+
+async function loadLastSavedVersion(
+  taskName: string,
+  payload: Record<string, unknown>
+): Promise<unknown> {
+  if (taskName === 'blueprint') {
+    const rawTier = String(payload.tier || 'lite').toLowerCase();
+    const allowed: BlueprintTier[] = ['full', 'mini', 'lite', 'realignment'];
+    const tier = (allowed.includes(rawTier as BlueprintTier)
+      ? (rawTier as BlueprintTier)
+      : 'lite') as BlueprintTier;
+    return loadBlueprintFallback(tier);
+  }
+  if (taskName === 'schedule') {
+    return (await loadScheduleFallback()) || { title: 'Default schedule', days: [] };
+  }
+  if (taskName === 'icon') {
+    return loadIconFallback(payload);
+  }
+  return { message: 'No cached version available', task: taskName, payload };
+}
+
+async function tryProvider(
+  label: string,
+  run: () => Promise<string>,
+  attempts: AttemptLog[],
+): Promise<MaggieFallbackResult | null> {
+  const startedAt = new Date().toISOString();
+  try {
+    const output = await run();
+    attempts.push({ provider: label, ok: true, startedAt });
+    return { provider: label, output, attempts };
+  } catch (err) {
+    attempts.push({ provider: label, ok: false, startedAt, error: summarizeError(err) });
+    return null;
+  }
+}
+
+export async function runMaggieTaskWithFallback(
+  taskName: string,
+  payload: Record<string, unknown> = {}
+): Promise<MaggieFallbackResult> {
+  const prompt = buildPrompt(taskName, payload);
+  const attempts: AttemptLog[] = [];
+
+  const primary = await tryProvider(
+    'GPT-4o',
+    () =>
+      runWithCodex({
+        task: prompt,
+        model: process.env.CODEX_MODEL || 'gpt-4o',
+      }),
+    attempts,
+  );
+  if (primary) return primary;
+
+  const claude = await tryProvider('Claude 3', () => callClaude(prompt), attempts);
+  if (claude) return claude;
+
+  const gemini = await tryProvider('Gemini Pro', () => callGemini(prompt), attempts);
+  if (gemini) return gemini;
+
+  const fallback = await loadLastSavedVersion(taskName, payload);
+  attempts.push({ provider: 'last-saved', ok: true, startedAt: new Date().toISOString() });
+  return { provider: 'last-saved', output: fallback, attempts, notes: 'Used cached content' };
+}

--- a/lib/maggieLogs.ts
+++ b/lib/maggieLogs.ts
@@ -1,0 +1,82 @@
+import { appendRows } from './google.ts';
+
+const LOG_SHEET_ID =
+  process.env.MAGGIE_LOG_SHEET_ID || process.env.GOOGLE_SHEET_ID || process.env.LOG_SHEET_ID;
+const LOCAL_TZ = process.env.MAGGIE_LOCAL_TZ || process.env.TZ || 'America/Los_Angeles';
+
+interface TimestampBundle {
+  utc: string;
+  local: string;
+}
+
+function formatTimestamps(timestamp?: string | number | Date): TimestampBundle {
+  const date = timestamp ? new Date(timestamp) : new Date();
+  const utc = date.toISOString();
+  const local = new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: LOCAL_TZ,
+  }).format(date);
+  return { utc, local: `${local} (${LOCAL_TZ})` };
+}
+
+function normalizeError(error?: unknown): string {
+  if (!error) return '';
+  if (typeof error === 'string') return error;
+  if (error instanceof Error) return error.stack || error.message;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+async function append(range: string, values: (string | number)[][]): Promise<void> {
+  if (!LOG_SHEET_ID) {
+    console.warn('[maggieLogs] Missing MAGGIE_LOG_SHEET_ID/GOOGLE_SHEET_ID; skipping log append.');
+    return;
+  }
+  try {
+    await appendRows(LOG_SHEET_ID, range, values);
+  } catch (err) {
+    console.warn('[maggieLogs] Failed to append rows:', err);
+  }
+}
+
+export interface BrainSyncLogInput {
+  kvKey: string;
+  status: 'success' | 'fail' | 'prepared';
+  trigger?: string;
+  source?: string;
+  timestamp?: string;
+  error?: unknown;
+}
+
+export async function logBrainSyncToSheet(input: BrainSyncLogInput): Promise<void> {
+  const ts = formatTimestamps(input.timestamp);
+  const trigger = input.trigger || input.source || 'manual';
+  const status = input.status === 'fail' ? 'fail' : input.status === 'prepared' ? 'success' : input.status;
+  const error =
+    input.status === 'fail'
+      ? normalizeError(input.error)
+      : input.status === 'prepared' && input.error
+      ? `prepared: ${normalizeError(input.error)}`
+      : normalizeError(input.error);
+  await append("'Brain Syncs'!A:F", [
+    [ts.utc, ts.local, input.kvKey, trigger, status, error],
+  ]);
+}
+
+export interface ErrorLogInput {
+  module: string;
+  error: unknown;
+  recovery?: string;
+  timestamp?: string;
+}
+
+export async function logErrorToSheet(input: ErrorLogInput): Promise<void> {
+  const ts = formatTimestamps(input.timestamp);
+  await append("'Errors'!A:D", [
+    [ts.utc, input.module, normalizeError(input.error), input.recovery ? String(input.recovery) : ''],
+  ]);
+}

--- a/lib/selfHealing.ts
+++ b/lib/selfHealing.ts
@@ -1,0 +1,103 @@
+import { tgSend } from './telegram';
+import { logErrorToSheet } from './maggieLogs.ts';
+import { updatePuppeteerStatus } from './statusStore.ts';
+import { runMaggieTaskWithFallback, type MaggieFallbackResult } from '../fallback';
+
+export interface PuppeteerSelfHealOptions {
+  moduleName?: string;
+  fallbackTask?: string;
+  payload?: Record<string, unknown>;
+  notifyChatId?: string;
+}
+
+export interface SelfHealOutcome<T> {
+  status: 'success' | 'fallback';
+  result?: T;
+  error?: string;
+  fallback?: MaggieFallbackResult | null;
+  attempts: number;
+}
+
+function summarizeError(error: unknown): string {
+  if (!error) return 'Unknown error';
+  if (typeof error === 'string') return error;
+  if (error instanceof Error) {
+    return error.stack || error.message || 'Error with no message';
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+}
+
+export async function withPuppeteerSelfHeal<T>(
+  operation: () => Promise<T>,
+  options: PuppeteerSelfHealOptions = {}
+): Promise<SelfHealOutcome<T>> {
+  const moduleName = options.moduleName || 'Puppeteer';
+  const fallbackTask = options.fallbackTask || 'puppeteer-recovery';
+  const payload = options.payload || {};
+  const attemptAt = new Date().toISOString();
+  let attempt = 0;
+  let lastError: unknown;
+
+  while (attempt < 2) {
+    attempt += 1;
+    try {
+      const result = await operation();
+      await updatePuppeteerStatus({
+        lastRunAt: attemptAt,
+        status: 'success',
+        attempts: attempt,
+        error: null,
+        fallbackModel: null,
+        recoveryNotes: null,
+      });
+      return { status: 'success', result, attempts: attempt };
+    } catch (err) {
+      lastError = err;
+      console.warn(`[self-heal] ${moduleName} attempt ${attempt} failed`, err);
+    }
+  }
+
+  const errorMessage = summarizeError(lastError);
+  let fallback: MaggieFallbackResult | null = null;
+  try {
+    fallback = await runMaggieTaskWithFallback(fallbackTask, payload);
+  } catch (fallbackErr) {
+    console.warn('[self-heal] fallback execution failed', fallbackErr);
+  }
+
+  const recoveryNotes: string[] = [`retry:${attempt}`];
+  if (fallback) {
+    recoveryNotes.push(`fallback:${fallback.provider}`);
+  } else {
+    recoveryNotes.push('fallback:unavailable');
+  }
+
+  await Promise.all([
+    logErrorToSheet({
+      module: moduleName,
+      error: errorMessage,
+      recovery: recoveryNotes.join(' → '),
+      timestamp: attemptAt,
+    }),
+    updatePuppeteerStatus({
+      lastRunAt: attemptAt,
+      status: 'fail',
+      attempts: attempt,
+      error: errorMessage,
+      fallbackModel: fallback?.provider || null,
+      recoveryNotes: recoveryNotes.join(' → '),
+    }),
+    tgSend(
+      `⚠️ ${moduleName} failure after retry.\nTime: ${attemptAt}\nError: ${errorMessage}${
+        fallback?.provider ? `\nFallback: ${fallback.provider}` : ''
+      }`,
+      options.notifyChatId
+    ).catch(() => undefined),
+  ]);
+
+  return { status: 'fallback', error: errorMessage, fallback, attempts: attempt };
+}

--- a/lib/statusStore.ts
+++ b/lib/statusStore.ts
@@ -1,0 +1,147 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export type BrainSyncResult = 'success' | 'fail' | 'pending';
+
+export interface BrainSyncStatus {
+  lastAttemptAt?: string;
+  lastSuccessAt?: string;
+  lastFailureAt?: string;
+  status?: BrainSyncResult;
+  trigger?: string;
+  source?: string;
+  kvKey?: string;
+  sizeBytes?: number;
+  error?: string | null;
+}
+
+export interface PuppeteerStatus {
+  lastRunAt?: string;
+  status?: 'success' | 'fail';
+  attempts?: number;
+  error?: string | null;
+  fallbackModel?: string | null;
+  recoveryNotes?: string | null;
+}
+
+export interface WebhookStatus {
+  lastSuccessAt?: string;
+  lastFailureAt?: string;
+  error?: string | null;
+  attemptedRecovery?: string | null;
+}
+
+export interface MaggieStatusStore {
+  brainSync?: BrainSyncStatus;
+  puppeteer?: PuppeteerStatus;
+  webhooks?: {
+    stripe?: WebhookStatus;
+    tally?: WebhookStatus;
+  };
+  lastUpdatedAt?: string;
+}
+
+const STATUS_PATH = path.resolve(process.cwd(), 'data', 'maggie-status.json');
+
+async function ensureDirExists(filePath: string) {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+}
+
+async function readStatusFile(): Promise<MaggieStatusStore> {
+  try {
+    const raw = await fs.readFile(STATUS_PATH, 'utf8');
+    return raw ? (JSON.parse(raw) as MaggieStatusStore) : {};
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
+      return {};
+    }
+    throw err;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function mergeDeep<T extends Record<string, unknown>>(base: T, patch: Partial<T>): T {
+  const result: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined) continue;
+    const existing = result[key];
+    if (isRecord(existing) && isRecord(value)) {
+      result[key] = mergeDeep(existing, value);
+    } else {
+      result[key] = value;
+    }
+  }
+  return result as T;
+}
+
+async function writeStatusFile(data: MaggieStatusStore): Promise<MaggieStatusStore> {
+  await ensureDirExists(STATUS_PATH);
+  const next: MaggieStatusStore = {
+    ...data,
+    lastUpdatedAt: new Date().toISOString(),
+  };
+  await fs.writeFile(STATUS_PATH, `${JSON.stringify(next, null, 2)}\n`, 'utf8');
+  return next;
+}
+
+export async function getStatus(): Promise<MaggieStatusStore> {
+  return readStatusFile();
+}
+
+export async function updateStatus(patch: Partial<MaggieStatusStore>): Promise<MaggieStatusStore> {
+  const current = await readStatusFile();
+  const merged = mergeDeep(current, patch as MaggieStatusStore);
+  return writeStatusFile(merged);
+}
+
+export async function updateBrainStatus(patch: Partial<BrainSyncStatus>): Promise<MaggieStatusStore> {
+  const normalized: BrainSyncStatus = {
+    ...(patch || {}),
+  };
+  if (normalized.error === undefined) {
+    normalized.error = undefined;
+  }
+  const nextPatch: Partial<MaggieStatusStore> = {
+    brainSync: normalized,
+  };
+  return updateStatus(nextPatch);
+}
+
+export async function updatePuppeteerStatus(patch: Partial<PuppeteerStatus>): Promise<MaggieStatusStore> {
+  const normalized: PuppeteerStatus = {
+    ...(patch || {}),
+  };
+  if (normalized.error === undefined) {
+    normalized.error = undefined;
+  }
+  const nextPatch: Partial<MaggieStatusStore> = { puppeteer: normalized };
+  return updateStatus(nextPatch);
+}
+
+export async function updateWebhookStatus(
+  kind: 'stripe' | 'tally',
+  patch: Partial<WebhookStatus>
+): Promise<MaggieStatusStore> {
+  const normalized: WebhookStatus = {
+    ...(patch || {}),
+  };
+  if (normalized.error === undefined) {
+    normalized.error = undefined;
+  }
+  const current = await readStatusFile();
+  const next: MaggieStatusStore = mergeDeep(current, {
+    webhooks: {
+      ...(current.webhooks || {}),
+      [kind]: normalized,
+    },
+  } as MaggieStatusStore);
+  return writeStatusFile(next);
+}
+
+export function getStatusFilePath(): string {
+  return STATUS_PATH;
+}

--- a/src/clients/capcut-browserless.ts
+++ b/src/clients/capcut-browserless.ts
@@ -1,30 +1,59 @@
 import { launch } from 'puppeteer-core';
-import { getBrowserlessOptions } from '../utils/browserless';
+import { promises as fs } from 'fs';
 import path from 'path';
+
+import { getBrowserlessOptions } from '../utils/browserless';
+import { withPuppeteerSelfHeal } from '../../lib/selfHealing';
 
 export async function runBrowserlessCapCut(
   rawPath: string,
   outDir: string
 ): Promise<string> {
-  const browser = await launch(getBrowserlessOptions());
+  const outcome = await withPuppeteerSelfHeal(
+    async () => {
+      const browser = await launch(getBrowserlessOptions());
+      try {
+        const page = await browser.newPage();
+        await page.goto('https://www.capcut.com/tools/video-editor');
 
-  try {
-    const page = await browser.newPage();
-    await page.goto('https://www.capcut.com/tools/video-editor');
+        // Simulate drag & drop upload
+        await page.waitForSelector('input[type="file"]');
+        const input = await page.$('input[type="file"]');
+        if (input) await input.uploadFile(rawPath);
 
-    // Simulate drag & drop upload
-    await page.waitForSelector('input[type="file"]');
-    const input = await page.$('input[type="file"]');
-    if (input) await input.uploadFile(rawPath);
+        await page.waitForTimeout(5000); // simulate processing
 
-    await page.waitForTimeout(5000); // simulate processing
+        const filename = path.basename(rawPath).replace(/\.[^/.]+$/, '');
+        const exported = path.join(outDir, `${filename}-capcut.mp4`);
+        return exported;
+      } finally {
+        await browser.close();
+      }
+    },
+    {
+      moduleName: 'CapCut Browserless',
+      fallbackTask: 'capcut-upload',
+      payload: { rawPath, outDir },
+    }
+  );
 
-    // Final export path (stubbed)
-    const filename = path.basename(rawPath).replace(/\.[^/.]+$/, '');
-    const exported = path.join(outDir, `${filename}-capcut.mp4`);
-
-    return exported;
-  } finally {
-    await browser.close();
+  if (outcome.status === 'success' && outcome.result) {
+    return outcome.result;
   }
+
+  const fallbackPath = path.join(outDir, `capcut-fallback-${Date.now()}.json`);
+  await fs.mkdir(outDir, { recursive: true });
+  await fs.writeFile(
+    fallbackPath,
+    JSON.stringify(
+      {
+        error: outcome.error,
+        fallback: outcome.fallback,
+      },
+      null,
+      2
+    ),
+    'utf8'
+  );
+  return fallbackPath;
 }

--- a/src/clients/runBrowserlessCapCut.ts
+++ b/src/clients/runBrowserlessCapCut.ts
@@ -2,51 +2,73 @@ import { launch } from 'puppeteer-core';
 import axios from 'axios';
 import fs from 'fs/promises';
 import path from 'path';
+
 import { getBrowserlessOptions } from '../utils/browserless';
+import { withPuppeteerSelfHeal } from '../../lib/selfHealing';
 
 const DEFAULT_TEMPLATE_URL = 'https://www.capcut.com/tools/video-editor';
 const DEFAULT_OUTDIR = 'uploads/maggie/exported';
 
 export async function runBrowserlessCapCut(rawPath: string, outDir = DEFAULT_OUTDIR): Promise<string> {
-  const browser = await launch(getBrowserlessOptions());
+  const outcome = await withPuppeteerSelfHeal(
+    async () => {
+      const browser = await launch(getBrowserlessOptions());
+      try {
+        const page = await browser.newPage();
+        await page.goto(DEFAULT_TEMPLATE_URL);
 
-  try {
-    const page = await browser.newPage();
-    await page.goto(DEFAULT_TEMPLATE_URL);
+        await page.waitForSelector('input[type="file"]');
+        const input = await page.$('input[type="file"]');
+        if (!input) throw new Error('Upload input not found on CapCut.');
+        await input.uploadFile(rawPath);
 
-    // Upload file
-    await page.waitForSelector('input[type="file"]');
-    const input = await page.$('input[type="file"]');
-    if (!input) throw new Error('Upload input not found on CapCut.');
-    await input.uploadFile(rawPath);
+        await page.waitForTimeout(5000);
 
-    // Simulate editing wait
-    await page.waitForTimeout(5000);
+        const exportBtn = await page.locator('button:has-text("Export")').first();
+        await exportBtn.click();
 
-    // Export video
-    const exportBtn = await page.locator('button:has-text("Export")').first();
-    await exportBtn.click();
+        const downloadBtn = await page.locator('a:has-text("Download")').first();
+        await page.waitForTimeout(5000);
 
-    // Wait for download button to appear
-    const downloadBtn = await page.locator('a:has-text("Download")').first();
-    await page.waitForTimeout(5000);
+        const href = await downloadBtn.getAttribute('href');
+        if (!href || !href.startsWith('http')) throw new Error('No download link found.');
 
-    const href = await downloadBtn.getAttribute('href');
-    if (!href || !href.startsWith('http')) throw new Error('No download link found.');
+        const filename = `capcut-${Date.now()}.mp4`;
+        const outPath = path.join(outDir, filename);
+        const response = await axios.get(href, { responseType: 'arraybuffer' });
+        await fs.mkdir(outDir, { recursive: true });
+        await fs.writeFile(outPath, response.data);
 
-    // Download video file
-    const filename = `capcut-${Date.now()}.mp4`;
-    const outPath = path.join(outDir, filename);
-    const response = await axios.get(href, { responseType: 'arraybuffer' });
-    await fs.mkdir(outDir, { recursive: true });
-    await fs.writeFile(outPath, response.data);
+        console.log(`[CapCut] Downloaded video to ${outPath}`);
+        return outPath;
+      } finally {
+        await browser.close();
+      }
+    },
+    {
+      moduleName: 'CapCut Browserless Download',
+      fallbackTask: 'capcut-upload',
+      payload: { rawPath, outDir },
+    }
+  );
 
-    console.log(`[CapCut] Downloaded video to ${outPath}`);
-    return outPath;
-  } catch (err) {
-    console.error('[CapCut] Error in runBrowserlessCapCut:', err);
-    throw err;
-  } finally {
-    await browser.close();
+  if (outcome.status === 'success' && outcome.result) {
+    return outcome.result;
   }
+
+  const fallbackPath = path.join(outDir, `capcut-download-fallback-${Date.now()}.json`);
+  await fs.mkdir(outDir, { recursive: true });
+  await fs.writeFile(
+    fallbackPath,
+    JSON.stringify(
+      {
+        error: outcome.error,
+        fallback: outcome.fallback,
+      },
+      null,
+      2
+    ),
+    'utf8'
+  );
+  return fallbackPath;
 }

--- a/utils/icon-generator.ts
+++ b/utils/icon-generator.ts
@@ -1,0 +1,45 @@
+import path from 'path';
+import { promises as fs } from 'fs';
+
+import { logErrorToSheet } from '../lib/maggieLogs';
+import { runMaggieTaskWithFallback } from '../fallback';
+
+export async function createCustomIconSheet(userId: string, icons: string[]): Promise<string> {
+  const baseDir = path.resolve('data', 'icon-sheets', userId);
+  await fs.mkdir(baseDir, { recursive: true });
+  const filePath = path.join(baseDir, `icons-${Date.now()}.json`);
+  const payload = { userId, icons };
+
+  try {
+    const content = {
+      generatedAt: new Date().toISOString(),
+      icons,
+    };
+    await fs.writeFile(filePath, JSON.stringify(content, null, 2), 'utf8');
+    return `file://${filePath}`;
+  } catch (err) {
+    const fallback = await runMaggieTaskWithFallback('icon', payload);
+    const fallbackPath = path.join(baseDir, `icons-fallback-${Date.now()}.json`);
+    await fs.writeFile(
+      fallbackPath,
+      JSON.stringify(
+        {
+          provider: fallback.provider,
+          payload,
+          output: fallback.output,
+          attempts: fallback.attempts,
+          generatedAt: new Date().toISOString(),
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+    await logErrorToSheet({
+      module: 'IconGeneration',
+      error: err,
+      recovery: `fallback:${fallback.provider}`,
+    });
+    return `file://${fallbackPath}`;
+  }
+}


### PR DESCRIPTION
## Summary
- enrich /maggie-status with Cloudflare KV insight, automation health, and persisted telemetry
- add Google Sheets logging helpers with status file tracking for brain syncs, Puppeteer, and webhooks
- create fallback orchestration across GPT-4o, Claude, Gemini, and cached artifacts with self-healing wrappers
- update CapCut clients and Stripe webhook handler to retry, log recoveries, and notify on failure

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d080c0a7788327971475d49a9944b4