### PR TITLE
feat: end-to-end fulfillment (Tally/Stripe → Blueprint + Icons + Schedule → Drive/Email) with self-heal + fallbacks

### DIFF
--- a/config/icon-library.json
+++ b/config/icon-library.json
@@ -1,0 +1,47 @@
+[
+  {
+    "slug": "sunrise-anchor",
+    "name": "Sunrise Anchor",
+    "fileId": "1A2B3Csunrise",
+    "tags": ["morning", "calm", "breath"],
+    "tone": "soft",
+    "ageRanges": ["adult", "teen"],
+    "folderUrl": "https://drive.google.com/drive/folders/1A2B3Csunrise"
+  },
+  {
+    "slug": "midday-spark",
+    "name": "Midday Spark",
+    "fileId": "1A2B3Cspark",
+    "tags": ["midday", "creative", "focus"],
+    "tone": "bright",
+    "ageRanges": ["adult"],
+    "folderUrl": "https://drive.google.com/drive/folders/1A2B3Cspark"
+  },
+  {
+    "slug": "evening-soften",
+    "name": "Evening Soften",
+    "fileId": "1A2B3Csoften",
+    "tags": ["evening", "rest", "moon"],
+    "tone": "soft",
+    "ageRanges": ["adult", "child"],
+    "folderUrl": "https://drive.google.com/drive/folders/1A2B3Csoften"
+  },
+  {
+    "slug": "weekly-reset",
+    "name": "Weekly Reset",
+    "fileId": "1A2B3Creset",
+    "tags": ["weekly", "reset", "ritual"],
+    "tone": "earthy",
+    "ageRanges": ["adult", "teen"],
+    "folderUrl": "https://drive.google.com/drive/folders/1A2B3Creset"
+  },
+  {
+    "slug": "family-circle",
+    "name": "Family Circle",
+    "fileId": "1A2B3Cfamily",
+    "tags": ["family", "connection"],
+    "tone": "bright",
+    "ageRanges": ["child", "adult"],
+    "folderUrl": "https://drive.google.com/drive/folders/1A2B3Cfamily"
+  }
+]

--- a/config/sku-map.json
+++ b/config/sku-map.json
@@ -1,0 +1,8 @@
+{
+  "price_mini": { "tier": "mini", "addOns": [] },
+  "price_lite": { "tier": "lite", "addOns": [] },
+  "price_full": { "tier": "full", "addOns": [] },
+  "price_schedule_addon": { "addOns": ["schedule"] },
+  "price_magnet_addon": { "addOns": ["magnet"] },
+  "price_bundle_full": { "tier": "full", "addOns": ["schedule", "magnet"] }
+}

--- a/docs/fulfillment.md
+++ b/docs/fulfillment.md
@@ -1,0 +1,70 @@
+# Fulfillment Pipeline
+
+This module automates readings and rhythm kits from intake through delivery. It pulls context from Stripe checkout sessions or Tally quiz submissions, generates the soul blueprint story, assembles icon and schedule kits, delivers everything by email, and logs the run for operators.
+
+## Flow Overview
+
+1. **Intake normalization (`src/fulfillment/intake.ts`)**
+   - `normalizeFromStripe(sessionId)` looks up the checkout session, maps Stripe price IDs to tiers and add-ons using `config/sku-map.json`, and extracts name + birth data from metadata. Missing essentials trigger a gentle follow-up email with the fallback intake form.
+   - `normalizeFromTally(payload)` parses Tally submissions, aligns them with SKU mappings, and captures preferences plus household rhythm notes.
+   - Both paths emit a unified object `{ customer, tier, addOns, prefs, email, source }` used by the rest of the pipeline.
+
+2. **Blueprint generation (`src/fulfillment/blueprint.ts`)**
+   - Creates/loads the order workspace in Drive under `/Fulfillment/{email}/{date}/`.
+   - Builds a warm narrative using Codex first, retries once, then falls back to Claude and Gemini. Attempt metadata is stored on the result.
+   - Copies the configured Google Docs template (or creates a blank doc), inserts the story, and exports a PDF alongside the doc. Both files live inside `/blueprint/` for the order.
+
+3. **Icon bundle (`src/fulfillment/icons.ts`)**
+   - Reads `config/icon-library.json` to reuse existing icons whenever possible.
+   - For missing slots, generates a simple SVG icon aligned to the requested tone and saves it to `/icons/` in the Drive workspace.
+   - Produces a `manifest.json` that lists every icon, origin (library vs generated), and Drive links.
+
+4. **Schedule kit (`src/fulfillment/schedule.ts`)**
+   - Creates daily / weekly / monthly rhythm docs based on tier rules:
+     - Mini → daily only
+     - Lite → daily + weekly
+     - Full → daily + weekly + monthly
+   - Copies optional templates defined in `thread-state` or environment variables, otherwise builds docs from scratch.
+   - Exports PDFs for each doc into `/schedule/`.
+
+5. **Delivery (`src/fulfillment/deliver.ts`)**
+   - Sends a human email via Resend/Zoho that links to the doc, PDF, schedule folder, and icon bundle. Tone stays warm and simple (no AI tells).
+
+6. **Runner (`src/fulfillment/runner.ts`)**
+   - `runOrder(orderRef)` orchestrates intake → blueprint → icons → schedule → deliver.
+   - Logs to the Google Sheet tab `Fulfillment` (`UTC, Local, Email, Tier, BundleType, Files, Status`).
+   - Updates the Notion orders database when credentials are available.
+   - Records the last summary to disk/KV for `/ops/recent-order` and optional Telegram updates.
+   - Retries the full pipeline once on error; final failure sends a Telegram alert via configured bot/chat.
+
+## Queue & Webhooks
+
+- `src/queue.ts` maintains a lightweight queue backed by KV with `queue.json` as local fallback. Jobs are `{ id, source, payload, attempts }`.
+- `/webhooks/stripe` accepts `checkout.session.completed` events, verifies the webhook, and enqueues the session ID for processing.
+- `/webhooks/tally` validates the Tally signature and enqueues the submission payload.
+- `/ops/recent-order` returns the last processed order summary for quick operator or Telegram checks.
+
+## Storage Layout in Drive
+
+Each fulfillment run creates/uses:
+```
+/Fulfillment/{email}/{YYYY-MM-DD}/
+  blueprint/
+    Soul Blueprint (Google Doc)
+    Soul Blueprint.pdf
+  icons/
+    *.png / *.svg
+    manifest.json
+  schedule/
+    Daily rhythm doc + PDF
+    Weekly rhythm doc + PDF (Lite/Full)
+    Monthly cadence doc + PDF (Full)
+```
+Root folders, template IDs, and sheet/notion IDs can be defined in `thread-state` under the `fulfillment` section or via environment variables (`FULFILLMENT_*`).
+
+## Fallback & Self-Heal Logic
+
+- Story generation tries Codex → Claude → Gemini. Each provider gets one retry before moving to the next.
+- If all providers fail, the runner logs to Sheets, records the error summary, and sends a Telegram alert.
+- Missing intake essentials automatically trigger a friendly email pointing to the intake form.
+- Queue state survives restarts via KV; the runner records the last success/failure so operators can poll `/ops/recent-order` without digging into logs.

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "seed:kv": "tsx scripts/seedKV.ts"
   },
   "dependencies": {
+    "@notionhq/client": "^2.3.0",
     "axios": "^1.6.7",
     "chokidar": "^3.5.3",
     "googleapis": "^131.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@notionhq/client':
+        specifier: ^2.3.0
+        version: 2.3.0
       axios:
         specifier: ^1.6.7
         version: 1.11.0
@@ -1179,6 +1182,10 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@notionhq/client@2.3.0':
+    resolution: {integrity: sha512-l7WqTCpQqC+HibkB9chghONQTYcxNQT0/rOJemBfmuKQRTu2vuV8B3yA395iKaUdDo7HI+0KvQaz9687Xskzkw==}
+    engines: {node: '>=12'}
+
   '@poppinss/colors@4.1.5':
     resolution: {integrity: sha512-FvdDqtcRCtz6hThExcFOgW0cWX+xwSMWcRuQe5ZEb2m7cVQOAVZOIMt+/v9RxGiD9/OY16qJBXK4CVKWAPalBw==}
 
@@ -1327,6 +1334,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/node-fetch@2.6.13':
+    resolution: {integrity: sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==}
 
   '@types/node@24.3.0':
     resolution: {integrity: sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==}
@@ -3514,6 +3524,13 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@notionhq/client@2.3.0':
+    dependencies:
+      '@types/node-fetch': 2.6.13
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
+
   '@poppinss/colors@4.1.5':
     dependencies:
       kleur: 4.1.5
@@ -3624,6 +3641,11 @@ snapshots:
       '@babel/types': 7.28.2
 
   '@types/estree@1.0.8': {}
+
+  '@types/node-fetch@2.6.13':
+    dependencies:
+      '@types/node': 24.3.0
+      form-data: 4.0.4
 
   '@types/node@24.3.0':
     dependencies:

--- a/src/fulfillment/blueprint.ts
+++ b/src/fulfillment/blueprint.ts
@@ -1,0 +1,233 @@
+import { Buffer } from 'buffer';
+import type { docs_v1 } from 'googleapis';
+import { ensureOrderWorkspace, ensureFolder, summarizeStory, notifyOpsChannel } from './common';
+import type { NormalizedIntake, BlueprintResult, FulfillmentWorkspace, ModelAttempt } from './types';
+import { runWithCodex } from '../../lib/codex';
+
+async function callCodex(prompt: string): Promise<string> {
+  const result = await runWithCodex({
+    task: prompt,
+    role: 'Soul blueprint composer',
+    context:
+      'Write vivid, grounded readings that feel handwritten by a caring guide. No AI disclaimers. Favor shorter sentences and avoid m-dashes.',
+  });
+  return result.trim();
+}
+
+async function callClaude(prompt: string): Promise<string> {
+  const key = process.env.ANTHROPIC_API_KEY || process.env.CLAUDE_API_KEY;
+  if (!key) throw new Error('Missing ANTHROPIC_API_KEY');
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': key,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model: 'claude-3-sonnet-20240229',
+      max_tokens: 1200,
+      temperature: 0.6,
+      messages: [{ role: 'user', content: prompt }],
+    }),
+  });
+  const json: any = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`Claude error ${res.status}: ${JSON.stringify(json)}`);
+  const text = json?.content?.[0]?.text || json?.content?.map?.((p: any) => p?.text)?.join('\n');
+  if (!text) throw new Error('Claude returned empty response');
+  return text.trim();
+}
+
+async function callGemini(prompt: string): Promise<string> {
+  const key = process.env.GEMINI_API_KEY;
+  if (!key) throw new Error('Missing GEMINI_API_KEY');
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/gemini-1.5-pro:generateContent?key=${key}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: prompt }] }],
+        generationConfig: { temperature: 0.5 },
+      }),
+    }
+  );
+  const json: any = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(`Gemini error ${res.status}: ${JSON.stringify(json)}`);
+  const text =
+    json?.candidates?.[0]?.content?.parts?.map((part: any) => part?.text || '').join('\n').trim() || '';
+  if (!text) throw new Error('Gemini returned empty response');
+  return text;
+}
+
+function buildPrompt(intake: NormalizedIntake): string {
+  const focus = intake.prefs?.focus || intake.prefs?.intention || 'support their natural rhythm';
+  const name = intake.customer.name || intake.customer.firstName || 'this soul';
+  const tierLabel = intake.tier === 'full' ? 'Full' : intake.tier === 'lite' ? 'Lite' : 'Mini';
+  const birthParts: string[] = [];
+  if (intake.customer.birth?.date) birthParts.push(`born ${intake.customer.birth.date}`);
+  if (intake.customer.birth?.time) birthParts.push(`at ${intake.customer.birth.time}`);
+  if (intake.customer.birth?.location) birthParts.push(`in ${intake.customer.birth.location}`);
+  const birthLine = birthParts.length ? birthParts.join(' ') : 'birth data pending';
+  const addons = intake.addOns.length ? `Add-ons: ${intake.addOns.join(', ')}.` : '';
+  const preferenceSummary = Object.entries(intake.prefs || {})
+    .filter(([key]) => !['email', 'productid', 'tier'].includes(key))
+    .map(([key, value]) => `${key}: ${value}`)
+    .slice(0, 12)
+    .join('\n');
+
+  return `You are writing a ${tierLabel} soul blueprint in a friendly, grounded, poetic tone. Avoid sounding robotic and do not use m-dashes.
+Client: ${name}
+Tier: ${tierLabel}
+Birth: ${birthLine}
+${addons}
+Preferences:
+${preferenceSummary || 'No additional notes.'}
+
+Write a single cohesive story that weaves astrology, numerology, and subtle energy themes into a warm narrative. Include gentle suggestions for rhythm and rituals appropriate for their stage of life. Keep paragraphs short (3-4 sentences max) and emphasize encouragement.`;
+}
+
+async function generateStory(intake: NormalizedIntake): Promise<{ story: string; attempts: ModelAttempt[] }> {
+  const prompt = buildPrompt(intake);
+  const providers: Array<{
+    id: ModelAttempt['provider'];
+    fn: (prompt: string) => Promise<string>;
+  }> = [
+    { id: 'codex', fn: callCodex },
+    { id: 'claude', fn: callClaude },
+    { id: 'gemini', fn: callGemini },
+  ];
+  const attempts: ModelAttempt[] = [];
+  for (const provider of providers) {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const startedAt = new Date();
+      try {
+        const story = await provider.fn(prompt);
+        attempts.push({
+          provider: provider.id,
+          ok: true,
+          startedAt: startedAt.toISOString(),
+          finishedAt: new Date().toISOString(),
+        });
+        return { story, attempts };
+      } catch (err: any) {
+        attempts.push({
+          provider: provider.id,
+          ok: false,
+          startedAt: startedAt.toISOString(),
+          finishedAt: new Date().toISOString(),
+          error: err?.message || String(err),
+        });
+      }
+    }
+  }
+  throw Object.assign(new Error('All providers failed to generate blueprint'), { attempts });
+}
+
+async function insertStory(
+  docs: docs_v1.Docs,
+  documentId: string,
+  story: string,
+  intake: NormalizedIntake,
+  workspace: FulfillmentWorkspace
+) {
+  const summary = summarizeStory(story, 180);
+  const headerName = intake.customer.name || intake.customer.firstName || 'Beloved Soul';
+  const tierLabel = intake.tier === 'full' ? 'Full' : intake.tier === 'lite' ? 'Lite' : 'Mini';
+  const body = `${headerName} — ${tierLabel} Soul Blueprint\nGenerated ${workspace.timestamp.toLocaleString()}\n\n${story}\n\nHighlights: ${summary}`;
+  const requests: docs_v1.Schema$Request[] = [
+    { insertText: { location: { index: 1 }, text: body } },
+  ];
+  if (intake.customer.name) {
+    requests.push({
+      replaceAllText: {
+        containsText: { text: '{{CLIENT_NAME}}', matchCase: false },
+        replaceText: intake.customer.name,
+      },
+    });
+  }
+  requests.push({
+    replaceAllText: {
+      containsText: { text: '{{TIER}}', matchCase: false },
+      replaceText: tierLabel,
+    },
+  });
+  requests.push({
+    replaceAllText: {
+      containsText: { text: '{{BLUEPRINT_STORY}}', matchCase: false },
+      replaceText: story,
+    },
+  });
+
+  await docs.documents.batchUpdate({
+    documentId,
+    requestBody: { requests },
+  });
+}
+
+export async function generateBlueprint(
+  intake: NormalizedIntake,
+  opts: { workspace?: FulfillmentWorkspace; env?: any } = {}
+): Promise<BlueprintResult> {
+  const workspace = opts.workspace || (await ensureOrderWorkspace(intake, opts));
+  const { story, attempts } = await generateStory(intake).catch(async (err) => {
+    await notifyOpsChannel(`⚠️ Blueprint story failed for ${intake.email}: ${err?.message || err}`, workspace.config);
+    throw err;
+  });
+
+  const drive = workspace.drive;
+  const docs = workspace.docs;
+  const blueprintFolder = await ensureFolder(drive, workspace.orderFolderId, 'blueprint');
+  const nameBase = `${intake.customer.name || intake.email || 'Soul Friend'} - Blueprint`;
+
+  let docId: string;
+  let docUrl = '';
+  if (workspace.config.blueprintTemplateId) {
+    const copy = await drive.files.copy({
+      fileId: workspace.config.blueprintTemplateId,
+      requestBody: {
+        name: nameBase,
+        parents: [blueprintFolder.id!],
+      },
+      fields: 'id, webViewLink',
+    });
+    docId = copy.data.id!;
+    docUrl = copy.data.webViewLink || '';
+  } else {
+    const created = await docs.documents.create({ requestBody: { title: nameBase } });
+    docId = created.data.documentId!;
+    await drive.files.update({ fileId: docId, addParents: blueprintFolder.id!, fields: 'id, webViewLink' });
+    const meta = await drive.files.get({ fileId: docId, fields: 'webViewLink' });
+    docUrl = meta.data.webViewLink || '';
+  }
+
+  await insertStory(docs, docId, story, intake, workspace);
+
+  const exportRes = await drive.files.export(
+    { fileId: docId, mimeType: 'application/pdf' },
+    { responseType: 'arraybuffer' }
+  );
+  const pdfBuffer = Buffer.from(exportRes.data as ArrayBuffer);
+  const pdf = await drive.files.create({
+    requestBody: {
+      name: `${nameBase}.pdf`,
+      mimeType: 'application/pdf',
+      parents: [blueprintFolder.id!],
+    },
+    media: { mimeType: 'application/pdf', body: pdfBuffer },
+    fields: 'id, webViewLink',
+  });
+
+  const summary = summarizeStory(story, 240);
+  return {
+    docId,
+    docUrl,
+    pdfId: pdf.data.id || '',
+    pdfUrl: pdf.data.webViewLink || '',
+    summary,
+    story,
+    attempts,
+    folderId: blueprintFolder.id!,
+    folderUrl: blueprintFolder.webViewLink || '',
+  };
+}

--- a/src/fulfillment/common.ts
+++ b/src/fulfillment/common.ts
@@ -1,0 +1,224 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+import type { drive_v3 } from 'googleapis';
+import { getDrive, getDocs, getSheets } from '../../lib/google';
+import { getSecrets } from '../config';
+import { appendRows } from '../../lib/google';
+import { NormalizedIntake, FulfillmentConfig, FulfillmentWorkspace, OrderSummary } from './types';
+import { tgSend } from '../lib/telegram';
+
+let cachedConfig: FulfillmentConfig | null = null;
+let cachedSkuMap: Record<string, { tier?: string; addOns?: string[] }> | null = null;
+let cachedIconLibrary: IconLibraryEntry[] | null = null;
+
+interface IconLibraryEntry {
+  slug: string;
+  name: string;
+  fileId: string;
+  tone?: string;
+  ageRanges?: string[];
+  tags?: string[];
+  folderUrl?: string;
+}
+
+interface LoadOptions {
+  env?: any;
+}
+
+export async function loadFulfillmentConfig(opts: LoadOptions = {}): Promise<FulfillmentConfig> {
+  if (cachedConfig) return cachedConfig;
+
+  let secrets: any = {};
+  try {
+    secrets = await getSecrets(opts.env || {});
+  } catch (err) {
+    console.warn('[fulfillment.config] unable to load secrets from KV:', err);
+  }
+
+  const fromBlob = secrets?.fulfillment || secrets?.services?.fulfillment || {};
+
+  const env = typeof process !== 'undefined' ? process.env : ({} as Record<string, string>);
+
+  const config: FulfillmentConfig = {
+    driveRootId:
+      fromBlob.driveRootId ||
+      env.FULFILLMENT_DRIVE_ROOT_ID ||
+      env.MM_DRIVE_READY_ID ||
+      env.MM_DRIVE_ROOT_ID ||
+      '',
+    blueprintTemplateId:
+      fromBlob.blueprintTemplateId || env.FULFILLMENT_BLUEPRINT_TEMPLATE_ID,
+    scheduleTemplates: {
+      daily: fromBlob.scheduleTemplates?.daily || env.FULFILLMENT_SCHEDULE_DAILY_TEMPLATE_ID,
+      weekly: fromBlob.scheduleTemplates?.weekly || env.FULFILLMENT_SCHEDULE_WEEKLY_TEMPLATE_ID,
+      monthly: fromBlob.scheduleTemplates?.monthly || env.FULFILLMENT_SCHEDULE_MONTHLY_TEMPLATE_ID,
+    },
+    intakeFallbackFormUrl:
+      fromBlob.intakeFallbackFormUrl || env.FULFILLMENT_INTAKE_FALLBACK_URL,
+    sheetId: fromBlob.sheetId || env.FULFILLMENT_SHEET_ID,
+    notionDatabaseId: fromBlob.notionDatabaseId || env.FULFILLMENT_NOTION_DB_ID,
+    telegramChatId: fromBlob.telegramChatId || env.TELEGRAM_CHAT_ID,
+    telegramBotToken: fromBlob.telegramBotToken || env.TELEGRAM_BOT_TOKEN,
+    iconLibraryFolderId: fromBlob.iconLibraryFolderId || env.FULFILLMENT_ICON_LIBRARY_ID,
+    resendFromEmail: fromBlob.resendFromEmail || env.RESEND_FROM_EMAIL,
+    resendFromName: fromBlob.resendFromName || env.RESEND_FROM_NAME,
+  };
+
+  if (!config.driveRootId) {
+    throw new Error(
+      'Fulfillment drive root is not configured. Set FULFILLMENT_DRIVE_ROOT_ID or fulfillment.driveRootId in thread-state.'
+    );
+  }
+
+  cachedConfig = config;
+  return config;
+}
+
+export async function loadSkuMap(): Promise<Record<string, { tier?: string; addOns?: string[] }>> {
+  if (cachedSkuMap) return cachedSkuMap;
+  const filePath = path.resolve(process.cwd(), 'config', 'sku-map.json');
+  try {
+    const raw = await readFile(filePath, 'utf8');
+    cachedSkuMap = JSON.parse(raw);
+  } catch (err) {
+    console.warn('[fulfillment.config] Unable to load config/sku-map.json:', err);
+    cachedSkuMap = {};
+  }
+  return cachedSkuMap;
+}
+
+export async function loadIconLibrary(): Promise<IconLibraryEntry[]> {
+  if (cachedIconLibrary) return cachedIconLibrary;
+  const filePath = path.resolve(process.cwd(), 'config', 'icon-library.json');
+  try {
+    const raw = await readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    cachedIconLibrary = Array.isArray(parsed)
+      ? parsed
+      : Object.entries(parsed).map(([slug, value]: [string, any]) => ({ slug, ...(value || {}) }));
+  } catch (err) {
+    console.warn('[fulfillment.config] Unable to load config/icon-library.json:', err);
+    cachedIconLibrary = [];
+  }
+  return cachedIconLibrary;
+}
+
+export function validateEmail(email?: string | null): boolean {
+  if (!email) return false;
+  const clean = email.trim();
+  if (!clean) return false;
+  const pattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  return pattern.test(clean.toLowerCase());
+}
+
+export function splitName(name?: string | null): { firstName?: string; lastName?: string } {
+  if (!name) return {};
+  const parts = name
+    .replace(/\s+/g, ' ')
+    .trim()
+    .split(' ')
+    .filter(Boolean);
+  if (!parts.length) return {};
+  if (parts.length === 1) return { firstName: parts[0] };
+  return { firstName: parts.slice(0, -1).join(' '), lastName: parts.slice(-1)[0] };
+}
+
+export async function ensureOrderWorkspace(
+  intake: NormalizedIntake,
+  opts: LoadOptions = {}
+): Promise<FulfillmentWorkspace> {
+  const config = await loadFulfillmentConfig(opts);
+  const drive = await getDrive();
+  const docs = await getDocs();
+  const timestamp = new Date();
+
+  const emailSegment = intake.email.replace(/[^a-z0-9@._-]/gi, '_').toLowerCase();
+  const dateSegment = `${timestamp.getUTCFullYear()}-${String(timestamp.getUTCMonth() + 1).padStart(2, '0')}-${String(
+    timestamp.getUTCDate()
+  ).padStart(2, '0')}`;
+
+  const parent = await ensureFolder(drive, config.driveRootId, 'Fulfillment');
+  const customerFolder = await ensureFolder(drive, parent.id!, emailSegment);
+  const orderFolder = await ensureFolder(drive, customerFolder.id!, dateSegment);
+
+  return {
+    drive,
+    docs,
+    rootFolderId: config.driveRootId,
+    orderFolderId: orderFolder.id!,
+    orderFolderUrl: orderFolder.webViewLink || '',
+    timestamp,
+    config,
+  };
+}
+
+export async function ensureFolder(
+  drive: drive_v3.Drive,
+  parentId: string,
+  name: string
+): Promise<drive_v3.Schema$File> {
+  const query = `mimeType = 'application/vnd.google-apps.folder' and trashed = false and '${parentId}' in parents and name = '${
+    name.replace(/'/g, "\\'")
+  }'`;
+  const res = await drive.files.list({
+    q: query,
+    fields: 'files(id, name, webViewLink)',
+    pageSize: 1,
+  });
+  const existing = res.data.files?.[0];
+  if (existing) return existing;
+  const created = await drive.files.create({
+    requestBody: {
+      name,
+      mimeType: 'application/vnd.google-apps.folder',
+      parents: [parentId],
+    },
+    fields: 'id, name, webViewLink',
+  });
+  return created.data;
+}
+
+export async function appendFulfillmentLog(
+  intake: NormalizedIntake,
+  summary: OrderSummary,
+  config: FulfillmentConfig
+): Promise<void> {
+  if (!config.sheetId) return;
+  try {
+    const sheets = await getSheets();
+    const utc = new Date(summary.completedAt).toISOString();
+    const local = new Date(summary.completedAt).toLocaleString('en-US', { timeZone: 'America/Denver' });
+    const files = summary.files.join('\n');
+    await appendRows(config.sheetId, 'Fulfillment!A2:G', [
+      [utc, local, intake.email, intake.tier, summary.message, files, summary.status],
+    ]);
+  } catch (err) {
+    console.warn('[fulfillment.log] failed to append to sheet:', err);
+  }
+}
+
+export async function notifyOpsChannel(message: string, config: FulfillmentConfig): Promise<void> {
+  if (!config.telegramChatId || !config.telegramBotToken) return;
+  try {
+    await tgSend(message, config.telegramChatId);
+  } catch (err) {
+    console.warn('[fulfillment.notify] failed to send telegram message:', err);
+  }
+}
+
+export function summarizeStory(story: string, maxLength = 280): string {
+  const clean = story.replace(/\s+/g, ' ').trim();
+  if (clean.length <= maxLength) return clean;
+  return `${clean.slice(0, maxLength - 1).trim()}…`;
+}
+
+export async function recordOrderSummary(summary: OrderSummary): Promise<void> {
+  try {
+    const { writeFile, mkdir } = await import('fs/promises');
+    const filePath = path.resolve(process.cwd(), 'data');
+    await mkdir(filePath, { recursive: true });
+    await writeFile(path.join(filePath, 'last-fulfillment.json'), JSON.stringify(summary, null, 2));
+  } catch {}
+}
+
+export type { IconLibraryEntry };

--- a/src/fulfillment/deliver.ts
+++ b/src/fulfillment/deliver.ts
@@ -1,0 +1,58 @@
+import { sendEmail } from '../../utils/email';
+import type { NormalizedIntake, BlueprintResult, IconBundleResult, ScheduleResult, DeliveryReceipt } from './types';
+
+interface DeliverOptions {
+  env?: any;
+}
+
+export async function deliverFulfillment(
+  intake: NormalizedIntake,
+  blueprint: BlueprintResult,
+  icons: IconBundleResult,
+  schedule: ScheduleResult,
+  opts: DeliverOptions = {}
+): Promise<DeliveryReceipt[]> {
+  if (!intake.email) {
+    throw new Error('Cannot deliver fulfillment without customer email');
+  }
+
+  const subject = `Your ${intake.tier === 'full' ? 'Full' : intake.tier === 'lite' ? 'Lite' : 'Mini'} Soul Blueprint is here`;
+  const greeting = intake.customer.firstName || intake.customer.name || 'Hi friend';
+  const textBody = `${greeting},
+
+Your reading and rhythm kit are ready. Here is everything in one place:
+- Story in Google Docs: ${blueprint.docUrl}
+- Downloadable PDF: ${blueprint.pdfUrl}
+- Rhythm templates: ${schedule.scheduleFolderUrl}
+- Icon bundle: ${icons.bundleFolderUrl}
+
+Take your time, sip some tea, and let this settle in. Reply if anything feels off or if you want an adjustment.
+
+With warmth,
+Maggie`;
+
+  const htmlBody = `
+  <p>${greeting},</p>
+  <p>Your reading and rhythm kit are ready. Here is everything in one place:</p>
+  <ul>
+    <li><a href="${blueprint.docUrl}">Story in Google Docs</a></li>
+    <li><a href="${blueprint.pdfUrl}">Downloadable PDF</a></li>
+    <li><a href="${schedule.scheduleFolderUrl}">Rhythm templates</a></li>
+    <li><a href="${icons.bundleFolderUrl}">Icon bundle</a></li>
+  </ul>
+  <p>Take your time, sip some tea, and let this settle in. Reply if anything feels off or if you want an adjustment.</p>
+  <p>With warmth,<br/>Maggie</p>
+  `;
+
+  const result = await sendEmail(
+    {
+      to: intake.email,
+      subject,
+      text: textBody,
+      html: htmlBody,
+    },
+    opts.env
+  );
+
+  return [{ channel: 'email', id: result.id }];
+}

--- a/src/fulfillment/icons.ts
+++ b/src/fulfillment/icons.ts
@@ -1,0 +1,244 @@
+import { Buffer } from 'buffer';
+import { ensureOrderWorkspace, ensureFolder, loadIconLibrary } from './common';
+import type { NormalizedIntake, IconBundleResult, IconAsset, FulfillmentWorkspace } from './types';
+
+interface IconRequest {
+  slug: string;
+  label: string;
+  description: string;
+  tags: string[];
+  tone: 'bright' | 'soft' | 'earthy';
+}
+
+function deriveIconRequests(intake: NormalizedIntake): IconRequest[] {
+  const tone = (intake.prefs?.tone || '').toLowerCase();
+  const baseTone: IconRequest['tone'] = tone.includes('earth')
+    ? 'earthy'
+    : tone.includes('bold')
+    ? 'bright'
+    : 'soft';
+
+  const requests: IconRequest[] = [
+    {
+      slug: 'sunrise-anchor',
+      label: 'Sunrise anchor',
+      description: 'Gentle start to welcome the day with breath and intention.',
+      tags: ['morning', 'calm'],
+      tone: baseTone,
+    },
+    {
+      slug: 'midday-spark',
+      label: 'Midday spark',
+      description: 'Creative activation icon for the heart of the day.',
+      tags: ['midday', 'creative'],
+      tone: baseTone,
+    },
+    {
+      slug: 'evening-soften',
+      label: 'Evening soften',
+      description: 'Wind-down reminder with candlelight energy.',
+      tags: ['evening', 'rest'],
+      tone: 'soft',
+    },
+    {
+      slug: 'weekly-reset',
+      label: 'Weekly reset',
+      description: 'Sunday reset / reset altar icon for planning and gratitude.',
+      tags: ['weekly', 'reset'],
+      tone: 'earthy',
+    },
+  ];
+
+  if (intake.tier !== 'mini') {
+    requests.push({
+      slug: 'seasonal-wave',
+      label: 'Seasonal wave',
+      description: 'Icon to mark monthly or seasonal pulse checks.',
+      tags: ['seasonal', 'cycle'],
+      tone: baseTone,
+    });
+  }
+
+  if (intake.tier === 'full') {
+    requests.push(
+      {
+        slug: 'daily-flow',
+        label: 'Daily flow',
+        description: 'Visual for detailed daily rhythm prompts.',
+        tags: ['daily', 'flow'],
+        tone: 'bright',
+      },
+      {
+        slug: 'sacred-rest',
+        label: 'Sacred rest',
+        description: 'Cue for sabbath or full reset days.',
+        tags: ['rest', 'sacred'],
+        tone: 'soft',
+      }
+    );
+  }
+
+  const prefThemes = (intake.prefs?.themes || intake.prefs?.focus || '').toString().toLowerCase();
+  if (prefThemes.includes('kid') || prefThemes.includes('family')) {
+    requests.push({
+      slug: 'family-circle',
+      label: 'Family circle',
+      description: 'Icon to signal shared family rhythm moments.',
+      tags: ['family', 'connection'],
+      tone: 'bright',
+    });
+  }
+
+  return requests;
+}
+
+interface LibraryMatch {
+  slug: string;
+  label: string;
+  fileId: string;
+  tags: string[];
+  tone?: string;
+  url?: string;
+}
+
+function findLibraryMatch(request: IconRequest, library: LibraryMatch[]): LibraryMatch | null {
+  const slugMatch = library.find((icon) => icon.slug === request.slug);
+  if (slugMatch) return slugMatch;
+  const tagMatch = library.find((icon) => {
+    if (!icon.tags?.length) return false;
+    const normalized = icon.tags.map((t) => t.toLowerCase());
+    return request.tags.every((tag) => normalized.includes(tag));
+  });
+  if (tagMatch) return tagMatch;
+  const looseMatch = library.find((icon) => (icon.label || '').toLowerCase().includes(request.label.split(' ')[0].toLowerCase()));
+  return looseMatch || null;
+}
+
+function paletteForTone(tone: IconRequest['tone']) {
+  switch (tone) {
+    case 'bright':
+      return { bg: '#ffd8e5', accent: '#f26d9d', detail: '#8a3ffc' };
+    case 'earthy':
+      return { bg: '#f4efe6', accent: '#c97b4a', detail: '#4f3b2f' };
+    default:
+      return { bg: '#e9ecff', accent: '#7c8cff', detail: '#4b5ad1' };
+  }
+}
+
+function generateSvgIcon(request: IconRequest): string {
+  const palette = paletteForTone(request.tone);
+  const text = request.label.replace(/[^a-zA-Z0-9 ]/g, '').slice(0, 18);
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="${palette.bg}" />
+      <stop offset="100%" stop-color="${palette.accent}" />
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="512" height="512" rx="64" fill="url(#bg)" />
+  <circle cx="256" cy="220" r="140" fill="${palette.accent}" opacity="0.75" />
+  <path d="M120 360 C180 300 332 300 392 360" stroke="${palette.detail}" stroke-width="22" fill="none" stroke-linecap="round" />
+  <text x="256" y="410" font-family="'Poppins', 'Arial', sans-serif" font-size="46" fill="${palette.detail}" text-anchor="middle">
+    ${text}
+  </text>
+</svg>`;
+}
+
+function buildManifest(intake: NormalizedIntake, icons: IconAsset[]) {
+  return {
+    generatedAt: new Date().toISOString(),
+    email: intake.email,
+    tier: intake.tier,
+    icons: icons.map((icon) => ({
+      slug: icon.slug,
+      name: icon.name,
+      description: icon.description,
+      fileId: icon.fileId,
+      url: icon.url,
+      origin: icon.origin,
+    })),
+  };
+}
+
+export async function buildIconBundle(
+  intake: NormalizedIntake,
+  opts: { workspace?: FulfillmentWorkspace; env?: any } = {}
+): Promise<IconBundleResult> {
+  const workspace = opts.workspace || (await ensureOrderWorkspace(intake, opts));
+  const drive = workspace.drive;
+  const iconFolder = await ensureFolder(drive, workspace.orderFolderId, 'icons');
+  const libraryEntries = await loadIconLibrary();
+  const library: LibraryMatch[] = libraryEntries.map((entry) => ({
+    slug: entry.slug,
+    label: entry.name,
+    fileId: entry.fileId,
+    tags: entry.tags || [],
+    tone: entry.tone,
+    url: entry.folderUrl,
+  }));
+
+  const requests = deriveIconRequests(intake);
+  const icons: IconAsset[] = [];
+
+  for (const request of requests) {
+    const match = findLibraryMatch(request, library);
+    if (match?.fileId) {
+      const copy = await drive.files.copy({
+        fileId: match.fileId,
+        requestBody: {
+          name: `${request.label}.png`,
+          parents: [iconFolder.id!],
+        },
+        fields: 'id, webViewLink',
+      });
+      icons.push({
+        slug: request.slug,
+        name: request.label,
+        description: request.description,
+        url: copy.data.webViewLink || match.url || '',
+        fileId: copy.data.id || '',
+        origin: 'library',
+      });
+      continue;
+    }
+
+    const svg = generateSvgIcon(request);
+    const created = await drive.files.create({
+      requestBody: {
+        name: `${request.label}.svg`,
+        mimeType: 'image/svg+xml',
+        parents: [iconFolder.id!],
+      },
+      media: { mimeType: 'image/svg+xml', body: Buffer.from(svg, 'utf8') },
+      fields: 'id, webViewLink',
+    });
+    icons.push({
+      slug: request.slug,
+      name: request.label,
+      description: request.description,
+      url: created.data.webViewLink || '',
+      fileId: created.data.id || '',
+      origin: 'generated',
+    });
+  }
+
+  const manifest = buildManifest(intake, icons);
+  const manifestFile = await drive.files.create({
+    requestBody: {
+      name: 'manifest.json',
+      mimeType: 'application/json',
+      parents: [iconFolder.id!],
+    },
+    media: { mimeType: 'application/json', body: Buffer.from(JSON.stringify(manifest, null, 2), 'utf8') },
+    fields: 'id, webViewLink',
+  });
+
+  return {
+    bundleFolderId: iconFolder.id!,
+    bundleFolderUrl: iconFolder.webViewLink || '',
+    manifestId: manifestFile.data.id || '',
+    manifestUrl: manifestFile.data.webViewLink || '',
+    icons,
+  };
+}

--- a/src/fulfillment/intake.ts
+++ b/src/fulfillment/intake.ts
@@ -1,0 +1,298 @@
+import Stripe from 'stripe';
+import { loadSkuMap, validateEmail, splitName, loadFulfillmentConfig } from './common';
+import type { NormalizedIntake, CustomerProfile, FulfillmentTier } from './types';
+import { sendEmail } from '../../utils/email';
+
+type StripeSession = Stripe.Checkout.Session & {
+  line_items?: Stripe.ApiList<Stripe.LineItem>;
+};
+
+interface MissingFieldNotice {
+  email?: string;
+  missing: string[];
+  source: 'stripe' | 'tally';
+}
+
+function normalizeTier(input?: string | null): FulfillmentTier | undefined {
+  if (!input) return undefined;
+  const value = input.toLowerCase();
+  if (value.includes('mini')) return 'mini';
+  if (value.includes('lite')) return 'lite';
+  if (value.includes('full')) return 'full';
+  return undefined;
+}
+
+async function requestMissingInfo(intake: MissingFieldNotice, configEmail?: { fromEmail?: string; fromName?: string }) {
+  if (!intake.email || !validateEmail(intake.email)) return;
+  const subject = 'Quick follow-up so we can finish your kit';
+  const body = `Hi there,\n\nThanks for your order! We just need a little more information to complete your ${
+    intake.source === 'stripe' ? 'reading bundle' : 'reading'}
+  . Could you share the following details?\n\n- ${intake.missing.join('\n- ')}\n\nYou can reply to this email or fill out the intake form here: ${
+    process.env.FULFILLMENT_INTAKE_FALLBACK_URL || 'https://messyandmagnetic.com/forms/intake'
+  }.\n\nWith love,\nMaggie`;
+  try {
+    await sendEmail(
+      {
+        to: intake.email,
+        subject,
+        text: body,
+        html: body.replace(/\n/g, '<br />'),
+      },
+      {
+        RESEND_FROM_EMAIL: configEmail?.fromEmail,
+        RESEND_FROM_NAME: configEmail?.fromName,
+      }
+    );
+  } catch (err) {
+    console.warn('[fulfillment.intake] unable to send missing info email:', err);
+  }
+}
+
+function mergeCustomer(base: CustomerProfile, update: Partial<CustomerProfile>): CustomerProfile {
+  return {
+    ...base,
+    ...update,
+    birth: {
+      ...(base.birth || {}),
+      ...(update.birth || {}),
+    },
+  };
+}
+
+function extractBirthFromMetadata(metadata: Stripe.Metadata | null | undefined): CustomerProfile['birth'] {
+  if (!metadata) return {};
+  const birth: CustomerProfile['birth'] = {};
+  const date = metadata['birthdate'] || metadata['birth_date'] || metadata['dob'];
+  if (typeof date === 'string') birth.date = date.trim();
+  const time = metadata['birthtime'] || metadata['birth_time'];
+  if (typeof time === 'string') birth.time = time.trim();
+  const location = metadata['birthplace'] || metadata['birth_place'] || metadata['birthlocation'];
+  if (typeof location === 'string') birth.location = location.trim();
+  const tz = metadata['timezone'] || metadata['birth_timezone'];
+  if (typeof tz === 'string') birth.timezone = tz.trim();
+  return birth;
+}
+
+function buildCustomerProfile(session: StripeSession): CustomerProfile {
+  const details = session.customer_details || {};
+  const metadata = session.metadata || {};
+  const profile: CustomerProfile = {};
+
+  const name = metadata['name'] || metadata['full_name'] || details.name || '';
+  if (name) {
+    profile.name = name;
+    const parts = splitName(name);
+    profile.firstName = metadata['first_name'] || parts.firstName;
+    profile.lastName = metadata['last_name'] || parts.lastName;
+  } else {
+    profile.firstName = metadata['first_name'] || details.name || undefined;
+    profile.lastName = metadata['last_name'] || undefined;
+  }
+  if (!profile.name && (profile.firstName || profile.lastName)) {
+    profile.name = [profile.firstName, profile.lastName].filter(Boolean).join(' ').trim();
+  }
+
+  const birth = extractBirthFromMetadata(metadata);
+  if (Object.keys(birth || {}).length) {
+    profile.birth = birth;
+  }
+  const pronouns = metadata['pronouns'];
+  if (pronouns && typeof pronouns === 'string') profile.pronouns = pronouns;
+  const partner = metadata['partner_name'] || metadata['partner'];
+  if (partner && typeof partner === 'string') profile.partnerName = partner;
+
+  return profile;
+}
+
+function deriveTierFromLineItems(lineItems: Stripe.LineItem[], skuMap: Record<string, { tier?: string; addOns?: string[] }>) {
+  let tier: FulfillmentTier | undefined;
+  const addOns = new Set<string>();
+  for (const item of lineItems) {
+    const priceId = item.price?.id;
+    if (!priceId) continue;
+    const mapping = skuMap[priceId];
+    if (!mapping) continue;
+    if (!tier && mapping.tier) tier = normalizeTier(mapping.tier) || tier;
+    for (const addOn of mapping.addOns || []) addOns.add(addOn);
+  }
+  return { tier, addOns: Array.from(addOns) };
+}
+
+function buildPrefsFromMetadata(metadata: Stripe.Metadata | null | undefined): Record<string, any> {
+  const prefs: Record<string, any> = {};
+  if (!metadata) return prefs;
+  for (const [key, value] of Object.entries(metadata)) {
+    if (value === undefined || value === null || value === '') continue;
+    const normalizedKey = key.replace(/([A-Z])/g, '_$1').toLowerCase();
+    prefs[normalizedKey] = value;
+  }
+  return prefs;
+}
+
+async function loadStripeClient(stripe?: Stripe): Promise<Stripe> {
+  if (stripe) return stripe;
+  const key = process.env.STRIPE_SECRET_KEY;
+  if (!key) throw new Error('Missing STRIPE_SECRET_KEY for Stripe intake normalization');
+  return new Stripe(key, { apiVersion: '2023-10-16' });
+}
+
+export async function normalizeFromStripe(
+  sessionId: string,
+  opts: { stripe?: Stripe; env?: any } = {}
+): Promise<NormalizedIntake> {
+  const skuMap = await loadSkuMap();
+  let config: Awaited<ReturnType<typeof loadFulfillmentConfig>> | null = null;
+  try {
+    config = await loadFulfillmentConfig(opts);
+  } catch (err) {
+    console.warn('[fulfillment.intake] continuing without full config:', err);
+  }
+  const stripe = await loadStripeClient(opts.stripe);
+  const session = (await stripe.checkout.sessions.retrieve(sessionId, {
+    expand: ['line_items.data.price.product'],
+  })) as StripeSession;
+
+  const lineItems = session.line_items?.data || [];
+  const { tier: mappedTier, addOns } = deriveTierFromLineItems(lineItems, skuMap);
+
+  const metadataTier = normalizeTier((session.metadata?.tier as string) || session.metadata?.package || '');
+  const tier = mappedTier || metadataTier;
+
+  const email = session.customer_details?.email || session.customer_email || session.metadata?.email || '';
+  const prefs = buildPrefsFromMetadata(session.metadata);
+  if (session.customer_details?.phone) prefs.phone = session.customer_details.phone;
+  if (session.customer_details?.address) prefs.address = session.customer_details.address;
+
+  const customer = buildCustomerProfile(session);
+  const normalized: NormalizedIntake = {
+    source: 'stripe',
+    email,
+    tier: tier || 'lite',
+    addOns,
+    prefs,
+    customer,
+    referenceId: session.id,
+    raw: session,
+  };
+
+  const missing: string[] = [];
+  if (!validateEmail(email)) missing.push('email');
+  if (!tier) missing.push('preferred tier');
+  if (!customer?.birth?.date) missing.push('birth date');
+
+  if (missing.length && config) {
+    await requestMissingInfo(
+      { email, missing, source: 'stripe' },
+      {
+        fromEmail: config.resendFromEmail,
+        fromName: config.resendFromName,
+      }
+    );
+  }
+
+  return normalized;
+}
+
+function parseTallyBirth(data: Record<string, any>): CustomerProfile['birth'] {
+  const birth: CustomerProfile['birth'] = {};
+  const date = data.birthdate || data.birth_date || data.dob;
+  if (typeof date === 'string') birth.date = date.trim();
+  const time = data.birthtime || data.birth_time;
+  if (typeof time === 'string') birth.time = time.trim();
+  const location = data.birthplace || data.birth_place || data.location;
+  if (typeof location === 'string') birth.location = location.trim();
+  const tz = data.birth_timezone || data.timezone;
+  if (typeof tz === 'string') birth.timezone = tz.trim();
+  return birth;
+}
+
+function parseHousehold(data: Record<string, any>): string[] | undefined {
+  const raw = data.household || data.children || data.family_members;
+  if (!raw) return undefined;
+  if (Array.isArray(raw)) return raw.map((v) => String(v));
+  if (typeof raw === 'string') {
+    return raw
+      .split(/[,\n]/)
+      .map((part) => part.trim())
+      .filter(Boolean);
+  }
+  return undefined;
+}
+
+export async function normalizeFromTally(
+  payload: any,
+  opts: { env?: any } = {}
+): Promise<NormalizedIntake> {
+  const skuMap = await loadSkuMap();
+  let config: Awaited<ReturnType<typeof loadFulfillmentConfig>> | null = null;
+  try {
+    config = await loadFulfillmentConfig(opts);
+  } catch (err) {
+    console.warn('[fulfillment.intake] continuing without full config:', err);
+  }
+  const data: Record<string, any> = payload?.data || payload || {};
+  const email = typeof data.email === 'string' ? data.email.trim() : '';
+  const tierFromField = normalizeTier(data.tier || data.package || data.selection);
+  const productId = data.productId || data.product_id || data.price_id;
+  const mapping = productId ? skuMap[String(productId)] : undefined;
+  const tier = tierFromField || normalizeTier(mapping?.tier || '');
+  const addOns = new Set<string>();
+  for (const addOn of mapping?.addOns || []) addOns.add(addOn);
+  const schedulePrefs = parseHousehold(data);
+
+  const name = data.name || `${data.first_name || ''} ${data.last_name || ''}`.trim();
+  const customer: CustomerProfile = {
+    name: name || undefined,
+    firstName: data.first_name || undefined,
+    lastName: data.last_name || undefined,
+    pronouns: data.pronouns || undefined,
+    birth: parseTallyBirth(data),
+    partnerName: data.partner || data.partner_name || undefined,
+    householdMembers: schedulePrefs,
+  };
+
+  const prefs: Record<string, any> = {};
+  for (const [key, value] of Object.entries(data)) {
+    if (value === undefined || value === null || key === 'email') continue;
+    prefs[key] = value;
+  }
+
+  const normalized: NormalizedIntake = {
+    source: 'tally',
+    email,
+    tier: tier || 'lite',
+    addOns: Array.from(addOns),
+    prefs,
+    customer,
+    referenceId: payload?.submissionId || payload?.eventId,
+    schedulePreferences: schedulePrefs,
+    raw: payload,
+  };
+
+  const missing: string[] = [];
+  if (!validateEmail(email)) missing.push('email');
+  if (!tier) missing.push('preferred tier');
+  if (!customer?.birth?.date) missing.push('birth date');
+
+  if (missing.length && config) {
+    await requestMissingInfo(
+      { email, missing, source: 'tally' },
+      {
+        fromEmail: config.resendFromEmail,
+        fromName: config.resendFromName,
+      }
+    );
+  }
+
+  return normalized;
+}
+
+export function mergeIntake(base: NormalizedIntake, update: Partial<NormalizedIntake>): NormalizedIntake {
+  return {
+    ...base,
+    ...update,
+    addOns: Array.from(new Set([...(base.addOns || []), ...(update.addOns || [])])).filter(Boolean),
+    prefs: { ...base.prefs, ...(update.prefs || {}) },
+    customer: mergeCustomer(base.customer || {}, update.customer || {}),
+  };
+}

--- a/src/fulfillment/runner.ts
+++ b/src/fulfillment/runner.ts
@@ -1,0 +1,130 @@
+import type { NormalizedIntake, FulfillmentRecord, OrderSummary } from './types';
+import { normalizeFromStripe, normalizeFromTally } from './intake';
+import { generateBlueprint } from './blueprint';
+import { buildIconBundle } from './icons';
+import { makeScheduleKit } from './schedule';
+import { deliverFulfillment } from './deliver';
+import {
+  ensureOrderWorkspace,
+  appendFulfillmentLog,
+  notifyOpsChannel,
+  recordOrderSummary,
+  loadFulfillmentConfig,
+} from './common';
+import { setLastOrderSummary } from '../queue';
+
+export type OrderReference =
+  | string
+  | { kind: 'stripe-session'; sessionId: string; env?: any }
+  | { kind: 'tally'; payload: any; env?: any }
+  | { kind: 'intake'; intake: NormalizedIntake };
+
+interface RunOptions {
+  env?: any;
+}
+
+function formatFiles(record: FulfillmentRecord): string[] {
+  return [
+    record.blueprint.docUrl,
+    record.blueprint.pdfUrl,
+    record.icons.bundleFolderUrl,
+    record.schedule.scheduleFolderUrl,
+  ].filter(Boolean);
+}
+
+async function updateNotion(record: FulfillmentRecord, env?: any) {
+  const config = record.workspace.config;
+  const databaseId = config.notionDatabaseId || process.env.FULFILLMENT_NOTION_DB_ID;
+  const token = process.env.NOTION_TOKEN || process.env.NOTION_API_KEY || env?.NOTION_TOKEN;
+  if (!databaseId || !token) return;
+  try {
+    const { Client } = await import('@notionhq/client');
+    const notion = new Client({ auth: token });
+    const properties: Record<string, any> = {
+      Name: { title: [{ text: { content: record.intake.customer.name || record.intake.email } }] },
+      Email: { email: record.intake.email },
+      Tier: { select: { name: record.intake.tier } },
+      Status: { select: { name: 'Delivered' } },
+      'Blueprint Doc': { url: record.blueprint.docUrl },
+      'Blueprint PDF': { url: record.blueprint.pdfUrl },
+      Icons: { url: record.icons.bundleFolderUrl },
+      Schedule: { url: record.schedule.scheduleFolderUrl },
+    };
+    await notion.pages.create({
+      parent: { database_id: databaseId },
+      properties,
+    });
+  } catch (err) {
+    console.warn('[fulfillment.runner] failed to update notion:', err);
+  }
+}
+
+async function resolveIntake(ref: OrderReference, opts: RunOptions): Promise<NormalizedIntake> {
+  if (typeof ref === 'string') {
+    return normalizeFromStripe(ref, { env: opts.env });
+  }
+  if ('intake' in ref) return ref.intake;
+  if (ref.kind === 'stripe-session') {
+    return normalizeFromStripe(ref.sessionId, { env: ref.env || opts.env });
+  }
+  if (ref.kind === 'tally') {
+    return normalizeFromTally(ref.payload, { env: ref.env || opts.env });
+  }
+  throw new Error('Unsupported order reference');
+}
+
+export async function runOrder(ref: OrderReference, opts: RunOptions = {}): Promise<FulfillmentRecord> {
+  let intake = await resolveIntake(ref, opts);
+  let lastError: any = null;
+  let record: FulfillmentRecord | null = null;
+  const config = await loadFulfillmentConfig(opts);
+
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const workspace = await ensureOrderWorkspace(intake, opts);
+      const blueprint = await generateBlueprint(intake, { workspace });
+      const icons = await buildIconBundle(intake, { workspace });
+      const schedule = await makeScheduleKit(intake, { workspace });
+      const delivery = await deliverFulfillment(intake, blueprint, icons, schedule, opts.env);
+      record = { intake, blueprint, icons, schedule, delivery, workspace };
+
+      const summary: OrderSummary = {
+        email: intake.email,
+        tier: intake.tier,
+        status: 'success',
+        message: 'Delivered',
+        completedAt: new Date().toISOString(),
+        files: formatFiles(record),
+      };
+
+      await appendFulfillmentLog(intake, summary, workspace.config);
+      await recordOrderSummary(summary);
+      await setLastOrderSummary(summary, opts.env);
+      await updateNotion(record, opts.env);
+      return record;
+    } catch (err) {
+      lastError = err;
+      console.warn(`[fulfillment.runner] attempt ${attempt + 1} failed:`, err);
+      if (attempt === 0) {
+        try {
+          intake = await resolveIntake({ kind: 'intake', intake }, opts);
+        } catch {}
+        continue;
+      }
+    }
+  }
+
+  const summary: OrderSummary = {
+    email: intake.email,
+    tier: intake.tier,
+    status: 'error',
+    message: lastError?.message || 'Unknown failure',
+    completedAt: new Date().toISOString(),
+    files: [],
+  };
+  await appendFulfillmentLog(intake, summary, config);
+  await recordOrderSummary(summary);
+  await setLastOrderSummary(summary, opts.env);
+  await notifyOpsChannel(`❌ Fulfillment failed for ${intake.email}: ${summary.message}`, config);
+  throw lastError || new Error('Fulfillment failed');
+}

--- a/src/fulfillment/schedule.ts
+++ b/src/fulfillment/schedule.ts
@@ -1,0 +1,161 @@
+import { Buffer } from 'buffer';
+import { ensureOrderWorkspace, ensureFolder } from './common';
+import type { NormalizedIntake, ScheduleResult, ScheduleFile, FulfillmentWorkspace } from './types';
+import type { docs_v1 } from 'googleapis';
+
+interface ScheduleContent {
+  headline: string;
+  body: string;
+}
+
+type ScheduleKind = 'daily' | 'weekly' | 'monthly';
+
+function buildDailyContent(intake: NormalizedIntake): ScheduleContent {
+  const name = intake.customer.firstName || intake.customer.name || 'your';
+  const morning = intake.prefs?.morning_focus || 'open with breath, water, and simple alignment practice';
+  const midday = intake.prefs?.midday_focus || 'focus block for creative or service work';
+  const evening = intake.prefs?.evening_focus || 'soft landing with reflection and rest';
+  const anchors = [
+    { time: '7:30a', focus: morning },
+    { time: '12:30p', focus: midday },
+    { time: '4:30p', focus: 'transition ritual to close loops and celebrate wins' },
+    { time: '9:00p', focus: evening },
+  ];
+  const lines = anchors.map((slot) => `• ${slot.time} — ${slot.focus}`);
+  return {
+    headline: `${name} daily rhythm`,
+    body: `Morning intention: ${morning}\nMidday anchor: ${midday}\nEvening ease: ${evening}\n\nSuggested cadence:\n${lines.join('\n')}`,
+  };
+}
+
+function buildWeeklyContent(intake: NormalizedIntake): ScheduleContent {
+  const themes = intake.prefs?.themes || intake.prefs?.focus || 'visibility, nourishment, community';
+  const resets = intake.prefs?.reset_day || 'Sunday';
+  const share = intake.prefs?.share_channels || 'email newsletter, social drop, personal outreach';
+  const week = [
+    { day: 'Monday', focus: 'vision + planning pulse' },
+    { day: 'Wednesday', focus: 'creation + delivery' },
+    { day: 'Friday', focus: 'celebration + check-in' },
+  ];
+  const lines = week.map((entry) => `• ${entry.day}: ${entry.focus}`);
+  return {
+    headline: 'Weekly wave',
+    body: `Key themes: ${themes}\nReset day: ${resets}\nShare / broadcast: ${share}\n\nWeekly arc:\n${lines.join('\n')}`,
+  };
+}
+
+function buildMonthlyContent(intake: NormalizedIntake): ScheduleContent {
+  const focus = intake.prefs?.season_focus || 'seasonal story, sales pulse, community care';
+  const rituals = intake.prefs?.rituals || 'new moon mapping, full moon gratitude, seasonal clean sweep';
+  const review = intake.prefs?.review || 'metrics + feeling check, client notes, offer refinement';
+  return {
+    headline: 'Monthly / seasonal cadence',
+    body: `Focus of the month: ${focus}\nRitual anchors: ${rituals}\nReview + integration: ${review}`,
+  };
+}
+
+function buildScheduleContent(intake: NormalizedIntake, kind: ScheduleKind): ScheduleContent {
+  if (kind === 'daily') return buildDailyContent(intake);
+  if (kind === 'weekly') return buildWeeklyContent(intake);
+  return buildMonthlyContent(intake);
+}
+
+async function writeScheduleDoc(
+  kind: ScheduleKind,
+  content: ScheduleContent,
+  workspace: FulfillmentWorkspace,
+  docs: docs_v1.Docs,
+  scheduleFolderId: string,
+  templateId?: string
+): Promise<ScheduleFile> {
+  const drive = workspace.drive;
+  const nameBase = `${workspace.timestamp.toISOString().slice(0, 10)} - ${content.headline}`;
+  let docId: string;
+  let docUrl = '';
+  if (templateId) {
+    const copy = await drive.files.copy({
+      fileId: templateId,
+      requestBody: {
+        name: nameBase,
+        parents: [scheduleFolderId],
+      },
+      fields: 'id, webViewLink',
+    });
+    docId = copy.data.id!;
+    docUrl = copy.data.webViewLink || '';
+  } else {
+    const created = await docs.documents.create({ requestBody: { title: nameBase } });
+    docId = created.data.documentId!;
+    await drive.files.update({ fileId: docId, addParents: scheduleFolderId, fields: 'id, webViewLink' });
+    const meta = await drive.files.get({ fileId: docId, fields: 'webViewLink' });
+    docUrl = meta.data.webViewLink || '';
+  }
+
+  const body = `${content.headline}\nGenerated ${workspace.timestamp.toLocaleString()}\n\n${content.body}`;
+  await docs.documents.batchUpdate({
+    documentId: docId,
+    requestBody: {
+      requests: [
+        { insertText: { location: { index: 1 }, text: body } },
+        {
+          replaceAllText: {
+            containsText: { text: '{{SCHEDULE_BODY}}', matchCase: false },
+            replaceText: content.body,
+          },
+        },
+      ],
+    },
+  });
+
+  const exportRes = await drive.files.export(
+    { fileId: docId, mimeType: 'application/pdf' },
+    { responseType: 'arraybuffer' }
+  );
+  const pdfBuffer = Buffer.from(exportRes.data as ArrayBuffer);
+  const pdf = await drive.files.create({
+    requestBody: {
+      name: `${content.headline}.pdf`,
+      mimeType: 'application/pdf',
+      parents: [scheduleFolderId],
+    },
+    media: { mimeType: 'application/pdf', body: pdfBuffer },
+    fields: 'id, webViewLink',
+  });
+
+  return {
+    type: kind,
+    headline: content.headline,
+    docId,
+    docUrl,
+    pdfId: pdf.data.id || '',
+    pdfUrl: pdf.data.webViewLink || '',
+  };
+}
+
+export async function makeScheduleKit(
+  intake: NormalizedIntake,
+  opts: { workspace?: FulfillmentWorkspace; env?: any } = {}
+): Promise<ScheduleResult> {
+  const workspace = opts.workspace || (await ensureOrderWorkspace(intake, opts));
+  const drive = workspace.drive;
+  const docs = workspace.docs;
+  const scheduleFolder = await ensureFolder(drive, workspace.orderFolderId, 'schedule');
+
+  const kinds: ScheduleKind[] = ['daily'];
+  if (intake.tier !== 'mini') kinds.push('weekly');
+  if (intake.tier === 'full') kinds.push('monthly');
+
+  const files: ScheduleFile[] = [];
+  for (const kind of kinds) {
+    const templateId = workspace.config.scheduleTemplates?.[kind];
+    const content = buildScheduleContent(intake, kind);
+    const file = await writeScheduleDoc(kind, content, workspace, docs, scheduleFolder.id!, templateId);
+    files.push(file);
+  }
+
+  return {
+    scheduleFolderId: scheduleFolder.id!,
+    scheduleFolderUrl: scheduleFolder.webViewLink || '',
+    files,
+  };
+}

--- a/src/fulfillment/types.ts
+++ b/src/fulfillment/types.ts
@@ -1,0 +1,135 @@
+import type { drive_v3, docs_v1 } from 'googleapis';
+
+export type FulfillmentTier = 'mini' | 'lite' | 'full';
+
+export interface BirthData {
+  date?: string;
+  time?: string;
+  location?: string;
+  timezone?: string;
+}
+
+export interface CustomerProfile {
+  name?: string;
+  firstName?: string;
+  lastName?: string;
+  pronouns?: string;
+  birth?: BirthData;
+  partnerName?: string;
+  householdMembers?: string[];
+}
+
+export interface NormalizedIntake {
+  source: 'stripe' | 'tally';
+  email: string;
+  tier: FulfillmentTier;
+  addOns: string[];
+  prefs: Record<string, any>;
+  customer: CustomerProfile;
+  referenceId?: string;
+  schedulePreferences?: string[];
+  raw?: any;
+}
+
+export interface ModelAttempt {
+  provider: 'codex' | 'claude' | 'gemini';
+  ok: boolean;
+  startedAt: string;
+  finishedAt: string;
+  error?: string;
+}
+
+export interface BlueprintResult {
+  docId: string;
+  docUrl: string;
+  pdfId: string;
+  pdfUrl: string;
+  summary: string;
+  story: string;
+  attempts: ModelAttempt[];
+  folderId: string;
+  folderUrl: string;
+}
+
+export interface IconAsset {
+  slug: string;
+  name: string;
+  description: string;
+  url: string;
+  fileId: string;
+  origin: 'library' | 'generated';
+}
+
+export interface IconBundleResult {
+  bundleFolderId: string;
+  bundleFolderUrl: string;
+  manifestId: string;
+  manifestUrl: string;
+  icons: IconAsset[];
+}
+
+export interface ScheduleFile {
+  type: 'daily' | 'weekly' | 'monthly';
+  docId: string;
+  docUrl: string;
+  pdfId: string;
+  pdfUrl: string;
+  headline: string;
+}
+
+export interface ScheduleResult {
+  scheduleFolderId: string;
+  scheduleFolderUrl: string;
+  files: ScheduleFile[];
+}
+
+export interface DeliveryReceipt {
+  channel: 'email' | 'zoho';
+  id?: string;
+}
+
+export interface FulfillmentWorkspace {
+  drive: drive_v3.Drive;
+  docs: docs_v1.Docs;
+  rootFolderId: string;
+  orderFolderId: string;
+  orderFolderUrl: string;
+  timestamp: Date;
+  config: FulfillmentConfig;
+}
+
+export interface FulfillmentConfig {
+  driveRootId: string;
+  blueprintTemplateId?: string;
+  scheduleTemplates?: {
+    daily?: string;
+    weekly?: string;
+    monthly?: string;
+  };
+  intakeFallbackFormUrl?: string;
+  sheetId?: string;
+  notionDatabaseId?: string;
+  telegramChatId?: string;
+  telegramBotToken?: string;
+  iconLibraryFolderId?: string;
+  resendFromEmail?: string;
+  resendFromName?: string;
+}
+
+export interface FulfillmentRecord {
+  intake: NormalizedIntake;
+  blueprint: BlueprintResult;
+  icons: IconBundleResult;
+  schedule: ScheduleResult;
+  delivery: DeliveryReceipt[];
+  workspace: FulfillmentWorkspace;
+}
+
+export interface OrderSummary {
+  email: string;
+  tier: FulfillmentTier;
+  status: 'success' | 'error';
+  message: string;
+  completedAt: string;
+  files: string[];
+}

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,0 +1,160 @@
+import { randomUUID } from 'crypto';
+import path from 'path';
+import { readFile, writeFile, mkdir } from 'fs/promises';
+import type { OrderSummary } from './fulfillment/types';
+
+export interface FulfillmentJob {
+  id: string;
+  source: 'stripe' | 'tally';
+  payload: any;
+  attempts: number;
+  createdAt: string;
+  metadata?: Record<string, any>;
+}
+
+interface QueueState {
+  jobs: FulfillmentJob[];
+  lastSummary?: OrderSummary | null;
+}
+
+const QUEUE_KEY = 'fulfillment:queue';
+const LAST_KEY = 'fulfillment:last';
+const FALLBACK_PATH = path.resolve(process.cwd(), 'queue.json');
+
+let memoryState: QueueState | null = null;
+
+function isNode(): boolean {
+  return typeof process !== 'undefined' && !!process.versions?.node;
+}
+
+async function readFromEnv(env: any, key: string): Promise<string | null> {
+  try {
+    if (env?.BRAIN && typeof env.BRAIN.get === 'function') {
+      const value = await env.BRAIN.get(key);
+      if (typeof value === 'string') return value;
+    }
+  } catch (err) {
+    console.warn('[queue] failed to read from env KV:', err);
+  }
+  return null;
+}
+
+async function writeToEnv(env: any, key: string, value: string): Promise<void> {
+  try {
+    if (env?.BRAIN && typeof env.BRAIN.put === 'function') {
+      await env.BRAIN.put(key, value);
+    }
+  } catch (err) {
+    console.warn('[queue] failed to write to env KV:', err);
+  }
+}
+
+async function readFallback(): Promise<QueueState | null> {
+  if (!isNode()) return null;
+  try {
+    const raw = await readFile(FALLBACK_PATH, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+async function writeFallback(state: QueueState): Promise<void> {
+  if (!isNode()) return;
+  try {
+    await mkdir(path.dirname(FALLBACK_PATH), { recursive: true });
+    await writeFile(FALLBACK_PATH, JSON.stringify(state, null, 2));
+  } catch (err) {
+    console.warn('[queue] failed to write fallback file:', err);
+  }
+}
+
+async function loadState(env?: any): Promise<QueueState> {
+  if (memoryState) return memoryState;
+  const raw = await readFromEnv(env, QUEUE_KEY);
+  if (raw) {
+    try {
+      memoryState = JSON.parse(raw);
+      return memoryState!;
+    } catch (err) {
+      console.warn('[queue] failed to parse KV state:', err);
+    }
+  }
+  const fallback = await readFallback();
+  if (fallback) {
+    memoryState = fallback;
+    return fallback;
+  }
+  memoryState = { jobs: [], lastSummary: null };
+  return memoryState;
+}
+
+async function saveState(state: QueueState, env?: any): Promise<void> {
+  memoryState = state;
+  const serialized = JSON.stringify(state);
+  await writeToEnv(env, QUEUE_KEY, serialized);
+  await writeFallback(state);
+}
+
+function ensureJob(job: Partial<FulfillmentJob>): FulfillmentJob {
+  return {
+    id: job.id || randomUUID(),
+    source: job.source || 'stripe',
+    payload: job.payload,
+    attempts: job.attempts ?? 0,
+    createdAt: job.createdAt || new Date().toISOString(),
+    metadata: job.metadata || {},
+  };
+}
+
+export async function enqueueFulfillmentJob(
+  job: Partial<FulfillmentJob>,
+  env?: any
+): Promise<FulfillmentJob> {
+  const state = await loadState(env);
+  const full = ensureJob(job);
+  state.jobs.push(full);
+  await saveState(state, env);
+  return full;
+}
+
+export async function dequeueFulfillmentJob(env?: any): Promise<FulfillmentJob | null> {
+  const state = await loadState(env);
+  const job = state.jobs.shift() || null;
+  if (job) await saveState(state, env);
+  return job;
+}
+
+export async function listQueuedJobs(env?: any): Promise<FulfillmentJob[]> {
+  const state = await loadState(env);
+  return [...state.jobs];
+}
+
+export async function requeueJob(job: FulfillmentJob, env?: any): Promise<void> {
+  const state = await loadState(env);
+  job.attempts += 1;
+  state.jobs.push(job);
+  await saveState(state, env);
+}
+
+export async function setLastOrderSummary(summary: OrderSummary, env?: any): Promise<void> {
+  const state = await loadState(env);
+  state.lastSummary = summary;
+  await saveState(state, env);
+  await writeToEnv(env, LAST_KEY, JSON.stringify(summary));
+}
+
+export async function getLastOrderSummary(env?: any): Promise<OrderSummary | null> {
+  const state = await loadState(env);
+  if (state.lastSummary) return state.lastSummary;
+  const raw = await readFromEnv(env, LAST_KEY);
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw);
+      state.lastSummary = parsed;
+      return parsed;
+    } catch {}
+  }
+  const fallback = await readFallback();
+  return fallback?.lastSummary ?? null;
+}

--- a/worker/orders/stripe.ts
+++ b/worker/orders/stripe.ts
@@ -1,0 +1,51 @@
+import Stripe from 'stripe';
+import type { KVNamespace } from '@cloudflare/workers-types';
+import { enqueueFulfillmentJob } from '../../src/queue';
+
+interface Env {
+  STRIPE_SECRET_KEY?: string;
+  STRIPE_WEBHOOK_SECRET?: string;
+  BRAIN?: KVNamespace;
+}
+
+export async function onRequestPost({ request, env }: { request: Request; env: Env }) {
+  const key = env.STRIPE_SECRET_KEY || process.env.STRIPE_SECRET_KEY;
+  const stripe = key ? new Stripe(key, { apiVersion: '2023-10-16' }) : null;
+  const secret = env.STRIPE_WEBHOOK_SECRET || process.env.STRIPE_WEBHOOK_SECRET;
+  const signature = request.headers.get('stripe-signature');
+  const rawBody = await request.text();
+
+  let event: Stripe.Event;
+  try {
+    if (secret && signature && stripe) {
+      event = stripe.webhooks.constructEvent(rawBody, signature, secret);
+    } else {
+      event = JSON.parse(rawBody || '{}');
+    }
+  } catch (err) {
+    return new Response(JSON.stringify({ ok: false, error: 'invalid-signature' }), {
+      status: 400,
+      headers: { 'content-type': 'application/json' },
+    });
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object as Stripe.Checkout.Session;
+    const sessionId = session.id;
+    if (sessionId) {
+      await enqueueFulfillmentJob(
+        {
+          source: 'stripe',
+          payload: { sessionId },
+          metadata: { eventId: event.id },
+        },
+        env
+      );
+    }
+  }
+
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/worker/routes/orders.ts
+++ b/worker/routes/orders.ts
@@ -1,5 +1,11 @@
+import { getLastOrderSummary } from "../../src/queue";
+
 export async function onRequestGet({ request, env }: { request: Request; env: any }) {
   const url = new URL(request.url);
+  if (url.pathname === "/ops/recent-order") {
+    const summary = await getLastOrderSummary(env);
+    return json({ ok: true, summary });
+  }
   if (url.pathname !== "/orders/list") return json({ ok: false }, 404);
 
   const email = url.searchParams.get("email")?.trim();


### PR DESCRIPTION
## Summary
- add fulfillment modules to normalize Stripe/Tally intake, generate blueprints, assemble icon bundles, build schedule kits, deliver email, and orchestrate self-healing runs
- introduce a KV-backed fulfillment queue, Stripe/Tally webhook handlers, and an ops route to expose the latest run status
- document the pipeline, provide SKU/icon configuration maps, and wire Notion/Sheets logging hooks in the runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0a5a5582c8327a56d583a516a76c0