### PR TITLE
Daily 5PM Telegram summary + /summary + KV queue

### DIFF
--- a/.github/workflows/daily-summary.yml
+++ b/.github/workflows/daily-summary.yml
@@ -1,0 +1,39 @@
+name: Daily 5PM Maggie Summary
+
+on:
+  schedule:
+    - cron: "0 23 * * *"  # 23:00 UTC = 5:00 PM America/Denver most of the year
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  summary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Worker daily summary
+        id: pull
+        run: |
+          set -e
+          curl -sS "https://maggie.messyandmagnetic.com/summary" \
+            -H "Authorization: Bearer ${{ secrets.POST_THREAD_SECRET }}" \
+            -o summary.json
+          echo "text<<EOF" >> $GITHUB_OUTPUT
+          jq -r '
+            def n(x): if x==null then "0" else (x|tostring) end;
+            "📒 Maggie Daily Summary\n" +
+            "⏰ " + (.time // "unknown") + "\n" +
+            "🧩 Tasks: " + ((.currentTasks // ["idle"]) | join(", ")) + "\n" +
+            "🌐 Website: " + (.website // "https://messyandmagnetic.com") + "\n" +
+            "📅 Scheduled: " + n(.socialQueue.scheduled) + " | 🔁 Retries: " + n(.socialQueue.flopsRetry) + "\n" +
+            "➡️ Next Post: " + ((.socialQueue.nextPost // "none")|tostring) + "\n" +
+            (if .topTrends then "🔥 Top Trends: " + (.topTrends | map(.title) | join(", ")) else "" end)
+          ' summary.json >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Send Telegram
+        run: |
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id=${{ secrets.TELEGRAM_CHAT_ID }} \
+            --data-urlencode text="${{ steps.pull.outputs.text }}"

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -52,3 +52,14 @@ jobs:
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
         run: wrangler pages deploy ui
 
+      - name: Notify Telegram of deploy
+        if: always()
+        run: |
+          MSG="🌸 Website deployed: https://messyandmagnetic.com"
+          if [ "${{ job.status }}" != "success" ]; then
+            MSG="❌ Website deploy failed."
+          fi
+          curl -s -X POST "https://api.telegram.org/bot${{ secrets.TELEGRAM_BOT_TOKEN }}/sendMessage" \
+            -d chat_id=${{ secrets.TELEGRAM_CHAT_ID }} \
+            --data-urlencode text="$MSG"
+

--- a/shared/maggieState.ts
+++ b/shared/maggieState.ts
@@ -1,0 +1,18 @@
+export interface MaggieTrend {
+  title: string;
+  url?: string;
+  score?: number;
+  [key: string]: unknown;
+}
+
+export interface MaggieState {
+  currentTasks?: string[];
+  lastCheck?: string;
+  scheduledPosts?: string[];
+  flopRetries?: string[];
+  topTrends?: MaggieTrend[];
+  website?: string;
+  [key: string]: unknown;
+}
+
+export const THREAD_STATE_KEY = 'thread-state';

--- a/worker/lib/env.ts
+++ b/worker/lib/env.ts
@@ -1,6 +1,9 @@
 export type Env = {
   BRAIN: KVNamespace;
   PostQ?: KVNamespace;
+  TELEGRAM_BOT_TOKEN?: string;
+  TELEGRAM_CHAT_ID?: string;
+  POST_THREAD_SECRET?: string;
   SECRET_BLOB?: string;        // e.g., "thread-state"
   BRAIN_DOC_KEY?: string;      // e.g., "PostQ:thread-state"
   THREAD_STATE_BRANCH?: string;

--- a/worker/lib/state.ts
+++ b/worker/lib/state.ts
@@ -1,0 +1,79 @@
+import type { Env } from './env';
+import type { MaggieState, MaggieTrend } from '../../shared/maggieState';
+import { THREAD_STATE_KEY } from '../../shared/maggieState';
+
+function resolveStateKV(env: Env): KVNamespace | undefined {
+  const kv = (env as any).PostQ ?? (env as any).POSTQ ?? env.BRAIN;
+  if (kv && typeof kv.get === 'function' && typeof kv.put === 'function') {
+    return kv as KVNamespace;
+  }
+  return undefined;
+}
+
+export async function loadState(env: Env): Promise<MaggieState> {
+  const kv = resolveStateKV(env);
+  if (!kv) return {};
+  try {
+    const raw = await kv.get(THREAD_STATE_KEY, 'json');
+    if (raw && typeof raw === 'object') {
+      return raw as MaggieState;
+    }
+  } catch (err) {
+    console.warn('[state] Failed to load thread-state:', err);
+  }
+  return {};
+}
+
+export async function saveState(env: Env, state: MaggieState): Promise<void> {
+  const kv = resolveStateKV(env);
+  if (!kv) return;
+  try {
+    await kv.put(THREAD_STATE_KEY, JSON.stringify(state));
+  } catch (err) {
+    console.warn('[state] Failed to save thread-state:', err);
+  }
+}
+
+export function normalizeTrends(trends: unknown): MaggieTrend[] | undefined {
+  if (!Array.isArray(trends)) return undefined;
+  const mapped = trends
+    .map((entry) => {
+      if (!entry) return null;
+      if (typeof entry === 'string') {
+        return { title: entry } satisfies MaggieTrend;
+      }
+      if (typeof entry === 'object') {
+        const obj = entry as Record<string, unknown>;
+        const title = obj.title ?? obj.name ?? obj.caption;
+        if (typeof title === 'string' && title.trim()) {
+          return { ...obj, title: title.trim() } as MaggieTrend;
+        }
+        const url = typeof obj.url === 'string' ? obj.url : undefined;
+        if (url) {
+          return { ...obj, title: url } as MaggieTrend;
+        }
+      }
+      return null;
+    })
+    .filter((value): value is MaggieTrend => Boolean(value));
+  return mapped.length ? mapped : undefined;
+}
+
+export async function sendTelegram(env: Env, text: string) {
+  const token = (env as any).TELEGRAM_BOT_TOKEN || env.TELEGRAM_BOT_TOKEN;
+  const chatId = (env as any).TELEGRAM_CHAT_ID || env.TELEGRAM_CHAT_ID;
+  if (!token || !chatId) {
+    console.warn('[telegram] Missing TELEGRAM credentials');
+    return;
+  }
+  const url = `https://api.telegram.org/bot${token}/sendMessage`;
+  const body = new URLSearchParams({
+    chat_id: String(chatId),
+    text,
+  });
+  try {
+    await fetch(url, { method: 'POST', body });
+  } catch (err) {
+    console.warn('[telegram] Failed to send message:', err);
+  }
+}

--- a/worker/routes/telegram.ts
+++ b/worker/routes/telegram.ts
@@ -1,0 +1,122 @@
+import type { Env } from '../lib/env';
+import { sendTelegram } from '../lib/state';
+
+interface TelegramUpdate {
+  message?: {
+    text?: string;
+    caption?: string;
+    chat?: { id?: number | string };
+  };
+  channel_post?: TelegramUpdate['message'];
+  edited_message?: TelegramUpdate['message'];
+  edited_channel_post?: TelegramUpdate['message'];
+  [key: string]: unknown;
+}
+
+function extractMessage(update: TelegramUpdate) {
+  return update.message || update.channel_post || update.edited_message || update.edited_channel_post;
+}
+
+function commandFromText(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('/')) return '';
+  const first = trimmed.split(/\s+/)[0] || '';
+  return first.split('@')[0] || '';
+}
+
+async function fetchJson(url: string, headers: HeadersInit = {}) {
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    throw new Error(`Request failed: ${res.status}`);
+  }
+  return res.json();
+}
+
+function formatTasks(value: unknown): string {
+  if (Array.isArray(value) && value.length) {
+    return value.join(', ');
+  }
+  return 'idle';
+}
+
+function denverNow() {
+  return new Date().toLocaleString('en-US', { timeZone: 'America/Denver' });
+}
+
+function summarizeTrends(value: unknown): string {
+  if (!Array.isArray(value)) return '';
+  const titles = value
+    .slice(0, 3)
+    .map((entry: any) => {
+      if (!entry) return null;
+      if (typeof entry === 'string') return entry;
+      if (typeof entry.title === 'string') return entry.title;
+      if (typeof entry.name === 'string') return entry.name;
+      if (typeof entry.url === 'string') return entry.url;
+      return null;
+    })
+    .filter((entry): entry is string => Boolean(entry));
+  return titles.join(', ');
+}
+
+export async function onRequestPost({ request, env }: { request: Request; env: Env }) {
+  const update = (await request.json().catch(() => ({}))) as TelegramUpdate;
+  const message = extractMessage(update);
+  const text = (message?.text || message?.caption || '').trim();
+  if (!text) {
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const command = commandFromText(text);
+  if (!command) {
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const origin = new URL(request.url).origin.replace(/\/$/, '');
+  const headers: HeadersInit = {};
+  if (env.POST_THREAD_SECRET) {
+    headers['Authorization'] = `Bearer ${env.POST_THREAD_SECRET}`;
+  }
+
+  try {
+    if (command === '/status') {
+      const status = await fetchJson(`${origin}/status`, headers);
+      const social = status.socialQueue || {};
+      await sendTelegram(
+        env,
+        `📊 Maggie Status\n` +
+          `⏰ ${denverNow()}\n` +
+          `🧩 Tasks: ${formatTasks(status.currentTasks)}\n` +
+          `🌐 Website: ${status.website || 'https://messyandmagnetic.com'}\n` +
+          `📅 Social: ${social.scheduled ?? 0} scheduled, ${social.flopsRetry ?? 0} retries\n` +
+          `➡️ Next: ${social.nextPost ?? 'none'}`,
+      );
+    } else if (command === '/summary') {
+      const summary = await fetchJson(`${origin}/summary`, headers);
+      const social = summary.socialQueue || {};
+      const trends = summarizeTrends(summary.topTrends);
+      await sendTelegram(
+        env,
+        `📒 Daily Summary\n` +
+          `⏰ ${denverNow()}\n` +
+          `🧩 Tasks: ${formatTasks(summary.currentTasks)}\n` +
+          `🌐 Website: ${summary.website || 'https://messyandmagnetic.com'}\n` +
+          `📅 Social: ${social.scheduled ?? 0} scheduled, ${social.flopsRetry ?? 0} retries\n` +
+          `🔥 Trends: ${trends || 'n/a'}`,
+      );
+    }
+  } catch (err) {
+    console.warn('[telegram] Command handling failed:', err);
+  }
+
+  return new Response(JSON.stringify({ ok: true }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}


### PR DESCRIPTION
## Summary
- add a scheduled workflow that fetches the worker summary endpoint and delivers a 5 PM Telegram briefing
- expose worker `/status` and `/summary` routes plus Telegram bot commands backed by KV thread-state helpers
- persist social queue details and trend picks into `thread-state`, and keep the Telegram deploy ping on UI deploys

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d370fa809083278bb7b9efd4c4901c