### PR TITLE
feat: quiet hours with daily + catch-up digests

### DIFF
--- a/.github/workflows/catchup-digest.yml
+++ b/.github/workflows/catchup-digest.yml
@@ -1,0 +1,42 @@
+name: Catch-up Digest
+
+on:
+  schedule:
+    - cron: '5 13 * * *'
+  workflow_dispatch:
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    env:
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CF_KV_POSTQ_NAMESPACE_ID: ${{ secrets.CF_KV_POSTQ_NAMESPACE_ID }}
+      WORKER_URL: ${{ secrets.WORKER_URL }}
+      WORKER_KEY: ${{ secrets.WORKER_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+          run_install: false
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Send catch-up digest
+        run: pnpm tsx scripts/digest.ts --since lastQuietStart

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -1,0 +1,43 @@
+name: Daily Digest
+
+on:
+  schedule:
+    - cron: '5 6 * 4-10 *'
+    - cron: '5 7 * 1-3,11-12 *'
+  workflow_dispatch:
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    env:
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CF_KV_POSTQ_NAMESPACE_ID: ${{ secrets.CF_KV_POSTQ_NAMESPACE_ID }}
+      WORKER_URL: ${{ secrets.WORKER_URL }}
+      WORKER_KEY: ${{ secrets.WORKER_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+          run_install: false
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Send digest
+        run: pnpm tsx scripts/digest.ts

--- a/.github/workflows/full-autonomy.yml
+++ b/.github/workflows/full-autonomy.yml
@@ -2,7 +2,7 @@ name: Full Autonomy
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '*/5 * * * *'
   workflow_dispatch:
 
 jobs:
@@ -59,17 +59,115 @@ jobs:
       - name: Run Maggie orchestrator
         run: pnpm tsx scripts/fullAutonomy.ts
 
-      - name: Notify Telegram completion
+      - name: Evaluate run outcome
         if: always()
+        id: runlog
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const resolved = path.resolve(process.cwd(), 'run-output.json');
+          const summary = {
+            exists: false,
+            summary: '',
+            errors: 0,
+            warnings: 0,
+            critical: false,
+            muted: false,
+            quietStart: '',
+            nextRun: '',
+          };
+
+          try {
+            const raw = fs.readFileSync(resolved, 'utf8');
+            const log = JSON.parse(raw);
+            summary.exists = true;
+            if (log?.summary?.text) {
+              summary.summary = String(log.summary.text).replace(/\s+/g, ' ').slice(0, 400);
+            }
+            if (Array.isArray(log?.errors)) {
+              summary.errors = log.errors.length;
+            }
+            if (Array.isArray(log?.warnings)) {
+              summary.warnings = log.warnings.length;
+            }
+            summary.critical = !!log?.critical;
+            summary.muted = !!(log?.quiet && log.quiet.muted);
+            if (log?.quiet?.windowStart) {
+              summary.quietStart = String(log.quiet.windowStart);
+            }
+            if (log?.nextRun) {
+              summary.nextRun = String(log.nextRun);
+            }
+          } catch (err) {
+            console.warn('[workflow] No run-output.json found:', err instanceof Error ? err.message : err);
+          }
+
+          const shouldNotify = summary.exists ? (!summary.muted || summary.critical) : true;
+          const outputs = {
+            should_notify: String(shouldNotify),
+            critical: String(summary.critical),
+            muted: String(summary.muted),
+            summary: summary.summary.replace(/\r?\n/g, ' '),
+            errors: String(summary.errors),
+            quiet_start: summary.quietStart,
+            next_run: summary.nextRun,
+          };
+
+          const outPath = process.env.GITHUB_OUTPUT;
+          if (outPath) {
+            const lines = Object.entries(outputs)
+              .map(([key, value]) => `${key}=${value}`);
+            fs.appendFileSync(outPath, `${lines.join('\n')}\n`);
+          }
+
+          const envPath = process.env.GITHUB_ENV;
+          if (envPath) {
+            if (summary.nextRun) {
+              fs.appendFileSync(envPath, `RUNLOG_NEXT_RUN=${summary.nextRun}\n`);
+            }
+            if (summary.quietStart) {
+              fs.appendFileSync(envPath, `LAST_QUIET_START=${summary.quietStart}\n`);
+            }
+          }
+
+          console.log(
+            '[workflow] shouldNotify=%s critical=%s muted=%s errors=%s',
+            shouldNotify,
+            summary.critical,
+            summary.muted,
+            summary.errors,
+          );
+          NODE
+
+      - name: Notify Telegram completion
+        if: always() && steps.runlog.outputs.should_notify == 'true'
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
         run: |
           if [ -n "${TELEGRAM_BOT_TOKEN}" ] && [ -n "${TELEGRAM_CHAT_ID}" ]; then
             DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            SUMMARY="${{ steps.runlog.outputs.summary }}"
+            ERRORS="${{ steps.runlog.outputs.errors }}"
+            CRITICAL="${{ steps.runlog.outputs.critical }}"
+            MESSAGE="Maggie run complete at ${DATE}"
+            if [ -n "$SUMMARY" ]; then
+              MESSAGE="${MESSAGE}
+Summary: ${SUMMARY}"
+            fi
+            if [ "$ERRORS" != "" ] && [ "$ERRORS" != "0" ]; then
+              MESSAGE="${MESSAGE}
+Errors logged: ${ERRORS}"
+            fi
+            if [ "$CRITICAL" = "true" ]; then
+              MESSAGE="${MESSAGE}
+Critical alerts present"
+            fi
             curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
               --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
-              --data-urlencode "text=Maggie run complete at ${DATE}" \
+              --data-urlencode "text=${MESSAGE}" \
               > /dev/null
           else
             echo "Skipping Telegram notify – credentials missing"
@@ -84,9 +182,15 @@ jobs:
 
           path = os.environ['GITHUB_ENV']
           now = datetime.now(timezone.utc)
+          next_env = os.environ.get('RUNLOG_NEXT_RUN')
+          try:
+              next_target = datetime.fromisoformat(next_env.replace('Z', '+00:00')) if next_env else None
+          except Exception:
+              next_target = None
+          next_iso = (next_target or (now + timedelta(minutes=5))).isoformat().replace('+00:00','Z')
           with open(path, 'a', encoding='utf-8') as fh:
               fh.write(f"AUTONOMY_TIMESTAMP={now.isoformat().replace('+00:00','Z')}\n")
-              fh.write(f"AUTONOMY_NEXT_RUN={(now + timedelta(minutes=15)).isoformat().replace('+00:00','Z')}\n")
+              fh.write(f"AUTONOMY_NEXT_RUN={next_iso}\n")
           PY
 
       - name: Publish failure heartbeat

--- a/scripts/digest.ts
+++ b/scripts/digest.ts
@@ -1,0 +1,275 @@
+import process from 'node:process';
+
+import { getConfigValue } from '../lib/kv';
+import {
+  AUTONOMY_LAST_RUN_KEY,
+  AUTONOMY_RUN_LOG_KEY,
+  AutonomyRunLogEntry,
+} from './fullAutonomy';
+import { sendTelegramMessage } from './lib/telegramClient';
+
+const DENVER_TZ = 'America/Denver';
+const DEFAULT_WINDOW_HOURS = 24;
+const MAX_ALERT_LINES = 6;
+
+interface DigestOptions {
+  since?: string | null;
+  send?: boolean;
+}
+
+interface ParsedOptions extends DigestOptions {
+  rawSince?: string | null;
+}
+
+interface DigestResult {
+  text: string;
+  since: string;
+  until: string;
+  runs: AutonomyRunLogEntry[];
+}
+
+function toDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatDenver(iso: string | null | undefined): string {
+  if (!iso) return 'unknown';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString('en-US', {
+    timeZone: DENVER_TZ,
+    hour12: false,
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+async function fetchRunHistory(): Promise<AutonomyRunLogEntry[]> {
+  try {
+    const data = await getConfigValue<AutonomyRunLogEntry[]>(AUTONOMY_RUN_LOG_KEY, { type: 'json' });
+    if (Array.isArray(data)) {
+      return data.filter((entry): entry is AutonomyRunLogEntry => !!entry && typeof entry === 'object');
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!/Failed to fetch config/.test(message)) {
+      console.warn('[digest] Unable to load run history:', err);
+    }
+  }
+
+  try {
+    const latest = await getConfigValue<AutonomyRunLogEntry>(AUTONOMY_LAST_RUN_KEY, { type: 'json' });
+    if (latest && typeof latest === 'object') {
+      return [latest];
+    }
+  } catch {
+    // ignore — handled as empty history
+  }
+
+  return [];
+}
+
+function resolveSinceTimestamp(
+  rawSince: string | null | undefined,
+  history: AutonomyRunLogEntry[],
+): string {
+  if (rawSince && rawSince.toLowerCase() === 'lastquietstart') {
+    for (const entry of history) {
+      if (entry?.quiet?.windowStart) {
+        return entry.quiet.windowStart;
+      }
+    }
+  }
+
+  if (rawSince) {
+    const parsed = toDate(rawSince);
+    if (parsed) return parsed.toISOString();
+    console.warn(`[digest] Ignoring invalid --since value: ${rawSince}`);
+  }
+
+  const fallback = new Date(Date.now() - DEFAULT_WINDOW_HOURS * 60 * 60 * 1000);
+  return fallback.toISOString();
+}
+
+function parseArgs(argv: string[]): ParsedOptions {
+  const options: ParsedOptions = { send: true, rawSince: null };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--since') {
+      options.rawSince = argv[index + 1] ?? null;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith('--since=')) {
+      options.rawSince = arg.slice('--since='.length);
+      continue;
+    }
+    if (arg === '--no-send' || arg === '--dry-run') {
+      options.send = false;
+      continue;
+    }
+    if (arg === '--send') {
+      options.send = true;
+      continue;
+    }
+  }
+
+  if (options.rawSince) {
+    options.since = options.rawSince;
+  }
+
+  return options;
+}
+
+function clampAlerts(entries: string[]): string[] {
+  if (entries.length <= MAX_ALERT_LINES) return entries;
+  return [...entries.slice(0, MAX_ALERT_LINES - 1), `… ${entries.length - (MAX_ALERT_LINES - 1)} more`];
+}
+
+function summarizeAlerts(
+  runs: AutonomyRunLogEntry[],
+  selector: (entry: AutonomyRunLogEntry) => string[],
+): string[] {
+  const lines: string[] = [];
+  for (const run of [...runs].reverse()) {
+    const when = formatDenver(run.finishedAt ?? run.startedAt);
+    for (const alert of selector(run)) {
+      if (!alert) continue;
+      lines.push(`${when} — ${alert}`);
+    }
+  }
+  return clampAlerts(lines);
+}
+
+function summarizeActions(runs: AutonomyRunLogEntry[]): string[] {
+  const lines: string[] = [];
+  for (const run of [...runs].reverse()) {
+    if (!Array.isArray(run.actions)) continue;
+    const when = formatDenver(run.finishedAt ?? run.startedAt);
+    for (const action of run.actions) {
+      if (!action) continue;
+      lines.push(`${when} — ${action}`);
+    }
+  }
+  return clampAlerts(lines);
+}
+
+function formatNextRun(nextRun: string | null | undefined): string {
+  if (!nextRun) return 'unscheduled';
+  return `${formatDenver(nextRun)} (${DENVER_TZ})`;
+}
+
+export async function buildDigest(options: DigestOptions = {}): Promise<DigestResult> {
+  const history = await fetchRunHistory();
+  const sinceIso = resolveSinceTimestamp(options.since ?? null, history);
+  const sinceDate = new Date(sinceIso);
+
+  const filtered = history
+    .filter((entry) => {
+      const finished = toDate(entry.finishedAt) ?? toDate(entry.startedAt);
+      if (!finished) return false;
+      return finished.getTime() >= sinceDate.getTime();
+    })
+    .sort((a, b) => {
+      const left = toDate(a.finishedAt) ?? toDate(a.startedAt);
+      const right = toDate(b.finishedAt) ?? toDate(b.startedAt);
+      if (!left && !right) return 0;
+      if (!left) return -1;
+      if (!right) return 1;
+      return left.getTime() - right.getTime();
+    });
+
+  const untilIso = filtered.length
+    ? (toDate(filtered[filtered.length - 1].finishedAt) ?? new Date()).toISOString()
+    : new Date().toISOString();
+
+  const totalRuns = filtered.length;
+  const quietRuns = filtered.filter((entry) => entry?.quiet?.muted).length;
+  const criticalRuns = filtered.filter((entry) => entry.critical).length;
+  const errorRuns = filtered.filter((entry) => entry.errors?.length).length;
+  const warningRuns = filtered.filter((entry) => entry.warnings?.length).length;
+  const latest = filtered[filtered.length - 1] ?? history[0] ?? null;
+
+  const alertLines = summarizeAlerts(filtered, (entry) => entry.errors ?? []);
+  const warningLines = summarizeAlerts(filtered, (entry) => entry.warnings ?? []);
+  const actionLines = summarizeActions(filtered);
+
+  const queue = latest?.queue;
+  const nextRun = latest?.nextRun ?? latest?.statusTimestamp ?? null;
+
+  const parts: string[] = [];
+  parts.push('📰 Maggie Digest');
+  parts.push(`🕒 Window: ${formatDenver(sinceIso)} → ${formatDenver(untilIso)} (${DENVER_TZ})`);
+  const metaBits: string[] = [`🔁 Runs: ${totalRuns}`];
+  if (quietRuns) metaBits.push(`🔕 Quiet: ${quietRuns}`);
+  if (criticalRuns) metaBits.push(`❗ Critical: ${criticalRuns}`);
+  if (errorRuns) metaBits.push(`❌ Errors: ${errorRuns}`);
+  if (warningRuns) metaBits.push(`⚠️ Warns: ${warningRuns}`);
+  parts.push(metaBits.join(' • '));
+  if (latest) {
+    parts.push(`🧾 Summary: ${latest.summary?.text ?? 'No summary available'}`);
+  }
+
+  if (queue) {
+    const scheduled = queue.scheduled ?? '0';
+    const retries = queue.retries ?? '0';
+    const nextPost = queue.nextPost ? String(queue.nextPost) : 'none';
+    parts.push(`📅 Queue: ${scheduled} scheduled • 🔁 ${retries} retries • ➡️ ${nextPost}`);
+  }
+
+  parts.push(`⏭️ Next: ${formatNextRun(nextRun)}`);
+
+  if (alertLines.length) {
+    parts.push('❌ Alerts:');
+    parts.push(...alertLines.map((line) => `• ${line}`));
+  }
+
+  if (warningLines.length) {
+    parts.push('⚠️ Warnings:');
+    parts.push(...warningLines.map((line) => `• ${line}`));
+  }
+
+  if (actionLines.length) {
+    parts.push('📝 Actions:');
+    parts.push(...actionLines.map((line) => `• ${line}`));
+  }
+
+  if (!alertLines.length && !warningLines.length && !actionLines.length) {
+    parts.push('✅ No notable alerts or actions recorded in this window.');
+  }
+
+  return {
+    text: parts.join('\n'),
+    since: sinceIso,
+    until: untilIso,
+    runs: filtered,
+  };
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const result = await buildDigest({ since: options.rawSince });
+
+  if (options.send !== false) {
+    const response = await sendTelegramMessage(result.text);
+    if (!response.ok) {
+      console.warn('[digest] Failed to send Telegram digest:', response.error ?? response.status);
+    }
+  } else {
+    console.log(result.text);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error('[digest] Fatal error:', err);
+    process.exitCode = 1;
+  });
+}
+
+export default buildDigest;


### PR DESCRIPTION
## Summary
- adjust full autonomy loop for quiet hour muting and persist run outcomes
- add daily and catch-up digest workflows driven by new digest script
- enhance Telegram status commands and worker status output to surface run state

## Testing
- pnpm tsx scripts/digest.ts --no-send
- pnpm eslint scripts/fullAutonomy.ts scripts/digest.ts scripts/runTelegram.ts worker/worker.ts # fails: ESLint couldn't find a configuration file

------
https://chatgpt.com/codex/tasks/task_e_68d410ee3cc483279e91a3a802e3e403