### PR TITLE
fix: ensure worker deploy uses wrangler publish

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,6 @@ name: Deploy Worker
 on:
   push:
     branches: [ main ]
-  pull_request:
   workflow_dispatch:
 
 jobs:
@@ -16,19 +15,21 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install Wrangler
-        run: npm i -g wrangler
+      - name: Setup Wrangler
+        run: npm install -g wrangler
 
       - name: Publish
         if: github.event_name != 'pull_request'
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-        run: wrangler deploy
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
+        run: wrangler publish worker/worker.ts
 
       - name: Preview (PRs)
         if: github.event_name == 'pull_request'
         env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
         run: wrangler deploy --dry-run


### PR DESCRIPTION
## Summary
- ensure the deploy workflow installs Wrangler explicitly and publishes the worker entrypoint
- configure Wrangler to read the Cloudflare account, token, and zone secrets
- limit the deploy workflow triggers to pushes to main and manual dispatches

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d40173043c8327b4e8d2406b9bf875