### PR TITLE
feat: quiet hours with daily + catch-up digests

### DIFF
--- a/.github/workflows/catchup-digest.yml
+++ b/.github/workflows/catchup-digest.yml
@@ -1,0 +1,41 @@
+name: Catch-up Digest
+
+on:
+  schedule:
+    - cron: '5 13 * * *'
+  workflow_dispatch:
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    env:
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+      WORKER_URL: ${{ secrets.WORKER_URL }}
+      WORKER_BASE_URL: ${{ secrets.WORKER_URL }}
+      WORKER_KEY: ${{ secrets.WORKER_KEY }}
+      POST_THREAD_SECRET: ${{ secrets.WORKER_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+          run_install: false
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Send catch-up digest
+        run: pnpm tsx scripts/digest.ts --since lastQuietStart

--- a/.github/workflows/daily-digest.yml
+++ b/.github/workflows/daily-digest.yml
@@ -1,0 +1,42 @@
+name: Daily Digest
+
+on:
+  schedule:
+    - cron: '5 6 * 4-10 *'
+    - cron: '5 7 * 1-3,11-12 *'
+  workflow_dispatch:
+
+jobs:
+  digest:
+    runs-on: ubuntu-latest
+    env:
+      TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+      TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+      WORKER_URL: ${{ secrets.WORKER_URL }}
+      WORKER_BASE_URL: ${{ secrets.WORKER_URL }}
+      WORKER_KEY: ${{ secrets.WORKER_KEY }}
+      POST_THREAD_SECRET: ${{ secrets.WORKER_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+          run_install: false
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.0 --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Send daily digest
+        run: pnpm tsx scripts/digest.ts

--- a/.github/workflows/full-autonomy.yml
+++ b/.github/workflows/full-autonomy.yml
@@ -2,7 +2,7 @@ name: Full Autonomy
 
 on:
   schedule:
-    - cron: '*/15 * * * *'
+    - cron: '*/5 * * * *'
   workflow_dispatch:
 
 jobs:
@@ -23,7 +23,7 @@ jobs:
       NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
       NOTION_DONOR_PAGE_ID: ${{ secrets.NOTION_DONOR_PAGE_ID }}
       AUTONOMY_TASK: full-autonomy
-      AUTONOMY_CHECKS: stripe=pending,tally=pending,social=pending,fileCleanup=pending,marketing=pending
+      AUTONOMY_CHECKS: website=pending,stripe=pending,tally=pending,social=pending,fileCleanup=pending,marketing=pending
     steps:
       - uses: actions/checkout@v4
 
@@ -59,21 +59,107 @@ jobs:
       - name: Run Maggie orchestrator
         run: pnpm tsx scripts/fullAutonomy.ts
 
-      - name: Notify Telegram completion
+      - name: Evaluate run summary
         if: always()
+        id: summary
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const path = require('path');
+
+          const outputPath = path.resolve('run-output.json');
+          let data = null;
+          try {
+            const raw = fs.readFileSync(outputPath, 'utf8');
+            data = JSON.parse(raw);
+          } catch (err) {
+            console.warn('[autonomy] Unable to read run-output.json:', err?.message ?? err);
+          }
+
+          const lines = [];
+          let critical = false;
+          let inQuiet = false;
+          if (data) {
+            critical = data.critical === true || (Array.isArray(data.errors) && data.errors.length > 0);
+            inQuiet = !!(data.quiet && data.quiet.inQuiet);
+            const icon = critical ? '🚨' : data.ok === false ? '⚠️' : '✅';
+            const summary = typeof data.summary === 'string' && data.summary.trim().length
+              ? data.summary.trim()
+              : 'Autonomy run complete.';
+            lines.push(`${icon} <b>Maggie autonomy</b>`);
+            lines.push(summary);
+            if (Array.isArray(data.actions) && data.actions.length) {
+              lines.push('⚙️ Actions:');
+              for (const action of data.actions) {
+                lines.push(`• ${action}`);
+              }
+            } else {
+              lines.push('⚙️ Actions: none');
+            }
+            if (Array.isArray(data.errors) && data.errors.length) {
+              lines.push('⚠️ Alerts:');
+              for (const issue of data.errors) {
+                const label = issue?.label ?? issue?.key ?? 'alert';
+                const detail = issue?.detail ?? 'Check failed.';
+                lines.push(`• ${label} — ${detail}`);
+              }
+            } else {
+              lines.push('⚠️ Alerts: none');
+            }
+            if (Array.isArray(data.warnings) && data.warnings.length) {
+              lines.push('🟡 Warnings:');
+              for (const issue of data.warnings) {
+                const label = issue?.label ?? issue?.key ?? 'warning';
+                const detail = issue?.detail ?? 'Degraded check.';
+                lines.push(`• ${label} — ${detail}`);
+              }
+            }
+            if (typeof data.nextRun === 'string' && data.nextRun.trim().length) {
+              const next = new Date(data.nextRun);
+              if (!Number.isNaN(next.getTime())) {
+                const nextLabel = new Intl.DateTimeFormat('en-US', {
+                  timeZone: 'America/Denver',
+                  dateStyle: 'medium',
+                  timeStyle: 'short',
+                  timeZoneName: 'short',
+                }).format(next);
+                lines.push(`➡️ Next: ${nextLabel}`);
+              }
+            }
+          } else {
+            critical = true;
+            lines.push('⚠️ <b>Maggie autonomy</b>');
+            lines.push('Run completed but run-output.json was not generated.');
+          }
+
+          const shouldNotify = critical || !inQuiet;
+          console.log('shouldNotify:', shouldNotify);
+          console.log('critical:', critical);
+          console.log('inQuiet:', inQuiet);
+
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `should_notify=${shouldNotify}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `critical=${critical}\n`);
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `in_quiet=${inQuiet}\n`);
+
+          const message = lines.join('\n');
+          fs.appendFileSync(process.env.GITHUB_ENV, `AUTONOMY_MESSAGE<<'EOF'\n${message}\nEOF\n`);
+          NODE
+
+      - name: Notify Telegram completion
+        if: ${{ always() && steps.summary.outputs.should_notify == 'true' }}
         env:
           TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
           TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          AUTONOMY_MESSAGE: ${{ env.AUTONOMY_MESSAGE }}
         run: |
-          if [ -n "${TELEGRAM_BOT_TOKEN}" ] && [ -n "${TELEGRAM_CHAT_ID}" ]; then
-            DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-            curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
-              --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
-              --data-urlencode "text=Maggie run complete at ${DATE}" \
-              > /dev/null
-          else
+          if [ -z "${TELEGRAM_BOT_TOKEN}" ] || [ -z "${TELEGRAM_CHAT_ID}" ]; then
             echo "Skipping Telegram notify – credentials missing"
+            exit 0
           fi
+          curl -sS -X POST "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+            --data-urlencode "chat_id=${TELEGRAM_CHAT_ID}" \
+            --data-urlencode "text=${AUTONOMY_MESSAGE}" \
+            > /dev/null
 
       - name: Stamp run metadata
         if: always()
@@ -86,14 +172,14 @@ jobs:
           now = datetime.now(timezone.utc)
           with open(path, 'a', encoding='utf-8') as fh:
               fh.write(f"AUTONOMY_TIMESTAMP={now.isoformat().replace('+00:00','Z')}\n")
-              fh.write(f"AUTONOMY_NEXT_RUN={(now + timedelta(minutes=15)).isoformat().replace('+00:00','Z')}\n")
+              fh.write(f"AUTONOMY_NEXT_RUN={(now + timedelta(minutes=5)).isoformat().replace('+00:00','Z')}\n")
           PY
 
       - name: Publish failure heartbeat
         if: failure()
         run: |
           {
-            echo "AUTONOMY_CHECKS=stripe=fail:workflow-error,tally=fail:workflow-error,social=fail:workflow-error,fileCleanup=fail:workflow-error,marketing=fail:workflow-error"
+            echo "AUTONOMY_CHECKS=website=fail:workflow-error,stripe=fail:workflow-error,tally=fail:workflow-error,social=fail:workflow-error,fileCleanup=fail:workflow-error,marketing=fail:workflow-error"
           } >> "$GITHUB_ENV"
           pnpm tsx scripts/fullAutonomy.ts --from-env
 

--- a/scripts/digest.ts
+++ b/scripts/digest.ts
@@ -1,0 +1,253 @@
+import process from 'node:process';
+
+import type { AutonomyRunIssue, AutonomyRunLogEntry } from '../shared/maggieState';
+import { sendTelegramMessage } from './lib/telegramClient';
+import { formatInTimeZone, resolveSince, QUIET_TIMEZONE } from './lib/timeUtils';
+
+interface DigestGenerateOptions {
+  since?: Date;
+  sinceInput?: string;
+  now?: Date;
+}
+
+interface DigestResult {
+  since: Date;
+  until: Date;
+  runs: AutonomyRunLogEntry[];
+  actions: string[];
+  errors: AutonomyRunIssue[];
+  warnings: AutonomyRunIssue[];
+  message: string;
+  hasAlerts: boolean;
+}
+
+function resolveWorkerBase(env: NodeJS.ProcessEnv): string {
+  const candidate =
+    env.WORKER_URL ||
+    env.WORKER_BASE_URL ||
+    env.WORKER_ENDPOINT ||
+    env.MAGS_WORKER_URL ||
+    env.MAGGIE_WORKER_URL;
+  if (!candidate) {
+    throw new Error('WORKER_URL not configured');
+  }
+  return candidate.trim().replace(/\/$/, '');
+}
+
+async function fetchWorkerStatus(env: NodeJS.ProcessEnv): Promise<any> {
+  const base = resolveWorkerBase(env);
+  const url = `${base}/status`;
+  const headers = new Headers();
+  const token =
+    env.WORKER_KEY || env.POST_THREAD_SECRET || env.MAGGIE_WORKER_KEY || env.CF_WORKER_KEY || env.AUTONOMY_WORKER_KEY;
+  if (token) {
+    headers.set('authorization', `Bearer ${token}`);
+  }
+  const res = await fetch(url, { headers });
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Worker status HTTP ${res.status}${text ? ` ${text}` : ''}`);
+  }
+  return res.json();
+}
+
+function coerceDate(value: unknown): Date | null {
+  if (!value) return null;
+  const date = new Date(String(value));
+  if (Number.isNaN(date.getTime())) return null;
+  return date;
+}
+
+function sortRuns(runs: AutonomyRunLogEntry[]): AutonomyRunLogEntry[] {
+  return [...runs].sort((a, b) => {
+    const left = coerceDate(a.finishedAt) ?? new Date(0);
+    const right = coerceDate(b.finishedAt) ?? new Date(0);
+    return right.getTime() - left.getTime();
+  });
+}
+
+function dedupeList(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+function dedupeIssues(issues: AutonomyRunIssue[]): AutonomyRunIssue[] {
+  const map = new Map<string, AutonomyRunIssue>();
+  for (const issue of issues) {
+    const key = `${issue.key}:${issue.detail ?? ''}`;
+    if (!map.has(key)) {
+      map.set(key, issue);
+    }
+  }
+  return [...map.values()];
+}
+
+function formatWindowLine(since: Date, until: Date): string {
+  const start = formatInTimeZone(since, QUIET_TIMEZONE, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZoneName: 'short',
+  });
+  const end = formatInTimeZone(until, QUIET_TIMEZONE, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZoneName: 'short',
+  });
+  return `${start} → ${end}`;
+}
+
+function formatIssues(icon: string, title: string, issues: AutonomyRunIssue[]): string[] {
+  if (!issues.length) {
+    return [];
+  }
+  const lines = [`${icon} <b>${title}</b>`];
+  for (const issue of issues) {
+    const label = issue.label ?? issue.key;
+    const detail = issue.detail ?? 'No detail recorded.';
+    lines.push(`• ${label} — ${detail}`);
+  }
+  return lines;
+}
+
+function formatActions(actions: string[]): string[] {
+  if (!actions.length) {
+    return ['⚙️ Actions: none'];
+  }
+  return ['⚙️ <b>Actions</b>', ...actions.map((action) => `• ${action}`)];
+}
+
+function buildDigestMessage(
+  since: Date,
+  until: Date,
+  runs: AutonomyRunLogEntry[],
+  actions: string[],
+  errors: AutonomyRunIssue[],
+  warnings: AutonomyRunIssue[],
+  status: any,
+): string {
+  const lines: string[] = [];
+  const criticalRuns = runs.filter((run) => run.critical).length;
+  const alertsCount = errors.length;
+  const warningsCount = warnings.length;
+  lines.push('🗓️ <b>Maggie Digest</b>');
+  lines.push(`⏱️ <i>${formatWindowLine(since, until)}</i>`);
+  let runsLine = `🔁 Runs: ${runs.length}`;
+  if (criticalRuns) runsLine += ` • ${criticalRuns} critical`;
+  if (alertsCount) runsLine += ` • ${alertsCount} alert${alertsCount === 1 ? '' : 's'}`;
+  if (warningsCount) runsLine += ` • ${warningsCount} warning${warningsCount === 1 ? '' : 's'}`;
+  lines.push(runsLine);
+  lines.push(...formatActions(actions));
+  lines.push(...formatIssues('⚠️', 'Alerts', errors));
+  lines.push(...formatIssues('🟡', 'Warnings', warnings));
+
+  const [latestRun] = runs;
+  if (latestRun) {
+    const finished = coerceDate(latestRun.finishedAt);
+    if (finished) {
+      const finishedLabel = formatInTimeZone(finished, QUIET_TIMEZONE, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+        timeZoneName: 'short',
+      });
+      const summary = latestRun.summary ?? 'No summary recorded.';
+      lines.push(`🧾 Last run: ${finishedLabel} — ${summary}`);
+    }
+  } else if (status?.autonomy?.lastRunAt) {
+    const finished = coerceDate(status.autonomy.lastRunAt);
+    if (finished) {
+      const finishedLabel = formatInTimeZone(finished, QUIET_TIMEZONE, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+        timeZoneName: 'short',
+      });
+      const summary = status.autonomy.lastSummary ?? 'No summary recorded.';
+      lines.push(`🧾 Last run: ${finishedLabel} — ${summary}`);
+    }
+  }
+
+  const nextRunIso = status?.nextRun ?? status?.autonomy?.lastNextRun;
+  if (typeof nextRunIso === 'string') {
+    const next = coerceDate(nextRunIso);
+    if (next) {
+      const nextLabel = formatInTimeZone(next, QUIET_TIMEZONE, {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+        timeZoneName: 'short',
+      });
+      lines.push(`➡️ Next: ${nextLabel}`);
+    }
+  }
+
+  const social = status?.socialQueue;
+  if (social) {
+    const scheduled = typeof social.scheduled === 'number' ? social.scheduled : 0;
+    const retries = typeof social.flopsRetry === 'number' ? social.flopsRetry : 0;
+    lines.push(`📅 Social queue: ${scheduled} scheduled • ${retries} retries`);
+  }
+
+  return lines.join('\n');
+}
+
+export async function generateDigest(options: DigestGenerateOptions = {}): Promise<DigestResult> {
+  const now = options.now ?? new Date();
+  const since = options.since ?? resolveSince(options.sinceInput ?? null, now);
+  const status = await fetchWorkerStatus(process.env);
+  const history: AutonomyRunLogEntry[] = Array.isArray(status?.autonomy?.history)
+    ? (status.autonomy.history as AutonomyRunLogEntry[])
+    : [];
+  const filtered = history.filter((entry) => {
+    const finished = coerceDate(entry.finishedAt);
+    return finished ? finished.getTime() >= since.getTime() : false;
+  });
+  const runs = sortRuns(filtered);
+  const actions = dedupeList(runs.flatMap((run) => run.actions ?? []));
+  const errors = dedupeIssues(runs.flatMap((run) => run.errors ?? []));
+  const warnings = dedupeIssues(runs.flatMap((run) => run.warnings ?? []));
+  const message = buildDigestMessage(since, now, runs, actions, errors, warnings, status);
+  const hasAlerts = runs.some((run) => run.critical) || errors.length > 0;
+  return { since, until: now, runs, actions, errors, warnings, message, hasAlerts };
+}
+
+interface CliOptions {
+  since?: string;
+  dryRun?: boolean;
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  const options: CliOptions = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--since' && argv[i + 1]) {
+      options.since = argv[i + 1];
+      i += 1;
+    } else if (arg === '--no-send' || arg === '--dry-run') {
+      options.dryRun = true;
+    }
+  }
+  return options;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const result = await generateDigest({ sinceInput: args.since });
+  console.log(result.message);
+  if (!args.dryRun) {
+    await sendTelegramMessage(result.message);
+  }
+}
+
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error('[digest] Failed to generate digest:', err);
+    process.exitCode = 1;
+  });
+}
+
+export type { DigestResult };

--- a/scripts/lib/timeUtils.ts
+++ b/scripts/lib/timeUtils.ts
@@ -1,0 +1,98 @@
+const QUIET_TIMEZONE = 'America/Denver';
+const QUIET_START_HOUR = 22;
+const QUIET_DURATION_HOURS = 9;
+
+interface DenverParts {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  second: number;
+}
+
+const partsFormatter = new Intl.DateTimeFormat('en-US', {
+  timeZone: QUIET_TIMEZONE,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+});
+
+export interface QuietWindow {
+  start: Date;
+  end: Date;
+  timeZone: string;
+}
+
+function extractParts(date: Date): DenverParts {
+  const parts = partsFormatter.formatToParts(date);
+  const lookup = new Map(parts.map((part) => [part.type, part.value]));
+  const value = (key: string, fallback: number) => {
+    const raw = lookup.get(key);
+    if (!raw) return fallback;
+    const parsed = Number.parseInt(raw, 10);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  };
+  return {
+    year: value('year', date.getUTCFullYear()),
+    month: value('month', date.getUTCMonth() + 1),
+    day: value('day', date.getUTCDate()),
+    hour: value('hour', date.getUTCHours()),
+    minute: value('minute', date.getUTCMinutes()),
+    second: value('second', date.getUTCSeconds()),
+  };
+}
+
+function denverDateToUtc(parts: DenverParts, hour: number, minute = 0, second = 0): Date {
+  const base = Date.UTC(parts.year, parts.month - 1, parts.day, hour, minute, second);
+  const asDenver = new Date(new Date(base).toLocaleString('en-US', { timeZone: QUIET_TIMEZONE }));
+  const offset = base - asDenver.getTime();
+  return new Date(base + offset);
+}
+
+export function computeQuietWindow(reference: Date = new Date()): QuietWindow {
+  const referenceParts = extractParts(reference);
+  const usePreviousDay = referenceParts.hour < QUIET_START_HOUR;
+  const baseRef = usePreviousDay ? new Date(reference.getTime() - 24 * 60 * 60 * 1000) : reference;
+  const baseParts = extractParts(baseRef);
+  const start = denverDateToUtc(baseParts, QUIET_START_HOUR, 0, 0);
+  const end = new Date(start.getTime() + QUIET_DURATION_HOURS * 60 * 60 * 1000);
+  return { start, end, timeZone: QUIET_TIMEZONE };
+}
+
+export function isWithinQuietHours(date: Date): boolean {
+  const window = computeQuietWindow(date);
+  return date >= window.start && date < window.end;
+}
+
+export function formatInTimeZone(
+  date: Date,
+  timeZone: string = QUIET_TIMEZONE,
+  options: Intl.DateTimeFormatOptions = {},
+): string {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    ...options,
+  });
+  return formatter.format(date);
+}
+
+export function resolveSince(value: string | undefined | null, now: Date = new Date()): Date {
+  if (!value) {
+    return new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  }
+  if (value === 'lastQuietStart') {
+    return computeQuietWindow(now).start;
+  }
+  const parsed = new Date(value);
+  if (!Number.isNaN(parsed.getTime())) {
+    return parsed;
+  }
+  return new Date(now.getTime() - 24 * 60 * 60 * 1000);
+}
+
+export { QUIET_TIMEZONE, QUIET_START_HOUR, QUIET_DURATION_HOURS };

--- a/scripts/runTelegram.ts
+++ b/scripts/runTelegram.ts
@@ -1,6 +1,11 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
 import { publishSite } from './publishSite';
 import { selfHeal } from './selfHeal';
+import { generateDigest } from './digest';
 import { sendTelegramMessage } from './lib/telegramClient';
+import { formatInTimeZone, QUIET_TIMEZONE } from './lib/timeUtils';
 
 const POLL_TIMEOUT_SEC = 30;
 const ERROR_BACKOFF_MS = 5000;
@@ -90,15 +95,171 @@ function describeTikTokSessions(): string {
   return `✅ ${sessions.length} TikTok session cookie(s) present`;
 }
 
+async function fetchAutonomyStatus(): Promise<any | null> {
+  const base =
+    process.env.WORKER_URL ||
+    process.env.WORKER_BASE_URL ||
+    process.env.WORKER_ENDPOINT ||
+    process.env.MAGS_WORKER_URL ||
+    process.env.MAGGIE_WORKER_URL;
+  if (!base) return null;
+  const url = `${base.trim().replace(/\/$/, '')}/status`;
+  const headers = new Headers();
+  const token =
+    process.env.WORKER_KEY ||
+    process.env.POST_THREAD_SECRET ||
+    process.env.MAGGIE_WORKER_KEY ||
+    process.env.CF_WORKER_KEY ||
+    process.env.AUTONOMY_WORKER_KEY;
+  if (token) {
+    headers.set('authorization', `Bearer ${token}`);
+  }
+  try {
+    const res = await fetch(url, { headers });
+    if (!res.ok) {
+      console.warn('[telegram] /status returned', res.status);
+      return null;
+    }
+    return res.json();
+  } catch (err) {
+    console.warn('[telegram] Failed to fetch /status:', err);
+    return null;
+  }
+}
+
+async function loadOpsQueueSummary(): Promise<{ queued: number; failures: number; lastRunAt: string | null } | null> {
+  const queuePath = path.resolve('queue.json');
+  try {
+    const raw = await fs.readFile(queuePath, 'utf8');
+    const parsed = JSON.parse(raw) as { items?: unknown[]; failures?: unknown[]; lastRunAt?: string };
+    const queued = Array.isArray(parsed.items) ? parsed.items.length : 0;
+    const failures = Array.isArray(parsed.failures) ? parsed.failures.length : 0;
+    const lastRunAt = typeof parsed.lastRunAt === 'string' ? parsed.lastRunAt : null;
+    return { queued, failures, lastRunAt };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+      console.warn('[telegram] Unable to read queue.json:', err);
+    }
+    return null;
+  }
+}
+
+function formatRelativeTime(iso: string | null | undefined): string {
+  if (!iso) return 'unknown';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  const diff = Date.now() - date.getTime();
+  const abs = Math.abs(diff);
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (abs < minute) return 'just now';
+  if (abs < hour) {
+    const minutes = Math.round(diff / minute);
+    const value = Math.abs(minutes);
+    const unit = value === 1 ? 'minute' : 'minutes';
+    return minutes >= 0 ? `${value} ${unit} ago` : `in ${value} ${unit}`;
+  }
+  if (abs < day) {
+    const hours = Math.round(diff / hour);
+    const value = Math.abs(hours);
+    const unit = value === 1 ? 'hour' : 'hours';
+    return hours >= 0 ? `${value} ${unit} ago` : `in ${value} ${unit}`;
+  }
+  const days = Math.round(diff / day);
+  const value = Math.abs(days);
+  const unit = value === 1 ? 'day' : 'days';
+  return days >= 0 ? `${value} ${unit} ago` : `in ${value} ${unit}`;
+}
+
+function describeTimestamp(iso: string | null | undefined): string {
+  if (!iso) return 'n/a';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  const absolute = formatInTimeZone(date, QUIET_TIMEZONE, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZoneName: 'short',
+  });
+  const relative = formatRelativeTime(iso);
+  return `${absolute} (${relative})`;
+}
+
 async function handleStatus(chatId: string) {
-  const [worker, browserless, tikTok] = await Promise.all([
+  const [worker, browserless, tikTok, status, queue] = await Promise.all([
     fetchWorkerHealth(),
     Promise.resolve(describeBrowserless()),
     Promise.resolve(describeTikTokSessions()),
+    fetchAutonomyStatus(),
+    loadOpsQueueSummary(),
   ]);
 
-  const timestamp = new Date().toISOString();
-  const message = `🛰️ <b>Maggie Status</b>\n${worker}\n${browserless}\n${tikTok}\n⏱️ <i>${timestamp}</i>`;
+  const timestamp = formatInTimeZone(new Date(), QUIET_TIMEZONE, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZoneName: 'short',
+  });
+
+  const lines: string[] = [];
+  lines.push('🛰️ <b>Maggie Status</b>');
+  lines.push(`🕒 <i>${timestamp}</i>`);
+  lines.push(worker);
+  lines.push(browserless);
+  lines.push(tikTok);
+
+  if (status) {
+    const autonomy = status.autonomy ?? {};
+    const lastSummary = typeof autonomy.lastSummary === 'string' && autonomy.lastSummary.trim().length
+      ? autonomy.lastSummary
+      : 'No summary recorded.';
+    lines.push(`🔁 Last run: ${describeTimestamp(autonomy.lastRunAt)} — ${lastSummary}`);
+    const nextRun = typeof status.nextRun === 'string' ? status.nextRun : autonomy.lastNextRun;
+    lines.push(`➡️ Next: ${describeTimestamp(typeof nextRun === 'string' ? nextRun : null)}`);
+    const social = status.socialQueue ?? {};
+    const scheduled = typeof social.scheduled === 'number' ? social.scheduled : 0;
+    const retries = typeof social.flopsRetry === 'number' ? social.flopsRetry : 0;
+    lines.push(`📅 Social queue: ${scheduled} scheduled • ${retries} retries`);
+    const actions = Array.isArray(autonomy.lastActions) ? autonomy.lastActions : [];
+    if (actions.length) {
+      lines.push('⚙️ Actions:');
+      for (const action of actions) {
+        lines.push(`• ${action}`);
+      }
+    } else {
+      lines.push('⚙️ Actions: none');
+    }
+    const errors = Array.isArray(autonomy.lastErrors) ? autonomy.lastErrors : [];
+    if (errors.length) {
+      lines.push('⚠️ Alerts:');
+      for (const issue of errors) {
+        const label = issue?.label ?? issue?.key ?? 'alert';
+        const detail = issue?.detail ?? 'Check failed.';
+        lines.push(`• ${label} — ${detail}`);
+      }
+    } else {
+      lines.push('⚠️ Alerts: none');
+    }
+    const warnings = Array.isArray(autonomy.lastWarnings) ? autonomy.lastWarnings : [];
+    if (warnings.length) {
+      lines.push('🟡 Warnings:');
+      for (const issue of warnings) {
+        const label = issue?.label ?? issue?.key ?? 'warning';
+        const detail = issue?.detail ?? 'Degraded check.';
+        lines.push(`• ${label} — ${detail}`);
+      }
+    }
+  } else {
+    lines.push('ℹ️ Autonomy status unavailable.');
+  }
+
+  if (queue) {
+    lines.push(`📦 Queue: ${queue.queued} queued • ${queue.failures} failures`);
+    if (queue.lastRunAt) {
+      lines.push(`Last worker tick: ${describeTimestamp(queue.lastRunAt)}`);
+    }
+  }
+
+  const message = lines.filter(Boolean).join('\n');
   await sendReply(chatId, message);
 }
 
@@ -155,6 +316,16 @@ async function handleCommand(chatId: string, text: string) {
     case '/status':
       await handleStatus(chatId);
       break;
+    case '/digest':
+      try {
+        const digest = await generateDigest();
+        await sendReply(chatId, digest.message);
+        await notifyDefaultChannel(digest.message, chatId);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        await sendReply(chatId, `❌ <b>Digest failed</b>\n<code>${message}</code>`);
+      }
+      break;
     case '/publish-site':
       await handlePublish(chatId);
       break;
@@ -162,7 +333,7 @@ async function handleCommand(chatId: string, text: string) {
       await handleSelfHeal(chatId);
       break;
     default:
-      await sendReply(chatId, '🤖 Unknown command. Try /status, /publish-site, or /self-heal.');
+      await sendReply(chatId, '🤖 Unknown command. Try /status, /digest, /publish-site, or /self-heal.');
   }
 }
 

--- a/shared/maggieState.ts
+++ b/shared/maggieState.ts
@@ -5,6 +5,50 @@ export interface MaggieTrend {
   [key: string]: unknown;
 }
 
+export interface AutonomyRunIssue {
+  key: string;
+  label?: string;
+  detail?: string;
+  state?: string;
+  critical?: boolean;
+}
+
+export interface AutonomyRunLogEntry {
+  startedAt: string;
+  finishedAt: string;
+  durationMs?: number;
+  summary?: string;
+  ok?: boolean;
+  critical?: boolean;
+  nextRun?: string | null;
+  actions?: string[];
+  errors?: AutonomyRunIssue[];
+  warnings?: AutonomyRunIssue[];
+  checks?: unknown[];
+  quiet?: {
+    start: string;
+    end: string;
+    inQuiet?: boolean;
+    timeZone?: string;
+  };
+}
+
+export interface AutonomyMetadata {
+  lastRunAt?: string;
+  lastStartedAt?: string;
+  lastNextRun?: string | null;
+  lastSummary?: string;
+  lastDurationMs?: number;
+  lastCritical?: boolean;
+  fallbackQueued?: string[];
+  checks?: string[];
+  history?: AutonomyRunLogEntry[];
+  lastActions?: string[];
+  lastErrors?: AutonomyRunIssue[];
+  lastWarnings?: AutonomyRunIssue[];
+  lastQuietWindow?: AutonomyRunLogEntry['quiet'];
+}
+
 export interface MaggieState {
   currentTasks?: string[];
   lastCheck?: string;
@@ -12,6 +56,7 @@ export interface MaggieState {
   flopRetries?: string[];
   topTrends?: MaggieTrend[];
   website?: string;
+  autonomy?: AutonomyMetadata;
   [key: string]: unknown;
 }
 

--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -97,12 +97,29 @@ export default {
           flopsRetry: state.flopRetries?.length || 0,
           nextPost: state.scheduledPosts?.[0] || null,
         };
+        const autonomy = (typeof state.autonomy === 'object' && state.autonomy !== null
+          ? state.autonomy
+          : {}) as Record<string, any>;
+        const actions = Array.isArray(autonomy.lastActions) ? autonomy.lastActions : [];
+        const errors = Array.isArray(autonomy.lastErrors) ? autonomy.lastErrors : [];
+        const warnings = Array.isArray(autonomy.lastWarnings) ? autonomy.lastWarnings : [];
+        const history = Array.isArray(autonomy.history) ? autonomy.history.slice(0, 50) : [];
+        const nextRun = typeof autonomy.lastNextRun === 'string' ? autonomy.lastNextRun : null;
         const status = {
           time: new Date().toISOString(),
           currentTasks: state.currentTasks || ['idle'],
           lastCheck: state.lastCheck || null,
-          website: 'https://messyandmagnetic.com',
+          website: state.website || 'https://messyandmagnetic.com',
           socialQueue,
+          lastRun: autonomy.lastRunAt ?? null,
+          nextRun,
+          actions,
+          errors,
+          warnings,
+          autonomy: {
+            ...autonomy,
+            history,
+          },
         };
         return new Response(JSON.stringify(status, null, 2), {
           headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- Autonomy loop runs every 5 min.
- Quiet hours (10 pm–7 am ABQ) → only critical alerts bypass.
- Daily digest at midnight ABQ for last 24h.
- Catch-up digest at 7:05 am ABQ with overnight actions.
- /digest command for on-demand summary.
- /status JSON enriched with last/next run and queue state.


------
https://chatgpt.com/codex/tasks/task_e_68d4112e70688327b0393e5a568dd69d