### PR TITLE
Fix Cloudflare Pages deploy dependencies

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -23,13 +23,13 @@ jobs:
       - name: Setup PNPM
         uses: pnpm/action-setup@v4
         with:
-          version: 9.12.0
+          version: 10.15.0
           run_install: false
 
       - name: Enable PNPM via Corepack
         run: |
           corepack enable
-          corepack prepare pnpm@9.12.0 --activate
+          corepack prepare pnpm@10.15.0 --activate
 
       - name: Enable PNPM cache
         uses: actions/setup-node@v4
@@ -45,6 +45,9 @@ jobs:
 
       - name: Build UI
         run: pnpm -w --filter ui build
+
+      - name: Install Wrangler CLI
+        run: npm install -g wrangler@4.33.1
 
       - name: Deploy to Cloudflare Pages
         env:


### PR DESCRIPTION
## Summary
- align the Pages deploy workflow with pnpm 10.15.0 so installs run with the expected toolchain
- install the Wrangler CLI before deploying to Cloudflare Pages to ensure the deploy step can find the binary

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d378b7cea0832796f33cf4d8ee2d45