### PR TITLE
feat: add Telegram control (/status, /retry, /pause, /resume) + heartbeat KV

### DIFF
--- a/.github/workflows/full-autonomy.yml
+++ b/.github/workflows/full-autonomy.yml
@@ -1,0 +1,136 @@
+name: Full Autonomy
+
+on:
+  schedule:
+    - cron: '*/30 * * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      GH_PAT: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      KV_NAMESPACE_ID: ${{ secrets.KV_NAMESPACE_ID }}
+      CF_KV_POSTQ_NAMESPACE_ID: ${{ secrets.KV_NAMESPACE_ID }}
+      CF_KV_NAMESPACE_ID: ${{ secrets.KV_NAMESPACE_ID }}
+
+    steps:
+      - name: Diagnostics
+        run: |
+          echo "Actor: $GITHUB_ACTOR"
+          if [ -n "$GH_PAT" ]; then
+            echo "Using personal access token for internal requests."
+          else
+            echo "Falling back to default GITHUB_TOKEN.";
+          fi
+
+      - name: Check Cloudflare secrets
+        id: secrets
+        run: |
+          set -euo pipefail
+          missing=()
+          for key in CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN KV_NAMESPACE_ID; do
+            if [ -z "${!key:-}" ]; then
+              missing+=("$key")
+            fi
+          done
+
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf 'missing=true\n' >>"$GITHUB_OUTPUT"
+            printf 'missing_list=%s\n' "${missing[*]}" >>"$GITHUB_OUTPUT"
+            echo "::warning::Missing Cloudflare secrets: ${missing[*]}"
+          else
+            printf 'missing=false\n' >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Abort (missing secrets)
+        if: steps.secrets.outputs.missing == 'true'
+        run: |
+          echo "Skipping autonomy run because secrets are missing: ${{ steps.secrets.outputs.missing_list }}"
+
+      - name: Check autonomy pause flag
+        id: pause
+        if: steps.secrets.outputs.missing != 'true'
+        env:
+          PAUSE_KEY: autonomy:paused
+        run: |
+          set -euo pipefail
+          api="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/storage/kv/namespaces/${KV_NAMESPACE_ID}/values/${PAUSE_KEY}"
+          response=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" "$api" || true)
+          body="${response%$'\n'*}"
+          status="${response##*$'\n'}"
+          if [ "$status" = "200" ]; then
+            normalized=$(echo "$body" | tr '[:upper:]' '[:lower:]' | tr -d ' \t\r\n')
+            if [[ "$normalized" =~ ^(1|true|yes|on|paused)$ ]]; then
+              echo "Autonomy is paused via KV flag."
+              printf 'paused=true\n' >>"$GITHUB_OUTPUT"
+            else
+              printf 'paused=false\n' >>"$GITHUB_OUTPUT"
+            fi
+          else
+            printf 'paused=false\n' >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Autonomy paused (skip run)
+        if: steps.pause.outputs.paused == 'true'
+        run: echo "Autonomy paused — skipping full autonomy cycle."
+
+      - name: Checkout repository
+        if: steps.pause.outputs.paused != 'true'
+        uses: actions/checkout@v4
+        with:
+          token: ${{ env.GH_PAT || github.token }}
+
+      - name: Setup Node.js
+        if: steps.pause.outputs.paused != 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Enable pnpm via corepack
+        if: steps.pause.outputs.paused != 'true'
+        run: |
+          set -euo pipefail
+          corepack enable
+          PNPM_VERSION=$(node -p "require('./package.json').packageManager?.split('@')[1] || ''" 2>/dev/null || echo '')
+          if [ -n "$PNPM_VERSION" ]; then
+            corepack prepare "pnpm@$PNPM_VERSION" --activate
+          else
+            corepack prepare pnpm@latest --activate || true
+          fi
+          pnpm --version
+
+      - name: Install dependencies
+        if: steps.pause.outputs.paused != 'true'
+        run: pnpm install --frozen-lockfile
+
+      - name: Hydrate thread-state snapshot
+        if: steps.pause.outputs.paused != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p config
+          api="https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/storage/kv/namespaces/${KV_NAMESPACE_ID}/values/PostQ:thread-state"
+          response=$(curl -s -w '\n%{http_code}' -H "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" "$api" || true)
+          body="${response%$'\n'*}"
+          status="${response##*$'\n'}"
+          if [ "$status" = "200" ]; then
+            printf '%s' "$body" > config/thread-state.remote.json
+          else
+            echo '{}' > config/thread-state.remote.json
+            echo "::warning::Unable to hydrate thread-state (status $status)."
+          fi
+          chmod 600 config/thread-state.remote.json || true
+
+      - name: Run full autonomy
+        if: steps.pause.outputs.paused != 'true'
+        run: pnpm exec tsx scripts/fullAutonomy.ts

--- a/lib/kv.ts
+++ b/lib/kv.ts
@@ -178,6 +178,29 @@ export async function putConfig(
   return { ok: true } as const;
 }
 
+export async function deleteConfigKey(key: string, options: ResolveOptions = {}) {
+  const { accountId, apiToken, namespaceId } = await resolveCredentials(options);
+  const url = `https://api.cloudflare.com/client/v4/accounts/${accountId}/storage/kv/namespaces/${namespaceId}/values/${encodeURIComponent(
+    key,
+  )}`;
+
+  const res = await fetch(url, {
+    method: 'DELETE',
+    headers: {
+      Authorization: `Bearer ${apiToken}`,
+    },
+  });
+
+  if (!res.ok && res.status !== 404) {
+    const text = await res.text().catch(() => '');
+    throw new Error(
+      `Failed to delete config for ${key}: ${res.status}${text ? ` ${text}` : ''}`,
+    );
+  }
+
+  return { ok: true } as const;
+}
+
 export interface GetConfigOptions extends ResolveOptions {
   type?: 'text' | 'json';
 }

--- a/scripts/fullAutonomy.ts
+++ b/scripts/fullAutonomy.ts
@@ -1,0 +1,426 @@
+import process from 'node:process';
+
+import { google } from 'googleapis';
+
+import { getConfigValue, putConfig } from '../lib/kv';
+import { hydrateEnvFromThreadState } from './lib/threadState';
+
+export interface HealthCheckResult {
+  service: string;
+  ok: boolean;
+  detail: string;
+  checkedAt: string;
+  latencyMs?: number;
+}
+
+export interface HeartbeatStatus {
+  lastRun: string;
+  currentTask: string;
+  lastHealthChecks: Record<string, HealthCheckResult>;
+  nextRun: string;
+  notes?: string[];
+}
+
+export interface RunFullAutonomyOptions {
+  triggeredBy?: string;
+  force?: boolean;
+}
+
+type EnvSnapshot = Record<string, string>;
+
+const HEARTBEAT_KEY = 'status:last';
+const PAUSE_KEY = 'autonomy:paused';
+
+function nowISO(): string {
+  return new Date().toISOString();
+}
+
+function limitDetail(detail: string, max = 220): string {
+  const clean = detail.trim();
+  return clean.length > max ? `${clean.slice(0, max - 1)}…` : clean;
+}
+
+function parseBooleanFlag(value: string | undefined): boolean {
+  if (!value) return false;
+  const normalized = value.trim().toLowerCase();
+  return ['1', 'true', 'yes', 'on', 'enabled'].includes(normalized);
+}
+
+async function isAutonomyPaused(): Promise<boolean> {
+  try {
+    const raw = await getConfigValue<string>(PAUSE_KEY);
+    if (typeof raw === 'string') {
+      return parseBooleanFlag(raw);
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!/404/.test(message) && !/not found/i.test(message)) {
+      console.warn('[full-autonomy] Unable to read autonomy pause flag:', message);
+    }
+  }
+  return false;
+}
+
+function envValue(key: string, snapshot: EnvSnapshot): string | undefined {
+  return process.env[key] ?? snapshot[key];
+}
+
+async function checkStripe(snapshot: EnvSnapshot): Promise<HealthCheckResult> {
+  const started = Date.now();
+  const key = envValue('STRIPE_SECRET_KEY', snapshot);
+  const checkedAt = nowISO();
+  if (!key) {
+    return {
+      service: 'stripe',
+      ok: false,
+      detail: 'Missing STRIPE_SECRET_KEY.',
+      checkedAt,
+    };
+  }
+
+  try {
+    const res = await fetch('https://api.stripe.com/v1/balance', {
+      headers: { Authorization: `Bearer ${key}` },
+    });
+    if (!res.ok) {
+      const detail = limitDetail(`HTTP ${res.status}`);
+      return {
+        service: 'stripe',
+        ok: false,
+        detail,
+        checkedAt,
+        latencyMs: Date.now() - started,
+      };
+    }
+    return {
+      service: 'stripe',
+      ok: true,
+      detail: `HTTP ${res.status}`,
+      checkedAt,
+      latencyMs: Date.now() - started,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      service: 'stripe',
+      ok: false,
+      detail: limitDetail(`Network error: ${message}`),
+      checkedAt,
+      latencyMs: Date.now() - started,
+    };
+  }
+}
+
+async function checkTally(snapshot: EnvSnapshot): Promise<HealthCheckResult> {
+  const started = Date.now();
+  const key = envValue('TALLY_API_KEY', snapshot);
+  const checkedAt = nowISO();
+  if (!key) {
+    return {
+      service: 'tally',
+      ok: false,
+      detail: 'Missing TALLY_API_KEY.',
+      checkedAt,
+    };
+  }
+
+  try {
+    const res = await fetch('https://api.tally.so/forms', {
+      headers: { Authorization: `Bearer ${key}` },
+    });
+    if (!res.ok) {
+      return {
+        service: 'tally',
+        ok: false,
+        detail: `HTTP ${res.status}`,
+        checkedAt,
+        latencyMs: Date.now() - started,
+      };
+    }
+    return {
+      service: 'tally',
+      ok: true,
+      detail: `HTTP ${res.status}`,
+      checkedAt,
+      latencyMs: Date.now() - started,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      service: 'tally',
+      ok: false,
+      detail: limitDetail(`Network error: ${message}`),
+      checkedAt,
+      latencyMs: Date.now() - started,
+    };
+  }
+}
+
+async function checkNotion(snapshot: EnvSnapshot): Promise<HealthCheckResult> {
+  const started = Date.now();
+  const token =
+    envValue('NOTION_TOKEN', snapshot) || envValue('NOTION_API_KEY', snapshot);
+  const checkedAt = nowISO();
+  if (!token) {
+    return {
+      service: 'notion',
+      ok: false,
+      detail: 'Missing NOTION_TOKEN / NOTION_API_KEY.',
+      checkedAt,
+    };
+  }
+
+  try {
+    const res = await fetch('https://api.notion.com/v1/users/me', {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Notion-Version': '2022-06-28',
+      },
+    });
+    if (!res.ok) {
+      return {
+        service: 'notion',
+        ok: false,
+        detail: `HTTP ${res.status}`,
+        checkedAt,
+        latencyMs: Date.now() - started,
+      };
+    }
+    return {
+      service: 'notion',
+      ok: true,
+      detail: `HTTP ${res.status}`,
+      checkedAt,
+      latencyMs: Date.now() - started,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      service: 'notion',
+      ok: false,
+      detail: limitDetail(`Network error: ${message}`),
+      checkedAt,
+      latencyMs: Date.now() - started,
+    };
+  }
+}
+
+async function checkDrive(snapshot: EnvSnapshot): Promise<HealthCheckResult> {
+  const started = Date.now();
+  const checkedAt = nowISO();
+  const clientEmail = envValue('GOOGLE_CLIENT_EMAIL', snapshot);
+  const rawKey = envValue('GOOGLE_PRIVATE_KEY', snapshot);
+
+  if (!clientEmail || !rawKey) {
+    return {
+      service: 'drive',
+      ok: false,
+      detail: 'Missing Google service account credentials.',
+      checkedAt,
+    };
+  }
+
+  const privateKey = rawKey.includes('BEGIN PRIVATE KEY')
+    ? rawKey.replace(/\\n/g, '\n')
+    : rawKey;
+
+  try {
+    const auth = new google.auth.JWT(clientEmail, undefined, privateKey, [
+      'https://www.googleapis.com/auth/drive.metadata.readonly',
+    ]);
+    await auth.authorize();
+    const drive = google.drive({ version: 'v3', auth });
+    await drive.files.list({ pageSize: 1, fields: 'files(id)' });
+    return {
+      service: 'drive',
+      ok: true,
+      detail: 'Service account authorized.',
+      checkedAt,
+      latencyMs: Date.now() - started,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      service: 'drive',
+      ok: false,
+      detail: limitDetail(`Drive error: ${message}`),
+      checkedAt,
+      latencyMs: Date.now() - started,
+    };
+  }
+}
+
+async function checkTikTok(snapshot: EnvSnapshot): Promise<HealthCheckResult> {
+  const started = Date.now();
+  const checkedAt = nowISO();
+  const sessions = [
+    envValue('TIKTOK_SESSION_MAGGIE', snapshot),
+    envValue('TIKTOK_SESSION_MAIN', snapshot),
+    envValue('TIKTOK_SESSION_WILLOW', snapshot),
+    envValue('TIKTOK_SESSION_MARS', snapshot),
+  ].filter((value): value is string => typeof value === 'string' && value.length > 0);
+
+  const workerUrl =
+    envValue('WORKER_URL', snapshot) || envValue('WORKER_BASE_URL', snapshot);
+  const trimmedWorker = workerUrl ? workerUrl.replace(/\/$/, '') : '';
+
+  if (trimmedWorker) {
+    try {
+      const res = await fetch(`${trimmedWorker}/tiktok/accounts`);
+      if (res.ok) {
+        let detail = `HTTP ${res.status}`;
+        try {
+          const payload = await res.json().catch(() => null);
+          const count = Array.isArray(payload)
+            ? payload.length
+            : Array.isArray(payload?.accounts)
+              ? payload.accounts.length
+              : null;
+          if (typeof count === 'number') {
+            detail += ` • ${count} account(s)`;
+          }
+        } catch {
+          // Ignore JSON parse errors; detail already recorded.
+        }
+        return {
+          service: 'tiktok',
+          ok: true,
+          detail,
+          checkedAt,
+          latencyMs: Date.now() - started,
+        };
+      }
+      return {
+        service: 'tiktok',
+        ok: false,
+        detail: `Worker HTTP ${res.status}`,
+        checkedAt,
+        latencyMs: Date.now() - started,
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        service: 'tiktok',
+        ok: false,
+        detail: limitDetail(`Worker error: ${message}`),
+        checkedAt,
+        latencyMs: Date.now() - started,
+      };
+    }
+  }
+
+  if (sessions.length) {
+    return {
+      service: 'tiktok',
+      ok: true,
+      detail: `Session cookies present (${sessions.length})`,
+      checkedAt,
+      latencyMs: Date.now() - started,
+    };
+  }
+
+  return {
+    service: 'tiktok',
+    ok: false,
+    detail: 'No TikTok session cookies loaded.',
+    checkedAt,
+    latencyMs: Date.now() - started,
+  };
+}
+
+async function runHealthChecks(snapshot: EnvSnapshot): Promise<Record<string, HealthCheckResult>> {
+  const results: Record<string, HealthCheckResult> = {};
+  const tasks: [string, () => Promise<HealthCheckResult>][] = [
+    ['stripe', () => checkStripe(snapshot)],
+    ['tally', () => checkTally(snapshot)],
+    ['tiktok', () => checkTikTok(snapshot)],
+    ['notion', () => checkNotion(snapshot)],
+    ['drive', () => checkDrive(snapshot)],
+  ];
+
+  for (const [service, runner] of tasks) {
+    try {
+      const result = await runner();
+      results[service] = result;
+      console.log(
+        `[full-autonomy] ${service} health → ${result.ok ? 'ok' : 'fail'} :: ${result.detail}`,
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      results[service] = {
+        service,
+        ok: false,
+        detail: limitDetail(`Health check crashed: ${message}`),
+        checkedAt: nowISO(),
+      };
+      console.error(`[full-autonomy] ${service} health crashed:`, message);
+    }
+  }
+
+  return results;
+}
+
+function computeNextRun(timestamp: Date): string {
+  const fallbackMinutes = 30;
+  const configured = Number.parseInt(process.env.AUTONOMY_INTERVAL_MINUTES || '', 10);
+  const minutes = Number.isFinite(configured) && configured > 0 ? configured : fallbackMinutes;
+  return new Date(timestamp.getTime() + minutes * 60_000).toISOString();
+}
+
+export async function runFullAutonomy(
+  options: RunFullAutonomyOptions = {},
+): Promise<HeartbeatStatus> {
+  const startedAt = new Date();
+  console.log('[full-autonomy] Starting autonomy cycle at', startedAt.toISOString());
+
+  const snapshot = await hydrateEnvFromThreadState();
+  const paused = !options.force && (await isAutonomyPaused());
+
+  if (paused) {
+    console.log('[full-autonomy] Autonomy paused via KV flag; skipping task execution.');
+  }
+
+  const health = await runHealthChecks(snapshot);
+
+  // Placeholder for additional task orchestration if needed in future iterations.
+  if (!paused) {
+    console.log('[full-autonomy] No additional tasks configured for this cycle.');
+  }
+
+  const status: HeartbeatStatus = {
+    lastRun: startedAt.toISOString(),
+    currentTask: paused ? 'paused' : 'autonomy-cycle',
+    lastHealthChecks: health,
+    nextRun: computeNextRun(startedAt),
+  };
+
+  const notes: string[] = [];
+  if (options.triggeredBy) notes.push(`triggeredBy:${options.triggeredBy}`);
+  if (options.force) notes.push('forced');
+  if (paused) notes.push('paused');
+  if (notes.length) status.notes = notes;
+
+  await putConfig(HEARTBEAT_KEY, status);
+  console.log('[full-autonomy] Saved heartbeat payload to KV.', JSON.stringify(status, null, 2));
+
+  return status;
+}
+
+async function runCli() {
+  try {
+    await runFullAutonomy({
+      triggeredBy: process.env.GITHUB_WORKFLOW
+        ? `workflow:${process.env.GITHUB_WORKFLOW}`
+        : 'manual',
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[full-autonomy] Fatal error:', message);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === new URL(`file://${process.argv[1] ?? ''}`).href) {
+  runCli();
+}
+

--- a/scripts/lib/threadState.ts
+++ b/scripts/lib/threadState.ts
@@ -1,0 +1,295 @@
+import { access, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { getConfigValue } from '../../lib/kv';
+
+export interface ThreadStateSnapshot {
+  raw: string;
+  json: any | null;
+}
+
+export interface ThreadStateValueDescriptor {
+  name: string;
+  keys: string[];
+  pathIncludes?: string[];
+  rawKeys?: string[];
+}
+
+const DEFAULT_SNAPSHOT_CANDIDATES: (string | undefined)[] = [
+  process.env.THREAD_STATE_SNAPSHOT_PATH,
+  'config/thread-state.remote.json',
+  'config/kv-state.json',
+];
+
+async function readIfExists(candidate?: string): Promise<string | null> {
+  if (!candidate) return null;
+  try {
+    const resolved = path.resolve(candidate);
+    await access(resolved);
+    return await readFile(resolved, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function parseJson(raw: string): any | null {
+  if (!raw.trim()) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function candidateMatches(keyLower: string, candidateLower: string): boolean {
+  if (candidateLower === '*') return true;
+  if (candidateLower.startsWith('*') && candidateLower.endsWith('*')) {
+    return keyLower.includes(candidateLower.slice(1, -1));
+  }
+  if (candidateLower.startsWith('*')) {
+    return keyLower.endsWith(candidateLower.slice(1));
+  }
+  if (candidateLower.endsWith('*')) {
+    return keyLower.startsWith(candidateLower.slice(0, -1));
+  }
+  return keyLower === candidateLower;
+}
+
+function searchJsonValue(
+  json: any,
+  candidates: string[],
+  pathIncludes: string[] = [],
+): string | undefined {
+  if (!json || typeof json !== 'object') return undefined;
+  const normalizedCandidates = candidates.map((value) => value.toLowerCase());
+  const pathNeedles = pathIncludes.map((value) => value.toLowerCase());
+  const seen = new WeakSet<object>();
+
+  const visit = (node: any, pathParts: string[]): string | undefined => {
+    if (!node || typeof node !== 'object') return undefined;
+    if (seen.has(node)) return undefined;
+    seen.add(node);
+
+    for (const [key, value] of Object.entries(node)) {
+      const nextPath = [...pathParts, key];
+      const keyLower = key.toLowerCase();
+      const pathLower = nextPath.map((part) => part.toLowerCase());
+      const pathMatches =
+        !pathNeedles.length || pathNeedles.every((needle) => pathLower.some((part) => part.includes(needle)));
+
+      if (typeof value === 'string') {
+        if (pathMatches) {
+          for (const candidate of normalizedCandidates) {
+            if (candidateMatches(keyLower, candidate)) {
+              return value;
+            }
+          }
+        }
+      } else if (typeof value === 'object' && value) {
+        const result = visit(value, nextPath);
+        if (result !== undefined) return result;
+      }
+    }
+
+    return undefined;
+  };
+
+  return visit(json, []);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function searchRawValue(raw: string, keys: string[]): string | undefined {
+  if (!raw.trim()) return undefined;
+  for (const key of keys) {
+    const pattern = new RegExp(`${escapeRegExp(key)}\s*[:=]\s*["'`]?([^"'`\s]+)`, 'i');
+    const match = pattern.exec(raw);
+    if (match?.[1]) {
+      return match[1].trim();
+    }
+  }
+  return undefined;
+}
+
+export async function loadThreadStateSnapshot(): Promise<ThreadStateSnapshot> {
+  for (const candidate of DEFAULT_SNAPSHOT_CANDIDATES) {
+    const raw = await readIfExists(candidate);
+    if (raw !== null) {
+      return { raw, json: parseJson(raw) };
+    }
+  }
+
+  const kvKeys = ['PostQ:thread-state', 'thread-state'];
+  for (const key of kvKeys) {
+    try {
+      const value = await getConfigValue<string>(key);
+      if (typeof value === 'string') {
+        return { raw: value, json: parseJson(value) };
+      }
+    } catch (err) {
+      console.warn(`[thread-state] Unable to load "${key}" from KV:`, err instanceof Error ? err.message : err);
+    }
+  }
+
+  return { raw: '', json: null };
+}
+
+export function extractValues(
+  snapshot: ThreadStateSnapshot,
+  descriptors: ThreadStateValueDescriptor[],
+): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const descriptor of descriptors) {
+    const { name, keys, pathIncludes = [], rawKeys } = descriptor;
+    let resolved: string | undefined;
+
+    if (snapshot.json) {
+      resolved = searchJsonValue(snapshot.json, keys, pathIncludes);
+    }
+
+    if (!resolved && snapshot.raw) {
+      resolved = searchRawValue(snapshot.raw, rawKeys ?? keys);
+    }
+
+    if (resolved) {
+      values[name] = resolved;
+    }
+  }
+  return values;
+}
+
+const DEFAULT_DESCRIPTORS: ThreadStateValueDescriptor[] = [
+  {
+    name: 'TELEGRAM_BOT_TOKEN',
+    keys: ['TELEGRAM_BOT_TOKEN', 'telegramBotToken', '*token'],
+    pathIncludes: ['telegram'],
+  },
+  {
+    name: 'TELEGRAM_CHAT_ID',
+    keys: ['TELEGRAM_CHAT_ID', 'telegramChatId', '*chat*'],
+    pathIncludes: ['telegram'],
+  },
+  {
+    name: 'STRIPE_SECRET_KEY',
+    keys: ['STRIPE_SECRET_KEY', 'stripeSecretKey'],
+    pathIncludes: ['stripe'],
+  },
+  {
+    name: 'STRIPE_WEBHOOK_SECRET',
+    keys: ['STRIPE_WEBHOOK_SECRET', 'stripeWebhookSecret'],
+    pathIncludes: ['stripe'],
+  },
+  {
+    name: 'TALLY_API_KEY',
+    keys: ['TALLY_API_KEY', 'tallyApiKey'],
+    pathIncludes: ['tally'],
+  },
+  {
+    name: 'TALLY_SIGNING_SECRET',
+    keys: ['TALLY_SIGNING_SECRET', 'tallySigningSecret'],
+    pathIncludes: ['tally'],
+  },
+  {
+    name: 'NOTION_TOKEN',
+    keys: ['NOTION_TOKEN', 'notionToken'],
+    pathIncludes: ['notion'],
+  },
+  {
+    name: 'NOTION_API_KEY',
+    keys: ['NOTION_API_KEY', 'notionApiKey'],
+    pathIncludes: ['notion'],
+  },
+  {
+    name: 'GOOGLE_CLIENT_EMAIL',
+    keys: ['GOOGLE_CLIENT_EMAIL', 'clientEmail'],
+    pathIncludes: ['google', 'service'],
+  },
+  {
+    name: 'GOOGLE_PRIVATE_KEY',
+    keys: ['GOOGLE_PRIVATE_KEY', 'privateKey'],
+    pathIncludes: ['google', 'service'],
+  },
+  {
+    name: 'GOOGLE_KEY_URL',
+    keys: ['GOOGLE_KEY_URL', 'keyUrl'],
+    pathIncludes: ['google'],
+  },
+  {
+    name: 'FETCH_PASS',
+    keys: ['FETCH_PASS', 'fetchPass'],
+  },
+  {
+    name: 'WORKER_URL',
+    keys: ['WORKER_URL', 'workerUrl'],
+  },
+  {
+    name: 'WORKER_BASE_URL',
+    keys: ['WORKER_BASE_URL', 'workerBaseUrl'],
+  },
+  {
+    name: 'TIKTOK_SESSION_MAGGIE',
+    keys: ['TIKTOK_SESSION_MAGGIE', 'sessionMaggie'],
+    pathIncludes: ['tiktok'],
+  },
+  {
+    name: 'TIKTOK_SESSION_MAIN',
+    keys: ['TIKTOK_SESSION_MAIN', 'sessionMain'],
+    pathIncludes: ['tiktok'],
+  },
+  {
+    name: 'TIKTOK_SESSION_WILLOW',
+    keys: ['TIKTOK_SESSION_WILLOW', 'sessionWillow'],
+    pathIncludes: ['tiktok'],
+  },
+  {
+    name: 'TIKTOK_SESSION_MARS',
+    keys: ['TIKTOK_SESSION_MARS', 'sessionMars'],
+    pathIncludes: ['tiktok'],
+  },
+  {
+    name: 'TIKTOK_PROFILE_MAGGIE',
+    keys: ['TIKTOK_PROFILE_MAGGIE', 'profileMaggie'],
+    pathIncludes: ['tiktok'],
+  },
+  {
+    name: 'TIKTOK_PROFILE_MAIN',
+    keys: ['TIKTOK_PROFILE_MAIN', 'profileMain'],
+    pathIncludes: ['tiktok'],
+  },
+  {
+    name: 'TIKTOK_PROFILE_WILLOW',
+    keys: ['TIKTOK_PROFILE_WILLOW', 'profileWillow'],
+    pathIncludes: ['tiktok'],
+  },
+  {
+    name: 'TIKTOK_PROFILE_MARS',
+    keys: ['TIKTOK_PROFILE_MARS', 'profileMars'],
+    pathIncludes: ['tiktok'],
+  },
+];
+
+export async function hydrateEnvFromThreadState(
+  descriptors: ThreadStateValueDescriptor[] = DEFAULT_DESCRIPTORS,
+): Promise<Record<string, string>> {
+  const snapshot = await loadThreadStateSnapshot();
+  if (!snapshot.raw) return {};
+  const values = extractValues(snapshot, descriptors);
+  for (const [key, value] of Object.entries(values)) {
+    if (!process.env[key]) {
+      process.env[key] = value;
+    }
+  }
+  return values;
+}
+
+export async function resolveThreadStateValue(
+  descriptor: ThreadStateValueDescriptor,
+): Promise<string | undefined> {
+  const snapshot = await loadThreadStateSnapshot();
+  if (!snapshot.raw) return undefined;
+  const values = extractValues(snapshot, [descriptor]);
+  return values[descriptor.name];
+}
+

--- a/scripts/telegramControl.ts
+++ b/scripts/telegramControl.ts
@@ -1,0 +1,241 @@
+import process from 'node:process';
+
+import { getConfigValue, putConfig, deleteConfigKey } from '../lib/kv';
+import { runFullAutonomy, type HeartbeatStatus } from './fullAutonomy';
+import { hydrateEnvFromThreadState } from './lib/threadState';
+import { sendTelegramMessage } from './lib/telegramClient';
+
+interface TelegramChat {
+  id: number;
+  type: string;
+  title?: string;
+  username?: string;
+  first_name?: string;
+  last_name?: string;
+}
+
+interface TelegramMessage {
+  message_id: number;
+  text?: string;
+  chat: TelegramChat;
+  from?: { id: number; username?: string; first_name?: string; last_name?: string };
+}
+
+interface TelegramUpdate {
+  update_id: number;
+  message?: TelegramMessage;
+}
+
+const POLL_TIMEOUT_SEC = 30;
+const ERROR_BACKOFF_MS = 5000;
+const HEARTBEAT_KEY = 'status:last';
+const PAUSE_KEY = 'autonomy:paused';
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function titleCase(value: string): string {
+  if (!value) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function formatTimestamp(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return `${date.toISOString()} (${date.toLocaleString('en-US', { timeZone: 'America/Los_Angeles' })})`;
+}
+
+async function ensureTelegramEnv(): Promise<{ token: string; chatId: string }> {
+  await hydrateEnvFromThreadState();
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.TELEGRAM_CHAT_ID;
+  if (!token || !chatId) {
+    throw new Error('Telegram credentials missing in environment and KV.');
+  }
+  return { token, chatId };
+}
+
+async function fetchUpdates(token: string, offset: number): Promise<TelegramUpdate[] | null> {
+  const url = new URL(`https://api.telegram.org/bot${token}/getUpdates`);
+  url.searchParams.set('timeout', String(POLL_TIMEOUT_SEC));
+  url.searchParams.set('offset', String(offset));
+
+  try {
+    const res = await fetch(url.toString());
+    const data = await res.json().catch(() => null);
+    if (!data?.ok) {
+      console.warn('[telegram-control] getUpdates returned non-ok response:', data);
+      return null;
+    }
+    return Array.isArray(data.result) ? (data.result as TelegramUpdate[]) : [];
+  } catch (err) {
+    console.error('[telegram-control] getUpdates failed:', err);
+    return null;
+  }
+}
+
+async function sendReply(chatId: string, text: string) {
+  await sendTelegramMessage(text, { chatId }).catch((err) => {
+    console.error('[telegram-control] Failed to send reply:', err);
+  });
+}
+
+async function fetchHeartbeat(): Promise<HeartbeatStatus | null> {
+  try {
+    const value = (await getConfigValue<HeartbeatStatus>(HEARTBEAT_KEY, {
+      type: 'json',
+    })) as HeartbeatStatus;
+    if (value && typeof value === 'object') return value;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!/404/.test(message) && !/not found/i.test(message)) {
+      console.warn('[telegram-control] Unable to read heartbeat:', message);
+    }
+  }
+  return null;
+}
+
+function formatHeartbeat(status: HeartbeatStatus): string {
+  const lines: string[] = [];
+  lines.push('🩺 <b>Autonomy heartbeat</b>');
+  lines.push(`• Last run: <code>${escapeHtml(formatTimestamp(status.lastRun))}</code>`);
+  lines.push(`• Current task: <b>${escapeHtml(status.currentTask)}</b>`);
+  lines.push(`• Next run: <code>${escapeHtml(formatTimestamp(status.nextRun))}</code>`);
+
+  const checks = Object.values(status.lastHealthChecks || {});
+  if (checks.length) {
+    lines.push('');
+    lines.push('<b>Health checks</b>');
+    for (const check of checks) {
+      const icon = check.ok ? '✅' : '❌';
+      const detail = escapeHtml(check.detail);
+      lines.push(`${icon} <b>${escapeHtml(titleCase(check.service))}</b> — ${detail}`);
+    }
+  }
+
+  if (status.notes?.length) {
+    lines.push('');
+    lines.push(`<b>Notes:</b> ${escapeHtml(status.notes.join(', '))}`);
+  }
+
+  return lines.join('\n');
+}
+
+function allowedChat(chatId: string, allowed: string): boolean {
+  return !allowed || allowed === chatId;
+}
+
+async function handleStatus(chatId: string) {
+  const snapshot = await fetchHeartbeat();
+  if (!snapshot) {
+    await sendReply(chatId, 'ℹ️ No heartbeat found yet.');
+    return;
+  }
+  await sendReply(chatId, formatHeartbeat(snapshot));
+}
+
+async function handleRetry(chatId: string) {
+  await sendReply(chatId, '🔁 Running autonomy cycle now…');
+  try {
+    const status = await runFullAutonomy({ triggeredBy: 'telegram:retry', force: true });
+    await sendReply(chatId, `✅ Autonomy run complete.\n${formatHeartbeat(status)}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await sendReply(chatId, `❌ Autonomy run failed.\n<code>${escapeHtml(message)}</code>`);
+  }
+}
+
+async function handlePause(chatId: string) {
+  try {
+    await putConfig(PAUSE_KEY, 'true');
+    await sendReply(chatId, '⏸ Autonomy paused.');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await sendReply(chatId, `❌ Failed to pause autonomy.\n<code>${escapeHtml(message)}</code>`);
+  }
+}
+
+async function handleResume(chatId: string) {
+  try {
+    await deleteConfigKey(PAUSE_KEY);
+    await sendReply(chatId, '▶️ Autonomy resumed.');
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await sendReply(chatId, `❌ Failed to resume autonomy.\n<code>${escapeHtml(message)}</code>`);
+  }
+}
+
+async function handleCommand(chatId: string, text: string) {
+  const [rawCommand] = text.trim().split(/\s+/);
+  if (!rawCommand.startsWith('/')) return;
+  const command = rawCommand.toLowerCase().split('@')[0];
+  console.log('[telegram-control] Received command', command, 'from', chatId);
+
+  switch (command) {
+    case '/status':
+      await handleStatus(chatId);
+      break;
+    case '/retry':
+      await handleRetry(chatId);
+      break;
+    case '/pause':
+      await handlePause(chatId);
+      break;
+    case '/resume':
+      await handleResume(chatId);
+      break;
+    default:
+      await sendReply(chatId, '🤖 Commands: /status, /retry, /pause, /resume');
+  }
+}
+
+async function runLoop(token: string, allowedChatId: string) {
+  let offset = 0;
+  console.log('[telegram-control] Listening for commands…');
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const updates = await fetchUpdates(token, offset);
+    if (!updates) {
+      await new Promise((resolve) => setTimeout(resolve, ERROR_BACKOFF_MS));
+      continue;
+    }
+
+    for (const update of updates) {
+      offset = Math.max(offset, update.update_id + 1);
+      const message = update.message;
+      if (!message?.text) continue;
+      const chatId = String(message.chat.id);
+      if (!allowedChat(chatId, allowedChatId)) {
+        console.warn('[telegram-control] Ignoring message from unauthorized chat', chatId);
+        continue;
+      }
+      try {
+        await handleCommand(chatId, message.text);
+      } catch (err) {
+        console.error('[telegram-control] Command handler crashed:', err);
+        await sendReply(chatId, '❌ Command failed. Check logs for details.');
+      }
+    }
+  }
+}
+
+async function runCli() {
+  try {
+    const { token, chatId } = await ensureTelegramEnv();
+    await runLoop(token, chatId);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[telegram-control] Fatal error:', message);
+    process.exitCode = 1;
+  }
+}
+
+if (import.meta.url === new URL(`file://${process.argv[1] ?? ''}`).href) {
+  runCli();
+}
+


### PR DESCRIPTION
- Adds Telegram commands to manage Maggie remotely:
  - `/status` shows heartbeat with last run + checks.
  - `/retry` manually triggers autonomy loop.
  - `/pause` and `/resume` toggle autonomy scheduling.
- Updates `fullAutonomy.ts` to persist status JSON in KV and respect paused flag.
- Workflow updated for KV hydration and PAT forwarding.

------
https://chatgpt.com/codex/tasks/task_e_68d30342db98832782753a275c322f68