### PR TITLE
feat: add site publish command and social automation

### DIFF
--- a/.github/workflows/social-loop.yml
+++ b/.github/workflows/social-loop.yml
@@ -1,0 +1,46 @@
+name: Social Loop
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 */2 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CF_KV_POSTQ_NAMESPACE_ID: ${{ secrets.CF_KV_POSTQ_NAMESPACE_ID }}
+      WORKER_URL: ${{ secrets.WORKER_URL }}
+      WORKER_BASE_URL: ${{ secrets.WORKER_URL }}
+      BROWSERLESS_BASE_URL: ${{ secrets.BROWSERLESS_BASE_URL }}
+      BROWSERLESS_API_KEY: ${{ secrets.BROWSERLESS_API_KEY }}
+      TIKTOK_PROFILE_MAIN: ${{ secrets.TIKTOK_PROFILE_MAIN }}
+      TIKTOK_PROFILE_MAGGIE: ${{ secrets.TIKTOK_PROFILE_MAGGIE }}
+      TIKTOK_PROFILE_WILLOW: ${{ secrets.TIKTOK_PROFILE_WILLOW }}
+      TIKTOK_PROFILE_MARS: ${{ secrets.TIKTOK_PROFILE_MARS }}
+      TIKTOK_SESSION_MAIN: ${{ secrets.TIKTOK_SESSION_MAIN }}
+      TIKTOK_SESSION_MAGGIE: ${{ secrets.TIKTOK_SESSION_MAGGIE }}
+      TIKTOK_SESSION_WILLOW: ${{ secrets.TIKTOK_SESSION_WILLOW }}
+      TIKTOK_SESSION_MARS: ${{ secrets.TIKTOK_SESSION_MARS }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Maggie social loop
+        run: npx tsx scripts/runMaggie.ts

--- a/README.md
+++ b/README.md
@@ -16,6 +16,17 @@ Use the private Telegram bot to run Maggie without opening GitHub:
 - `/start-sync` seeds Cloudflare KV with the latest brain payload, verifies `/diag/config`, and logs the run to Google Sheets.
 - `/maggie-status` reports the most recent brain sync, worker `/health`, recent task log entries, and any errors from the past 24 hours.
 - `/maggie-help` lists all supported chat commands.
+- `/status` checks Worker health, Browserless credentials, and TikTok session coverage from Telegram.
+- `/publish-site` deploys everything in `site/` directly to the Cloudflare Worker routes for `messyandmagnetic.com` and `assistant.messyandmagnetic.com`.
+- `/self-heal` restarts Browserless/Puppeteer flows and verifies TikTok sessions, reporting the results back to chat.
+
+Run `npx tsx scripts/runTelegram.ts` on a box with secrets loaded to keep the Telegram bridge online.
+
+## Automation loops
+
+- `scripts/publishSite.ts` publishes static HTML/CSS/JS from `site/` into Cloudflare KV and logs each deploy to Telegram.
+- `scripts/selfHeal.ts` retries Browserless, Puppeteer, and TikTok session health checks, sending a consolidated report.
+- `scripts/runMaggie.ts` orchestrates the social loop (TikTok boosters + Browserless warmup) and posts a summary to Telegram. GitHub Action **Social Loop** (`.github/workflows/social-loop.yml`) runs every two hours and on manual dispatch to execute this script.
 
 ### Pellet Cleaner
 Run `pnpm run clean:pellets` to nuke local node_modules and .pnpm-store, prune old packages, and reinstall fresh.

--- a/scripts/lib/telegramClient.ts
+++ b/scripts/lib/telegramClient.ts
@@ -1,0 +1,59 @@
+import process from 'node:process';
+
+export interface TelegramMessageOptions {
+  chatId?: string;
+  parseMode?: 'HTML' | 'MarkdownV2' | 'Markdown' | undefined;
+  disableLinkPreview?: boolean;
+}
+
+export interface TelegramResult {
+  ok: boolean;
+  status?: number;
+  error?: string;
+}
+
+function getTelegramCredentials() {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.TELEGRAM_CHAT_ID;
+  return { token, chatId };
+}
+
+export async function sendTelegramMessage(
+  text: string,
+  options: TelegramMessageOptions = {},
+): Promise<TelegramResult> {
+  const { token, chatId: defaultChatId } = getTelegramCredentials();
+  const chatId = options.chatId ?? defaultChatId;
+
+  if (!token || !chatId) {
+    console.warn('[telegram] Missing TELEGRAM_BOT_TOKEN or TELEGRAM_CHAT_ID');
+    return { ok: false, error: 'missing-credentials' };
+  }
+
+  const url = `https://api.telegram.org/bot${token}/sendMessage`;
+  const body = {
+    chat_id: chatId,
+    text,
+    parse_mode: options.parseMode ?? 'HTML',
+    disable_web_page_preview: options.disableLinkPreview ?? true,
+  };
+
+  try {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      console.error('[telegram] Failed to send message:', response.status, detail);
+      return { ok: false, status: response.status, error: detail || 'telegram-error' };
+    }
+
+    return { ok: true, status: response.status };
+  } catch (err) {
+    console.error('[telegram] Network error:', err);
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/scripts/publishSite.ts
+++ b/scripts/publishSite.ts
@@ -1,0 +1,336 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+import process from 'node:process';
+import { sendTelegramMessage } from './lib/telegramClient';
+
+const SITE_PREFIX = 'site:';
+const RESERVED_KEYS = new Set([`${SITE_PREFIX}manifest`]);
+
+interface PublishSiteOptions {
+  triggeredBy?: string;
+  notify?: boolean;
+}
+
+interface CloudflareCredentials {
+  accountId: string;
+  apiToken: string;
+  namespaceId: string;
+}
+
+interface SiteAssetRecord {
+  path: string;
+  contentType: string;
+  encoding: 'base64';
+  content: string;
+  hash: string;
+  size: number;
+  deployedAt: string;
+}
+
+interface PublishSiteResult {
+  manifest: {
+    generatedAt: string;
+    triggeredBy?: string;
+    assetCount: number;
+    assets: Record<string, {
+      hash: string;
+      size: number;
+      contentType: string;
+      deployedAt: string;
+    }>;
+  };
+  removedKeys: string[];
+}
+
+function ensureSiteDir(): string {
+  const dir = path.resolve('site');
+  return dir;
+}
+
+async function pathExists(target: string): Promise<boolean> {
+  try {
+    await fs.stat(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readSiteFiles(baseDir: string): Promise<string[]> {
+  async function walk(dir: string): Promise<string[]> {
+    const entries = await fs.readdir(dir, { withFileTypes: true });
+    const files: string[] = [];
+    for (const entry of entries) {
+      if (entry.name.startsWith('.')) continue;
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        files.push(...(await walk(fullPath)));
+      } else {
+        files.push(fullPath);
+      }
+    }
+    return files;
+  }
+
+  return walk(baseDir);
+}
+
+function guessMimeType(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case '.html':
+      return 'text/html; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.js':
+      return 'application/javascript; charset=utf-8';
+    case '.mjs':
+      return 'application/javascript; charset=utf-8';
+    case '.json':
+      return 'application/json; charset=utf-8';
+    case '.svg':
+      return 'image/svg+xml';
+    case '.png':
+      return 'image/png';
+    case '.jpg':
+    case '.jpeg':
+      return 'image/jpeg';
+    case '.gif':
+      return 'image/gif';
+    case '.webp':
+      return 'image/webp';
+    case '.ico':
+      return 'image/x-icon';
+    case '.txt':
+      return 'text/plain; charset=utf-8';
+    case '.xml':
+      return 'application/xml; charset=utf-8';
+    case '.woff':
+      return 'font/woff';
+    case '.woff2':
+      return 'font/woff2';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+function toBase64(buffer: Buffer): string {
+  return buffer.toString('base64');
+}
+
+function sha256(buffer: Buffer): string {
+  return crypto.createHash('sha256').update(buffer).digest('hex');
+}
+
+function getCloudflareCredentials(): CloudflareCredentials {
+  const accountId =
+    process.env.CLOUDFLARE_ACCOUNT_ID ||
+    process.env.CF_ACCOUNT_ID ||
+    '';
+  const apiToken =
+    process.env.CLOUDFLARE_API_TOKEN ||
+    process.env.CF_API_TOKEN ||
+    '';
+  const namespaceId =
+    process.env.CF_KV_POSTQ_NAMESPACE_ID ||
+    process.env.CF_KV_NAMESPACE_ID ||
+    '';
+
+  if (!accountId || !apiToken || !namespaceId) {
+    throw new Error(
+      'Missing Cloudflare credentials. Ensure CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN, and CF_KV_POSTQ_NAMESPACE_ID are set.',
+    );
+  }
+
+  return { accountId, apiToken, namespaceId };
+}
+
+async function putKvValue(
+  creds: CloudflareCredentials,
+  key: string,
+  body: string,
+  contentType: string,
+): Promise<void> {
+  const base = `https://api.cloudflare.com/client/v4/accounts/${creds.accountId}/storage/kv/namespaces/${creds.namespaceId}`;
+  const url = `${base}/values/${encodeURIComponent(key)}`;
+  const res = await fetch(url, {
+    method: 'PUT',
+    headers: {
+      Authorization: `Bearer ${creds.apiToken}`,
+      'Content-Type': contentType,
+    },
+    body,
+  });
+
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`Failed to write ${key}: ${res.status}${detail ? ` ${detail}` : ''}`);
+  }
+}
+
+async function deleteKvKey(creds: CloudflareCredentials, key: string): Promise<void> {
+  const base = `https://api.cloudflare.com/client/v4/accounts/${creds.accountId}/storage/kv/namespaces/${creds.namespaceId}`;
+  const url = `${base}/values/${encodeURIComponent(key)}`;
+  const res = await fetch(url, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${creds.apiToken}`,
+    },
+  });
+
+  if (!res.ok && res.status !== 404) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`Failed to delete ${key}: ${res.status}${detail ? ` ${detail}` : ''}`);
+  }
+}
+
+async function listExistingSiteKeys(creds: CloudflareCredentials): Promise<Set<string>> {
+  const keys = new Set<string>();
+  let cursor: string | undefined;
+  const base = `https://api.cloudflare.com/client/v4/accounts/${creds.accountId}/storage/kv/namespaces/${creds.namespaceId}/keys`;
+
+  do {
+    const previousCursor = cursor;
+    const url = new URL(base);
+    url.searchParams.set('prefix', SITE_PREFIX);
+    if (cursor) url.searchParams.set('cursor', cursor);
+
+    const res = await fetch(url.toString(), {
+      headers: { Authorization: `Bearer ${creds.apiToken}` },
+    });
+
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '');
+      throw new Error(`Failed to list site keys: ${res.status}${detail ? ` ${detail}` : ''}`);
+    }
+
+    const data: any = await res.json();
+    const result = Array.isArray(data?.result) ? data.result : [];
+    for (const entry of result) {
+      if (entry?.name) keys.add(String(entry.name));
+    }
+
+    const info = data?.result_info ?? {};
+    const nextCursor = typeof info.cursor === 'string' && info.cursor.length > 0
+      ? info.cursor
+      : undefined;
+
+    if (info.list_complete || !nextCursor || nextCursor === previousCursor) {
+      cursor = undefined;
+    } else {
+      cursor = nextCursor;
+    }
+  } while (cursor);
+
+  return keys;
+}
+
+async function buildAssetRecords(baseDir: string, files: string[], deployedAt: string) {
+  const records: SiteAssetRecord[] = [];
+  for (const absolute of files) {
+    const buffer = await fs.readFile(absolute);
+    const relative = path.relative(baseDir, absolute).replace(/\\/g, '/');
+    const contentType = guessMimeType(relative);
+    records.push({
+      path: relative,
+      contentType,
+      encoding: 'base64',
+      content: toBase64(buffer),
+      hash: sha256(buffer),
+      size: buffer.byteLength,
+      deployedAt,
+    });
+  }
+  return records;
+}
+
+export async function publishSite(options: PublishSiteOptions = {}): Promise<PublishSiteResult> {
+  const siteDir = ensureSiteDir();
+  const exists = await pathExists(siteDir);
+  if (!exists) {
+    throw new Error(`Site directory not found at ${siteDir}`);
+  }
+
+  const files = await readSiteFiles(siteDir);
+  if (!files.length) {
+    throw new Error('No files found in site/. Nothing to publish.');
+  }
+
+  const deployedAt = new Date().toISOString();
+  const records = await buildAssetRecords(siteDir, files, deployedAt);
+  const creds = getCloudflareCredentials();
+
+  console.log(`📦 Publishing ${records.length} assets to Cloudflare KV...`);
+
+  const existingKeys = await listExistingSiteKeys(creds);
+  const writtenKeys = new Set<string>();
+
+  for (const record of records) {
+    const key = `${SITE_PREFIX}${record.path}`;
+    writtenKeys.add(key);
+    const payload = JSON.stringify(record);
+    await putKvValue(creds, key, payload, 'application/json');
+    console.log(`  • uploaded ${record.path} (${record.size} bytes)`);
+  }
+
+  const manifestEntries: PublishSiteResult['manifest']['assets'] = {};
+  for (const record of records) {
+    manifestEntries[record.path] = {
+      hash: record.hash,
+      size: record.size,
+      contentType: record.contentType,
+      deployedAt: record.deployedAt,
+    };
+  }
+
+  const manifest = {
+    generatedAt: deployedAt,
+    triggeredBy: options.triggeredBy,
+    assetCount: records.length,
+    assets: manifestEntries,
+  };
+
+  await putKvValue(
+    creds,
+    `${SITE_PREFIX}manifest`,
+    JSON.stringify(manifest, null, 2),
+    'application/json',
+  );
+
+  const removed: string[] = [];
+  for (const key of existingKeys) {
+    if (RESERVED_KEYS.has(key)) continue;
+    if (!writtenKeys.has(key)) {
+      await deleteKvKey(creds, key);
+      removed.push(key);
+      console.log(`  • removed stale key ${key}`);
+    }
+  }
+
+  const summary = `🚀 <b>Site deployed</b>\n• Files: <code>${records.length}</code>\n• Removed: <code>${removed.length}</code>\n• Triggered by: <b>${options.triggeredBy || 'manual'}</b>`;
+  if (options.notify !== false) {
+    await sendTelegramMessage(summary).catch(() => undefined);
+  }
+
+  return { manifest, removedKeys: removed };
+}
+
+async function runCli() {
+  const triggeredBy = process.env.GITHUB_WORKFLOW
+    ? `workflow:${process.env.GITHUB_WORKFLOW}`
+    : 'manual';
+  try {
+    const result = await publishSite({ triggeredBy });
+    console.log('✅ Publish complete:', JSON.stringify(result.manifest, null, 2));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('❌ Publish failed:', message);
+    await sendTelegramMessage(`❌ <b>Site deploy failed</b>\n<code>${message}</code>`).catch(() => undefined);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === new URL(`file://${process.argv[1] ?? ''}`).href) {
+  runCli();
+}

--- a/scripts/runMaggie.ts
+++ b/scripts/runMaggie.ts
@@ -1,0 +1,149 @@
+import process from 'node:process';
+import { readFile } from 'node:fs/promises';
+import { selfHeal } from './selfHeal';
+import { sendTelegramMessage } from './lib/telegramClient';
+
+interface BoosterPlan {
+  handle: string;
+  offsetSec: number;
+}
+
+interface ActionLog {
+  ok: boolean;
+  message: string;
+}
+
+async function loadBoosterHandles(): Promise<string[]> {
+  try {
+    const raw = await readFile('data/accounts.json', 'utf8');
+    const data = JSON.parse(raw);
+    if (!Array.isArray(data)) return [];
+    return data
+      .filter((entry) => entry?.role === 'booster' && typeof entry?.username === 'string')
+      .map((entry) => String(entry.username))
+      .filter((value, index, array) => value.trim().length > 0 && array.indexOf(value) === index);
+  } catch (err) {
+    console.warn('[runMaggie] Unable to load booster handles:', err);
+    return [];
+  }
+}
+
+function buildBoosterPlan(handles: string[]): BoosterPlan[] {
+  return handles.map((handle, index) => ({ handle, offsetSec: 45 * (index + 1) }));
+}
+
+async function orchestrateTikTok(workerUrl: string): Promise<ActionLog[]> {
+  const logs: ActionLog[] = [];
+  const base = workerUrl.replace(/\/$/, '');
+
+  const boosters = buildBoosterPlan(await loadBoosterHandles());
+  if (boosters.length) {
+    try {
+      const res = await fetch(`${base}/tiktok/eng/orchestrate`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          boosters,
+          source: 'github-action',
+          triggeredAt: new Date().toISOString(),
+        }),
+      });
+      if (res.ok) {
+        logs.push({ ok: true, message: `Queued booster engagement for ${boosters.length} handle(s).` });
+      } else {
+        const detail = await res.text().catch(() => '');
+        logs.push({ ok: false, message: `Failed to queue boosters (HTTP ${res.status} ${detail})` });
+      }
+    } catch (err) {
+      logs.push({ ok: false, message: `Booster request error: ${err instanceof Error ? err.message : String(err)}` });
+    }
+  } else {
+    logs.push({ ok: false, message: 'No booster handles configured.' });
+  }
+
+  const whenISO = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+  try {
+    const res = await fetch(`${base}/tiktok/schedule`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ whenISO }),
+    });
+    if (res.ok) {
+      logs.push({ ok: true, message: `Scheduled next TikTok run for ${whenISO}.` });
+    } else {
+      logs.push({ ok: false, message: `Failed to schedule TikTok run (HTTP ${res.status}).` });
+    }
+  } catch (err) {
+    logs.push({ ok: false, message: `TikTok schedule error: ${err instanceof Error ? err.message : String(err)}` });
+  }
+
+  try {
+    const res = await fetch(`${base}/tiktok/review-queue`);
+    if (res.ok) {
+      const data = await res.json().catch(() => ({}));
+      const length = Array.isArray(data?.review) ? data.review.length : 0;
+      logs.push({ ok: true, message: `Review queue currently has ${length} item(s).` });
+    } else {
+      logs.push({ ok: false, message: `Unable to read review queue (HTTP ${res.status}).` });
+    }
+  } catch (err) {
+    logs.push({ ok: false, message: `Review queue error: ${err instanceof Error ? err.message : String(err)}` });
+  }
+
+  return logs;
+}
+
+function summarizeActions(actions: ActionLog[]): string {
+  return actions
+    .map((action) => `${action.ok ? '✅' : '⚠️'} ${action.message}`)
+    .join('\n');
+}
+
+async function main() {
+  const startedAt = new Date().toISOString();
+  console.log('[runMaggie] Social loop starting at', startedAt);
+  await sendTelegramMessage('📣 <b>Maggie social loop</b> run started.').catch(() => undefined);
+
+  const healSummary = await selfHeal({ triggeredBy: 'social-loop', notify: false });
+  const healLines = healSummary.results
+    .map((result) => {
+      const icon =
+        result.status === 'ok'
+          ? '✅'
+          : result.status === 'recovered'
+            ? '🟡'
+            : result.status === 'skipped'
+              ? '⚪️'
+              : '❌';
+      return `${icon} <b>${result.service}</b> — ${result.message}`;
+    })
+    .join('\n');
+
+  const workerUrl = process.env.WORKER_URL || process.env.WORKER_BASE_URL || '';
+  let actionLines = '⚠️ WORKER_URL not configured — skipped TikTok orchestration.';
+  if (workerUrl) {
+    const actions = await orchestrateTikTok(workerUrl);
+    actionLines = summarizeActions(actions);
+  }
+
+  const finishedAt = new Date().toISOString();
+  console.log('[runMaggie] Social loop finished at', finishedAt);
+
+  const summaryMessage = [
+    '📣 <b>Maggie social loop complete</b>',
+    healLines,
+    actionLines,
+    `⏱️ <i>${startedAt} → ${finishedAt}</i>`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  await sendTelegramMessage(summaryMessage).catch(() => undefined);
+}
+
+main().catch((err) => {
+  console.error('[runMaggie] Fatal error:', err);
+  const message = err instanceof Error ? err.message : String(err);
+  sendTelegramMessage(`❌ <b>Maggie social loop failed</b>\n<code>${message}</code>`).catch(() => undefined);
+  process.exitCode = 1;
+});

--- a/scripts/runTelegram.ts
+++ b/scripts/runTelegram.ts
@@ -1,0 +1,214 @@
+import { publishSite } from './publishSite';
+import { selfHeal } from './selfHeal';
+import { sendTelegramMessage } from './lib/telegramClient';
+
+const POLL_TIMEOUT_SEC = 30;
+const ERROR_BACKOFF_MS = 5000;
+
+interface TelegramUpdate {
+  update_id: number;
+  message?: {
+    message_id: number;
+    text?: string;
+    chat: { id: number; type: string; title?: string; username?: string; first_name?: string; last_name?: string };
+    from?: { id: number; username?: string; first_name?: string; last_name?: string };
+  };
+}
+
+function getToken(): string {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  if (!token) {
+    throw new Error('TELEGRAM_BOT_TOKEN is required for runTelegram.ts');
+  }
+  return token;
+}
+
+function allowedChat(chatId: string): boolean {
+  const configured = process.env.TELEGRAM_CHAT_ID;
+  return !configured || configured === chatId;
+}
+
+async function sendReply(chatId: string, text: string) {
+  await sendTelegramMessage(text, { chatId }).catch((err) => {
+    console.error('[telegram] Failed to send reply:', err);
+  });
+}
+
+async function notifyDefaultChannel(text: string, sourceChatId: string) {
+  const configured = process.env.TELEGRAM_CHAT_ID;
+  if (!configured || configured === sourceChatId) return;
+  await sendTelegramMessage(text).catch(() => undefined);
+}
+
+async function fetchUpdates(token: string, offset: number): Promise<TelegramUpdate[] | null> {
+  const url = new URL(`https://api.telegram.org/bot${token}/getUpdates`);
+  url.searchParams.set('timeout', String(POLL_TIMEOUT_SEC));
+  url.searchParams.set('offset', String(offset));
+
+  try {
+    const res = await fetch(url.toString());
+    const data = await res.json();
+    if (!data?.ok) {
+      console.warn('[telegram] getUpdates returned non-ok response:', data);
+      return null;
+    }
+    return Array.isArray(data.result) ? data.result : [];
+  } catch (err) {
+    console.error('[telegram] getUpdates error:', err);
+    return null;
+  }
+}
+
+async function fetchWorkerHealth(): Promise<string> {
+  const workerUrl = process.env.WORKER_URL || process.env.WORKER_BASE_URL;
+  if (!workerUrl) return '⚠️ Worker URL not configured';
+  try {
+    const res = await fetch(`${workerUrl.replace(/\/$/, '')}/health`);
+    if (!res.ok) return `❌ Worker health HTTP ${res.status}`;
+    const body = await res.text().catch(() => 'ok');
+    return `✅ Worker responded ${res.status} (${body.slice(0, 80)})`;
+  } catch (err) {
+    return `❌ Worker health error: ${err instanceof Error ? err.message : String(err)}`;
+  }
+}
+
+function describeBrowserless(): string {
+  const base = process.env.BROWSERLESS_BASE_URL || process.env.BROWSERLESS_API_URL;
+  const key = process.env.BROWSERLESS_API_KEY || process.env.BROWSERLESS_TOKEN;
+  if (!base) return '⚠️ No Browserless base URL';
+  return key ? `✅ Browserless configured (${base})` : `🟡 Browserless URL set (${base}) but API key missing`;
+}
+
+function describeTikTokSessions(): string {
+  const sessions = [
+    process.env.TIKTOK_SESSION_MAIN,
+    process.env.TIKTOK_SESSION_MAGGIE,
+    process.env.TIKTOK_SESSION_WILLOW,
+    process.env.TIKTOK_SESSION_MARS,
+  ].filter((value): value is string => !!value && value.trim().length > 0);
+  if (!sessions.length) return '⚠️ No TikTok session cookies loaded';
+  return `✅ ${sessions.length} TikTok session cookie(s) present`;
+}
+
+async function handleStatus(chatId: string) {
+  const [worker, browserless, tikTok] = await Promise.all([
+    fetchWorkerHealth(),
+    Promise.resolve(describeBrowserless()),
+    Promise.resolve(describeTikTokSessions()),
+  ]);
+
+  const timestamp = new Date().toISOString();
+  const message = `🛰️ <b>Maggie Status</b>\n${worker}\n${browserless}\n${tikTok}\n⏱️ <i>${timestamp}</i>`;
+  await sendReply(chatId, message);
+}
+
+async function handlePublish(chatId: string) {
+  await sendReply(chatId, '🚀 Deploying latest <code>site/</code> assets…');
+  try {
+    const result = await publishSite({ triggeredBy: 'telegram', notify: false });
+    const summary = `🚀 <b>Site deployed</b>\n• Files: <code>${result.manifest.assetCount}</code>\n• Removed: <code>${result.removedKeys.length}</code>\n• Triggered by: <b>telegram</b>`;
+    await sendReply(chatId, summary);
+    await notifyDefaultChannel(summary, chatId);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const text = `❌ <b>Site deploy failed</b>\n<code>${message}</code>`;
+    await sendReply(chatId, text);
+    await notifyDefaultChannel(text, chatId);
+  }
+}
+
+async function handleSelfHeal(chatId: string) {
+  await sendReply(chatId, '🛠️ Running Maggie self-heal…');
+  try {
+    const summary = await selfHeal({ triggeredBy: 'telegram', notify: false });
+    const lines = summary.results
+      .map((result) => {
+        const icon =
+          result.status === 'ok'
+            ? '✅'
+            : result.status === 'recovered'
+              ? '🟡'
+              : result.status === 'skipped'
+                ? '⚪️'
+                : '❌';
+        return `${icon} <b>${result.service}</b> — ${result.message}`;
+      })
+      .join('\n');
+    const text = `🛠️ <b>Self-heal complete</b>\n${lines}\n⏱️ <i>${summary.startedAt} → ${summary.finishedAt}</i>`;
+    await sendReply(chatId, text);
+    await notifyDefaultChannel(text, chatId);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const text = `❌ <b>Self-heal crashed</b>\n<code>${message}</code>`;
+    await sendReply(chatId, text);
+    await notifyDefaultChannel(text, chatId);
+  }
+}
+
+async function handleCommand(chatId: string, text: string) {
+  const [raw] = text.trim().split(/\s+/);
+  if (!raw.startsWith('/')) return;
+  const command = raw.toLowerCase().split('@')[0];
+  console.log('[telegram] Received command', command, 'from chat', chatId);
+
+  switch (command) {
+    case '/status':
+      await handleStatus(chatId);
+      break;
+    case '/publish-site':
+      await handlePublish(chatId);
+      break;
+    case '/self-heal':
+      await handleSelfHeal(chatId);
+      break;
+    default:
+      await sendReply(chatId, '🤖 Unknown command. Try /status, /publish-site, or /self-heal.');
+  }
+}
+
+async function processUpdate(update: TelegramUpdate): Promise<number> {
+  const message = update.message;
+  if (!message?.text) return update.update_id + 1;
+
+  const chatId = String(message.chat.id);
+  if (!allowedChat(chatId)) {
+    console.warn('[telegram] Ignoring message from unauthorized chat', chatId);
+    return update.update_id + 1;
+  }
+
+  try {
+    await handleCommand(chatId, message.text);
+  } catch (err) {
+    console.error('[telegram] Failed to process command:', err);
+    await sendReply(chatId, '❌ Maggie hit an error running that command. Check logs for details.');
+  }
+
+  return update.update_id + 1;
+}
+
+async function runLoop() {
+  const token = getToken();
+  let offset = 0;
+  console.log('[telegram] Listening for commands…');
+
+  while (true) {
+    const updates = await fetchUpdates(token, offset);
+    if (!updates) {
+      await new Promise((resolve) => setTimeout(resolve, ERROR_BACKOFF_MS));
+      continue;
+    }
+
+    if (!updates.length) {
+      continue;
+    }
+
+    for (const update of updates) {
+      offset = await processUpdate(update);
+    }
+  }
+}
+
+runLoop().catch((err) => {
+  console.error('[telegram] Uncaught error in runTelegram.ts:', err);
+  process.exitCode = 1;
+});

--- a/scripts/selfHeal.ts
+++ b/scripts/selfHeal.ts
@@ -1,0 +1,244 @@
+import process from 'node:process';
+import { sendTelegramMessage } from './lib/telegramClient';
+
+interface SelfHealOptions {
+  triggeredBy?: string;
+  notify?: boolean;
+}
+
+export type HealStatus = 'ok' | 'recovered' | 'failed' | 'skipped';
+
+export interface ServiceResult {
+  service: string;
+  status: HealStatus;
+  message: string;
+  attempts: number;
+}
+
+export interface SelfHealSummary {
+  startedAt: string;
+  finishedAt: string;
+  triggeredBy?: string;
+  results: ServiceResult[];
+}
+
+const WAIT_MS = 3000;
+
+function nowISO() {
+  return new Date().toISOString();
+}
+
+function trimUrl(url: string): string {
+  return url.replace(/\/$/, '');
+}
+
+async function wait(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function probe(url: string, init?: RequestInit): Promise<{ ok: boolean; status: number; error?: string }> {
+  try {
+    const res = await fetch(url, init);
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      return { ok: false, status: res.status, error: text || res.statusText };
+    }
+    return { ok: true, status: res.status };
+  } catch (err) {
+    return { ok: false, status: 0, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+async function healBrowserless(): Promise<ServiceResult> {
+  const base = process.env.BROWSERLESS_BASE_URL || process.env.BROWSERLESS_API_URL || '';
+  const apiKey = process.env.BROWSERLESS_API_KEY || process.env.BROWSERLESS_TOKEN || '';
+
+  if (!base) {
+    const message = 'No Browserless base URL configured';
+    console.warn('[self-heal] Browserless skipped:', message);
+    return { service: 'browserless', status: 'skipped', message, attempts: 0 };
+  }
+
+  const target = `${trimUrl(base)}/health`;
+  const headers: Record<string, string> = {};
+  if (apiKey) headers['x-api-key'] = apiKey;
+
+  let attempts = 0;
+  let lastError = '';
+
+  for (const delay of [0, WAIT_MS]) {
+    attempts += 1;
+    if (delay) {
+      console.log(`[self-heal] Browserless retrying in ${delay}ms`);
+      await wait(delay);
+    }
+
+    const result = await probe(target, { headers });
+    if (result.ok) {
+      const status = attempts === 1 ? 'ok' : 'recovered';
+      const message = `HTTP ${result.status} at ${target}`;
+      console.log('[self-heal] Browserless OK:', message);
+      return { service: 'browserless', status, message, attempts };
+    }
+
+    lastError = result.error ? `${result.status}: ${result.error}` : `HTTP ${result.status}`;
+    console.warn('[self-heal] Browserless probe failed:', lastError);
+  }
+
+  return {
+    service: 'browserless',
+    status: 'failed',
+    message: lastError || 'Unknown Browserless failure',
+    attempts,
+  };
+}
+
+async function healPuppeteer(): Promise<ServiceResult> {
+  const workerUrl = process.env.WORKER_URL || process.env.WORKER_BASE_URL;
+  if (!workerUrl) {
+    const message = 'WORKER_URL not configured';
+    console.warn('[self-heal] Puppeteer skipped:', message);
+    return { service: 'puppeteer', status: 'skipped', message, attempts: 0 };
+  }
+
+  const endpoint = `${trimUrl(workerUrl)}/api/browser/session`;
+  let attempts = 0;
+  let lastError = '';
+
+  for (const delay of [0, WAIT_MS]) {
+    attempts += 1;
+    if (delay) {
+      console.log(`[self-heal] Requesting new browser session after ${delay}ms pause`);
+      await wait(delay);
+    }
+
+    const result = await probe(endpoint, { method: 'POST' });
+    if (result.ok) {
+      const status = attempts === 1 ? 'ok' : 'recovered';
+      const message = `Session endpoint responded ${result.status}`;
+      console.log('[self-heal] Puppeteer session refreshed');
+      return { service: 'puppeteer', status, message, attempts };
+    }
+
+    lastError = result.error ? `${result.status}: ${result.error}` : `HTTP ${result.status}`;
+    console.warn('[self-heal] Puppeteer session request failed:', lastError);
+  }
+
+  return {
+    service: 'puppeteer',
+    status: 'failed',
+    message: lastError || 'Unable to refresh browser session',
+    attempts,
+  };
+}
+
+async function healTikTok(): Promise<ServiceResult> {
+  const workerUrl = process.env.WORKER_URL || process.env.WORKER_BASE_URL;
+  const handles = [
+    process.env.TIKTOK_PROFILE_MAIN,
+    process.env.TIKTOK_PROFILE_MAGGIE,
+    process.env.TIKTOK_PROFILE_WILLOW,
+    process.env.TIKTOK_PROFILE_MARS,
+  ].filter((value, index, array): value is string => !!value && array.indexOf(value) === index);
+
+  if (!workerUrl) {
+    const message = 'WORKER_URL not configured';
+    console.warn('[self-heal] TikTok skipped:', message);
+    return { service: 'tiktok', status: 'skipped', message, attempts: 0 };
+  }
+
+  if (!handles.length) {
+    const message = 'No TikTok profiles provided';
+    console.warn('[self-heal] TikTok skipped:', message);
+    return { service: 'tiktok', status: 'skipped', message, attempts: 0 };
+  }
+
+  const endpoint = `${trimUrl(workerUrl)}/tiktok/check`;
+  const missing: string[] = [];
+
+  for (const handle of handles) {
+    const res = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ handle }),
+    }).catch((err) => ({ ok: false, status: 0, error: err instanceof Error ? err.message : String(err) } as any));
+
+    if (!res || (res instanceof Response && !res.ok)) {
+      const error = res instanceof Response ? await res.text().catch(() => '') : res.error;
+      console.warn(`[self-heal] TikTok check failed for ${handle}:`, error);
+      missing.push(handle);
+      continue;
+    }
+
+    if (res instanceof Response) {
+      const payload = await res.json().catch(() => ({}));
+      if (!payload?.ok) {
+        missing.push(handle);
+      }
+    }
+  }
+
+  if (!missing.length) {
+    const message = `Sessions healthy for ${handles.length} profile(s)`;
+    console.log('[self-heal] TikTok sessions verified');
+    return { service: 'tiktok', status: 'ok', message, attempts: handles.length };
+  }
+
+  const message = `Missing session cookies for: ${missing.join(', ')}`;
+  console.warn('[self-heal] TikTok sessions missing:', message);
+  return { service: 'tiktok', status: 'failed', message, attempts: handles.length };
+}
+
+function formatResultLine(result: ServiceResult): string {
+  const symbol =
+    result.status === 'ok'
+      ? '✅'
+      : result.status === 'recovered'
+        ? '🟡'
+        : result.status === 'skipped'
+          ? '⚪️'
+          : '❌';
+  return `${symbol} <b>${result.service}</b> — ${result.message}`;
+}
+
+export async function selfHeal(options: SelfHealOptions = {}): Promise<SelfHealSummary> {
+  const startedAt = nowISO();
+  console.log(`[self-heal] Starting recovery sequence (triggered by ${options.triggeredBy || 'manual'})`);
+
+  const results: ServiceResult[] = [];
+  results.push(await healBrowserless());
+  results.push(await healPuppeteer());
+  results.push(await healTikTok());
+
+  const finishedAt = nowISO();
+  const summary: SelfHealSummary = { startedAt, finishedAt, triggeredBy: options.triggeredBy, results };
+
+  const lines = results.map(formatResultLine).join('\n');
+  const header = options.triggeredBy ? `🔧 <b>Self-heal triggered by ${options.triggeredBy}</b>` : '🔧 <b>Self-heal report</b>';
+  const footer = `⏱️ <i>${startedAt} → ${finishedAt}</i>`;
+
+  if (options.notify !== false) {
+    await sendTelegramMessage(`${header}\n${lines}\n${footer}`).catch(() => undefined);
+  }
+
+  console.log('[self-heal] Completed recovery sequence:', JSON.stringify(summary, null, 2));
+  return summary;
+}
+
+async function runCli() {
+  const triggeredBy = process.env.GITHUB_WORKFLOW
+    ? `workflow:${process.env.GITHUB_WORKFLOW}`
+    : 'manual';
+  try {
+    await selfHeal({ triggeredBy });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[self-heal] Fatal error:', message);
+    await sendTelegramMessage(`❌ <b>Self-heal crashed</b>\n<code>${message}</code>`).catch(() => undefined);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === new URL(`file://${process.argv[1] ?? ''}`).href) {
+  runCli();
+}

--- a/worker/lib/site.ts
+++ b/worker/lib/site.ts
@@ -1,0 +1,130 @@
+import type { Env } from './env';
+
+const SITE_PREFIX = 'site:';
+const SITE_HOSTS = new Set([
+  'messyandmagnetic.com',
+  'www.messyandmagnetic.com',
+  'assistant.messyandmagnetic.com',
+]);
+
+interface StoredSiteAsset {
+  path: string;
+  content: string;
+  encoding?: 'base64' | 'text' | 'utf8';
+  contentType?: string;
+  hash?: string;
+  size?: number;
+  deployedAt?: string;
+}
+
+function decodeBase64(content: string): Uint8Array {
+  const binary = atob(content);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+function buildResponse(
+  asset: StoredSiteAsset,
+  status = 200,
+  extraHeaders: Record<string, string> = {},
+): Response {
+  const headers: Record<string, string> = {
+    'cache-control': 'public, max-age=300, s-maxage=900',
+    'content-type': asset.contentType || 'application/octet-stream',
+    ...extraHeaders,
+  };
+
+  if (asset.hash) headers.etag = asset.hash;
+  if (asset.deployedAt) headers['last-modified'] = asset.deployedAt;
+
+  const encoding = asset.encoding || 'base64';
+  if (encoding === 'base64') {
+    const bytes = decodeBase64(asset.content);
+    return new Response(bytes, { status, headers });
+  }
+
+  return new Response(asset.content, { status, headers });
+}
+
+function normalizePath(pathname: string): string[] {
+  const raw = pathname.split('?')[0];
+  let normalized = raw.replace(/^\/+/g, '');
+  if (normalized === '') normalized = 'index.html';
+
+  const candidates = new Set<string>();
+  candidates.add(normalized);
+
+  if (normalized.endsWith('/')) {
+    candidates.add(`${normalized}index.html`);
+  }
+
+  if (!normalized.includes('.')) {
+    candidates.add(`${normalized}.html`);
+    candidates.add(`${normalized}/index.html`);
+  }
+
+  if (normalized !== 'index.html') {
+    candidates.add('index.html');
+  }
+
+  return [...candidates];
+}
+
+async function readAsset(env: Env, relativePath: string): Promise<StoredSiteAsset | null> {
+  const key = `${SITE_PREFIX}${relativePath}`;
+  try {
+    const record = await env.BRAIN.get<StoredSiteAsset>(key, { type: 'json' });
+    if (!record) return null;
+    return record;
+  } catch (err) {
+    console.warn('[site] Failed to read asset', relativePath, err);
+    return null;
+  }
+}
+
+export async function serveStaticSite(req: Request, env: Env): Promise<Response | null> {
+  const host = req.headers.get('host')?.toLowerCase();
+  if (!host || !SITE_HOSTS.has(host)) return null;
+
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    return null;
+  }
+
+  if (!env?.BRAIN || typeof env.BRAIN.get !== 'function') {
+    console.warn('[site] BRAIN KV binding missing');
+    return new Response('Service unavailable', { status: 503 });
+  }
+
+  const url = new URL(req.url);
+  const reserved = /^(?:\/api\/|\/webhooks\/|\/tiktok\/|\/cron\/|\/tasks\/|\/donors\/|\/ai\/|\/admin\/|\/diag\/|\/orders\/|\/planner\/|\/blueprint\/|\/ready$|\/health$|\/compose$|\/schedule$)/;
+  if (reserved.test(url.pathname)) {
+    return null;
+  }
+  const candidates = normalizePath(url.pathname);
+
+  for (const candidate of candidates) {
+    const asset = await readAsset(env, candidate);
+    if (asset) {
+      const headers: Record<string, string> = {};
+      if (candidate === 'index.html' && url.pathname !== '/' && !url.pathname.endsWith('index.html')) {
+        headers['x-site-fallback'] = candidate;
+      }
+      const response = buildResponse(asset, 200, headers);
+      if (req.method === 'HEAD') {
+        return new Response(null, { status: response.status, headers: response.headers });
+      }
+      return response;
+    }
+  }
+
+  return new Response('Not Found', {
+    status: 404,
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+      'cache-control': 'no-store',
+    },
+  });
+}

--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -3,6 +3,7 @@ import { handleHealth } from './health';
 import { handleDiagConfig } from './diag';
 import type { Env } from './lib/env';
 import { syncThreadStateFromGitHub } from './lib/threadStateSync';
+import { serveStaticSite } from './lib/site';
 type Ctx = { env: Env; request: Request; ctx: ExecutionContext };
 
 // ---------------- CORS helpers ----------------
@@ -76,6 +77,11 @@ export default {
   async fetch(req: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(req.url);
     try {
+      const siteResponse = await serveStaticSite(req, env);
+      if (siteResponse) {
+        return siteResponse;
+      }
+
       if (url.pathname === '/' || url.pathname === '/health') {
         return await handleHealth(env);
       }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -28,6 +28,14 @@ id = "1b8cbbc4a2f8426194368cb39baded79"
 pattern = "maggie.messyandmagnetic.com/*"
 zone_name = "messyandmagnetic.com"
 
+[[routes]]
+pattern = "assistant.messyandmagnetic.com/*"
+zone_name = "messyandmagnetic.com"
+
+[[routes]]
+pattern = "messyandmagnetic.com/*"
+zone_name = "messyandmagnetic.com"
+
 # === Cron triggers ===
 [triggers]
 crons = ["*/5 * * * *"]


### PR DESCRIPTION
## Summary
- add a Cloudflare Worker static-site pipeline driven by scripts/publishSite.ts and new KV-backed route handling
- wire up Telegram bridge commands plus Maggie self-heal + social run scripts with automated logging
- schedule the social loop GitHub Action and document the new commands/workflows in the README

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d2c75affc48327ba8c31b8f9470fbc