### PR TITLE
fix: continuous autonomy loop + Telegram notify

### DIFF
--- a/.github/workflows/full-autonomy.yml
+++ b/.github/workflows/full-autonomy.yml
@@ -2,7 +2,7 @@ name: Full Autonomy
 
 on:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '*/15 * * * *'
   workflow_dispatch:
 
 jobs:
@@ -46,8 +46,34 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run full autonomy loop
-        run: pnpm tsx scripts/fullAutonomy.ts --orchestrate
+      - name: Hydrate Maggie KV snapshot
+        if: ${{ secrets.THREAD_STATE_JSON != '' && secrets.BRAIN_DOC_MD != '' }}
+        env:
+          THREAD_STATE_JSON: ${{ secrets.THREAD_STATE_JSON }}
+          BRAIN_DOC_MD: ${{ secrets.BRAIN_DOC_MD }}
+          CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CF_KV_POSTQ_NAMESPACE_ID: ${{ secrets.CF_KV_POSTQ_NAMESPACE_ID }}
+        run: pnpm run seed:kv
+
+      - name: Run Maggie orchestrator
+        run: pnpm tsx scripts/fullAutonomy.ts
+
+      - name: Notify Telegram completion
+        if: always()
+        env:
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+        run: |
+          if [ -n "${TELEGRAM_BOT_TOKEN}" ] && [ -n "${TELEGRAM_CHAT_ID}" ]; then
+            DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+              --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+              --data-urlencode "text=Maggie run complete at ${DATE}" \
+              > /dev/null
+          else
+            echo "Skipping Telegram notify – credentials missing"
+          fi
 
       - name: Stamp run metadata
         if: always()
@@ -60,7 +86,7 @@ jobs:
           now = datetime.now(timezone.utc)
           with open(path, 'a', encoding='utf-8') as fh:
               fh.write(f"AUTONOMY_TIMESTAMP={now.isoformat().replace('+00:00','Z')}\n")
-              fh.write(f"AUTONOMY_NEXT_RUN={(now + timedelta(minutes=30)).isoformat().replace('+00:00','Z')}\n")
+              fh.write(f"AUTONOMY_NEXT_RUN={(now + timedelta(minutes=15)).isoformat().replace('+00:00','Z')}\n")
           PY
 
       - name: Publish failure heartbeat


### PR DESCRIPTION
## Summary
- add 15-minute cron trigger with hydration, orchestrator run, and Telegram completion ping in the full autonomy workflow
- enrich autonomy orchestrator to seed fallback tasks, update Maggie state, and auto-run when invoked without flags
- adjust status handling and next-run scheduling so Maggie reports active work and keeps queues populated

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d403ad2ffc83279ea9b006c1bd8091