### PR TITLE
Add advanced esoteric expansion for full soul blueprint

### DIFF
--- a/content/fixtures/blueprint/full.md
+++ b/content/fixtures/blueprint/full.md
@@ -34,6 +34,32 @@ Earth + Water lead (stability + empathy). Add Fire in small, intentional bursts 
 ## Aura + Chakra Profile
 Heart and Solar Plexus are the engines: lead with compassion, execute with steady will. Keep Root charged via nature and simple routines.
 
+## Destiny Matrix + Gene Keys
+Your Destiny Matrix threads disciplined builder lines with soft-hearted compassion codes. The Gene Keys mirror that braid: you carry the quiet genius of patience, the magnetic glow of generosity, and the willingness to rewrite inherited rules so communities can breathe. As you honor the slower pulse beneath your productivity, each door opens with less force and more invitation.
+
+## Advanced Soul Systems
+Your Enneagram current hovers between Type Two’s heart-led devotion and Type Three’s builder drive—a 2/3 bridge that explains why people feel both cared for and mobilized around you. That wing-to-wing dance pairs beautifully with your Human Design profile and Life Path number, translating into rhythm cues like Tuesday outreach spurts followed by a sacral rest pocket. Notice how your shoulders drop and breath deepens when you lead with warmth first; that somatic clue tells you you’re still in integrity.
+
+In the Akashic Records, a recurring scene appears: you’re a strategist-healer at a coastal monastery, ringing bells to warn villagers before a storm. That echo explains the déjà vu you feel around sirens, brass, or salt air. Bringing that wisdom forward means scheduling recovery windows before intensity hits and collaborating with people who honor your foresight. A quick chakra scan shows Root and Heart thriving while the Throat hums with a softer charge—color meditations, humming, and a teal scarf help that center stay open. Your Soul Urge Number shifted when you claimed your current name; the old signature asked for safe belonging, the new vibration invites visible leadership. If you feel your chest buzz when someone says your name, that’s confirmation the upgrade landed.
+
+Progressed astrology sketches the next three-year arc: a progressed Sun stepping into a more public house, a Moon craving spacious, water-side mornings, and an Ascendant that wants slower introductions before the big reveal. You’ll know each progression is activating when your palms warm, you dream of dusk light, or you crave citrus—treat those signals as rhythm alerts. Sabian Symbols add poetry: your Sun sits with “A harp whose strings are tuned to the winds,” reminding you to adjust tone rather than force; your rising degree whispers about “An illumined fountain” inviting you to circulate wisdom through community offerings. Let those images guide your weekly content cadence and household check-ins.
+
+An I Ching hexagram of 37, the Clan, floats in, affirming that tending the hearth (literal or digital) is the move; if you hear wind chimes or coin clinks, trust the guidance and reinforce boundaries with your inner circle. Archetype mapping crowns you The Bridge-Healer: part logistics anchor, part mystic translator. Wear the archetype by dedicating one ritual a week to celebratory storytelling—maybe a candlelit audio note or a slow kitchen dance—that keeps your mediumship alive in the body. Mention to clients that advanced helper agents can spin quick icon recaps or kid-friendly translations if layers start to feel dense.
+
+> 🪄 **Advanced Systems Integration**  
+> Your Enneagram compass, Akashic echoes, chakra tune-ups, Soul Urge evolution, progressed astrology forecasts, Sabian mythic images, I Ching whisper, and Archetype quest now braid into one cohesive map. Each modality feeds your aura hygiene and magnet routines, strengthening the clair senses you already trust. These advanced reads live inside the Full Soul Blueprint today—and can become future standalone upgrades whenever you want a deeper dive.
+
+## Magic Codes Key
+✴ Enneagram – Core drive + wing compass; feel for the breath drop when you’re aligned.  
+🌀 Akashic Echo – Past-life clue or ancestral loop; think salt air, bronze bells, or tingling wrists.  
+🕉 Chakra Current – Energy center focus + remedy; pair the noted color with movement or sound.  
+💗 Soul Urge – Heart-longing expression; speak your current name aloud until your chest hums.  
+🌅 Progressed Light – Next 2–3 year phase; watch for dream motifs, seasonal cravings, or new collaborators.  
+📜 Sabian Myth – Poetic mission image; weave it into journal prompts or story-led marketing.  
+☯ I Ching Whisper – Hexagram guidance; coins, breezes, or repeating numbers confirm the cue.  
+🗺 Archetype Trail – Quest role + rhythm; costume it with a weekly ritual or altar moment.  
+Need custom visuals? Ping the icon helper agent and they’ll sketch options to match your vibe.
+
 ## What Makes You Stand Out
 People feel safer and smarter around you. Your gift is turning overwhelm into simple steps without shaming the mess that got them there.
 

--- a/content/validators/blueprint-schema.ts
+++ b/content/validators/blueprint-schema.ts
@@ -5,7 +5,7 @@ interface ValidationResult {
   headings: string[];
 }
 
-const STANDARD_HEADINGS = [
+const BASE_HEADINGS = [
   'Who You Are at Your Core',
   'Your Soul’s Purpose + Mission',
   'Your Gifts and Rare Talents',
@@ -25,6 +25,20 @@ const STANDARD_HEADINGS = [
   'How to Know You’re On or Off Path',
   'Child-Friendly Version',
 ];
+
+const FULL_HEADINGS = [
+  ...BASE_HEADINGS.slice(0, 12),
+  'Destiny Matrix + Gene Keys',
+  'Advanced Soul Systems',
+  'Magic Codes Key',
+  ...BASE_HEADINGS.slice(12),
+];
+
+const HEADINGS_BY_TIER: Record<Exclude<BlueprintTier, 'realignment'>, string[]> = {
+  full: FULL_HEADINGS,
+  lite: BASE_HEADINGS,
+  mini: BASE_HEADINGS,
+};
 
 const REALIGN_REQUIRED = [
   'Why You’re Here',
@@ -75,8 +89,14 @@ export function validateBlueprint(
       if (!allowed.has(h)) throw new Error(`Unexpected heading: ${h}`);
     }
   } else {
-    for (let i = 0; i < STANDARD_HEADINGS.length; i++) {
-      const expected = STANDARD_HEADINGS[i];
+    const expectedHeadings = HEADINGS_BY_TIER[tier] || BASE_HEADINGS;
+    if (headings.length !== expectedHeadings.length) {
+      throw new Error(
+        `Heading count mismatch: expected ${expectedHeadings.length} got ${headings.length}`
+      );
+    }
+    for (let i = 0; i < expectedHeadings.length; i++) {
+      const expected = expectedHeadings[i];
       const actual = headings[i];
       if (actual !== expected) {
         throw new Error(`Heading mismatch at position ${i}: expected ${expected} got ${actual}`);

--- a/soul-blueprint/tiers/full/expansions/advanced-esoteric.json
+++ b/soul-blueprint/tiers/full/expansions/advanced-esoteric.json
@@ -1,0 +1,135 @@
+{
+  "section": {
+    "title": "Advanced Soul Systems",
+    "introduction": "Blend eight additional esoteric modalities into the Full Soul Blueprint immediately after the Destiny Matrix + Gene Keys section. Let the prose feel like a single conversation rather than a checklist.",
+    "mediumshipStyle": "Anchor every insight in tactile, evidential cues—describe the body sensations, deja vu flashes, ancestral echoes, or environmental signs that show up when this soul leans into the teaching.",
+    "rhythmIntegration": "Loop each modality back to Maggie's rhythm language: aura color calibration, chakra pacing, household magnets, and daily pattern resets.",
+    "evidentialExamples": [
+      "left shoulder tingles when truth lands",
+      "palms warming when energy wants to be shared",
+      "sudden memory of salt air or old train stations",
+      "pull toward particular colors or textures"
+    ]
+  },
+  "systems": [
+    {
+      "id": "enneagram",
+      "label": "Enneagram",
+      "icon": "✴",
+      "narrative": "Identify their likely Enneagram type and wing through the emotional signatures already mapped in the charts. Speak to their inner driver, primary fear, and the spiral of evolution they are walking.",
+      "integration": "Link subtype instincts back to the client’s Human Design profile lines and Life Path Number, translating the trio into rhythm cues they can feel in their calendar.",
+      "mediumship": "Name embodied tells—breath cadence, posture shifts, or how their voice softens around certain topics—to confirm the type.",
+      "rhythmTieIn": "Offer one rhythm reminder that keeps the type regulated (rest days, outreach pacing, or magnet resets).",
+      "childTone": "Frame the type as a friendly role (helper, explorer, builder) and give one brave choice they can practice with a caregiver.",
+      "mandatoryMentions": ["enneagram"]
+    },
+    {
+      "id": "akashic",
+      "label": "Akashic Records",
+      "icon": "🌀",
+      "narrative": "Pull through one to three past-life echoes or archetypal scenes that repeat through their lineage. Highlight gifts and karmic loops that now want refinement.",
+      "integration": "Connect each memory to their present vocation or relationship lesson so it feels actionable.",
+      "mediumship": "Offer sensory breadcrumbs—temperature drops, phantom scents, flashes of clothing or architecture—that often accompany the memory.",
+      "rhythmTieIn": "Translate the lesson into a present-day rhythm shift (who they collaborate with, how they schedule recovery, or where they travel).",
+      "mandatoryMentions": ["akashic"],
+      "skipForChild": true
+    },
+    {
+      "id": "chakras",
+      "label": "Chakra Imbalances",
+      "icon": "🕉",
+      "narrative": "Scan all seven chakras for both strength and congestion. Describe how those imprints show up in their daily life and relationships.",
+      "integration": "Provide rhythm-supportive remedies—colors, somatic practices, affirmations, and musical or nature cues that restore flow.",
+      "mediumship": "Mention physical confirmations (buzzing ears, fluttering solar plexus, grounded feet) that alert them when a chakra shifts.",
+      "rhythmTieIn": "Map chakra balance back to their aura color and household cadence so adjustments feel doable.",
+      "childTone": "Use simple color imagery and playful actions for younger souls (dance break, humming, hugging a tree).",
+      "mandatoryMentions": ["chakra"]
+    },
+    {
+      "id": "soul-urge",
+      "label": "Soul Urge Evolution",
+      "icon": "💗",
+      "narrative": "Compare the Soul Urge Number from their birth name with the vibration of their current legal or chosen name. Note any upgrades in emotional expression or clarity of longing.",
+      "integration": "If a name change occurred, reflect how it sharpened their life path or clarified relationships and creative voice.",
+      "mediumship": "Point out signs that confirm the shift—favorite songs, recurring initials, or the sensation of a name resonating in the chest.",
+      "rhythmTieIn": "Recommend one vocal or written ritual that keeps the new Soul Urge humming inside their daily magnet routines.",
+      "childTone": "Explain the Soul Urge as the heart’s nickname and describe how speaking their name with confidence changes the room.",
+      "mandatoryMentions": ["soul urge"]
+    },
+    {
+      "id": "progressed",
+      "label": "Progressed Astrology",
+      "icon": "🌅",
+      "narrative": "Read the progressed Sun, Moon, and Ascendant to map the next two to three years. Name the tone of identity, emotional climate, and outward expression.",
+      "integration": "Offer gentle forecasts and preparation tips so they can organize projects, launches, or sabbaticals around the shifts.",
+      "mediumship": "Describe timing markers—seasonal breezes, dream motifs, or bodily cravings—that signal each progression kicking in.",
+      "rhythmTieIn": "Suggest adjustments to their rhythm trackers and magnet system that match the coming wave.",
+      "mandatoryMentions": ["progressed"]
+    },
+    {
+      "id": "sabian",
+      "label": "Sabian Symbols",
+      "icon": "📜",
+      "narrative": "Translate the poetic Sabian Symbols for their Sun and Ascendant degrees. Show how these mythic images mentor their soul mission and mediumship practice.",
+      "integration": "Tie the symbols back to daily rituals—breathwork, writing prompts, or teaching moments—that embody the image.",
+      "mediumship": "Note the visual or auditory cues (certain birds, bells, or landscapes) that tend to appear when the symbol is active.",
+      "rhythmTieIn": "Integrate the symbolism into their weekly share schedule or content cadence.",
+      "mandatoryMentions": ["sabian"]
+    },
+    {
+      "id": "iching",
+      "label": "I Ching Guidance",
+      "icon": "☯",
+      "narrative": "Pull a relevant hexagram that answers the client’s current life path question. Offer a concise message from Source that aids decision-making.",
+      "integration": "If applicable, link the hexagram to any Human Design gate activations present in their chart.",
+      "mediumship": "Mention tactile confirmations (coin clinks, wind shifts, repetitive numbers) that tell them the guidance is landing.",
+      "rhythmTieIn": "Advise one embodiment step or rhythm cue to honor the hexagram.",
+      "mandatoryMentions": ["i ching", "hexagram"],
+      "skipForChild": true
+    },
+    {
+      "id": "archetype",
+      "label": "Archetype Mapping",
+      "icon": "🗺",
+      "narrative": "Assign the Hero’s Journey or mythical archetypes that mirror their current role—The Healer, The Bridge, The Sage, etc.—and explain how they move through the quest.",
+      "integration": "Connect the archetype to their business offers, household leadership, and rhythm commitments.",
+      "mediumship": "Share story-world clues—favorite films, recurring symbols, or the way strangers describe them—that affirm the archetype.",
+      "rhythmTieIn": "Translate the archetype into a personalized daily or weekly rhythm pattern so they can live it with ease.",
+      "childTone": "Describe the archetype as the hero of their storybook and invite a simple ritual (cape, dance, mantra) that helps them step into it.",
+      "mandatoryMentions": ["archetype"]
+    }
+  ],
+  "summary": {
+    "calloutHeading": "Advanced Systems Integration",
+    "instructions": "Close the expansion with a callout box that braids all eight modalities together. Emphasize how the combined insight sharpens their rhythm path, mediumship training, and intuitive confidence."
+  },
+  "magicCodes": {
+    "title": "Magic Codes Key",
+    "intro": "Offer a quick legend so they can reference each symbol in the PDF. The tone should feel like a secret decoder for their soul.",
+    "icons": [
+      { "symbol": "✴", "label": "Enneagram", "meaning": "Core drive + wing compass" },
+      { "symbol": "🌀", "label": "Akashic Echo", "meaning": "Past-life clue or ancestral echo" },
+      { "symbol": "🕉", "label": "Chakra Current", "meaning": "Energy center focus + remedy" },
+      { "symbol": "💗", "label": "Soul Urge", "meaning": "Heart-longing expression" },
+      { "symbol": "🌅", "label": "Progressed Light", "meaning": "Next 2–3 year phase" },
+      { "symbol": "📜", "label": "Sabian Myth", "meaning": "Poetic mission image" },
+      { "symbol": "☯", "label": "I Ching Whisper", "meaning": "Hexagram guidance" },
+      { "symbol": "🗺", "label": "Archetype Trail", "meaning": "Quest role + rhythm" }
+    ]
+  },
+  "automation": {
+    "includeTiers": ["full"],
+    "childRules": {
+      "skipSystems": ["akashic", "iching"],
+      "tone": "Use gentle language, keep the focus on adventure and emotional safety, and swap heavy karmic language for playful metaphors."
+    },
+    "fallbacks": {
+      "missingBirth": "If precise birth details are missing, name which data point would deepen the reading and offer an intuitive bridge until it arrives."
+    }
+  },
+  "upgradeNote": "Let them know this suite is bundled inside the Full Soul Blueprint now, while hinting that each modality may become a standalone upgrade later if they want a deeper dive.",
+  "helperAgents": {
+    "iconSuggester": "Reader-agent can spin up custom icon concepts from the Magic Codes legend when requested.",
+    "summary": "Helper agents may also condense the advanced layer into recap cards for overwhelmed clients."
+  }
+}

--- a/src/fulfillment/advanced-esoteric.ts
+++ b/src/fulfillment/advanced-esoteric.ts
@@ -1,0 +1,212 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import type { NormalizedIntake } from './types';
+
+export interface AdvancedEsotericSystem {
+  id: string;
+  label: string;
+  icon: string;
+  narrative: string;
+  integration: string;
+  mediumship: string;
+  rhythmTieIn: string;
+  childTone?: string;
+  skipForChild?: boolean;
+  mandatoryMentions?: string[];
+}
+
+interface AdvancedSectionMeta {
+  title: string;
+  introduction: string;
+  mediumshipStyle?: string;
+  rhythmIntegration?: string;
+  evidentialExamples?: string[];
+}
+
+interface AdvancedSummaryMeta {
+  calloutHeading: string;
+  instructions: string;
+}
+
+export interface AdvancedMagicCodeIcon {
+  symbol: string;
+  label: string;
+  meaning: string;
+}
+
+interface AdvancedMagicCodesMeta {
+  title: string;
+  intro: string;
+  icons: AdvancedMagicCodeIcon[];
+}
+
+interface AdvancedAutomationMeta {
+  includeTiers?: string[];
+  childRules?: {
+    skipSystems?: string[];
+    tone?: string;
+  };
+  fallbacks?: {
+    missingBirth?: string;
+  };
+}
+
+export interface AdvancedEsotericConfig {
+  section: AdvancedSectionMeta;
+  systems: AdvancedEsotericSystem[];
+  summary: AdvancedSummaryMeta;
+  magicCodes: AdvancedMagicCodesMeta;
+  automation?: AdvancedAutomationMeta;
+  upgradeNote?: string;
+  helperAgents?: Record<string, string>;
+}
+
+let cachedConfig: AdvancedEsotericConfig | null | undefined;
+
+export function loadAdvancedEsotericConfig(): AdvancedEsotericConfig | null {
+  if (cachedConfig !== undefined) return cachedConfig || null;
+  try {
+    const filePath = path.resolve(
+      process.cwd(),
+      'soul-blueprint',
+      'tiers',
+      'full',
+      'expansions',
+      'advanced-esoteric.json'
+    );
+    const raw = readFileSync(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as AdvancedEsotericConfig;
+    cachedConfig = parsed;
+    return parsed;
+  } catch (err) {
+    console.warn('[advanced-esoteric] unable to load advanced esoteric config:', err);
+    cachedConfig = null;
+    return null;
+  }
+}
+
+function normalizeCohort(value?: string | null): 'child' | 'teen' | 'adult' | 'elder' | undefined {
+  if (!value) return undefined;
+  const text = value.toLowerCase();
+  if (text.includes('child')) return 'child';
+  if (text.includes('teen')) return 'teen';
+  if (text.includes('elder') || text.includes('senior')) return 'elder';
+  if (text.includes('adult')) return 'adult';
+  return undefined;
+}
+
+export function resolveCohortFromIntake(intake: NormalizedIntake): 'child' | 'teen' | 'adult' | 'elder' | undefined {
+  if (intake.ageCohort) return intake.ageCohort;
+  const prefs = intake.prefs || {};
+  const cohortFields = [
+    'cohort',
+    'client_cohort',
+    'age_group',
+    'agegroup',
+    'client_age_group',
+    'recipient_age_group',
+    'tier_cohort',
+  ];
+  for (const key of cohortFields) {
+    const value = prefs[key];
+    if (typeof value === 'string') {
+      const normalized = normalizeCohort(value);
+      if (normalized) return normalized;
+    }
+  }
+  const ageFields = ['age', 'client_age', 'recipient_age', 'child_age'];
+  for (const key of ageFields) {
+    const value = prefs[key];
+    if (typeof value === 'number' && Number.isFinite(value)) {
+      if (value < 13) return 'child';
+      if (value < 18) return 'teen';
+      if (value >= 65) return 'elder';
+      return 'adult';
+    }
+    if (typeof value === 'string') {
+      const num = parseInt(value, 10);
+      if (!Number.isNaN(num)) {
+        if (num < 13) return 'child';
+        if (num < 18) return 'teen';
+        if (num >= 65) return 'elder';
+        return 'adult';
+      }
+    }
+  }
+  return undefined;
+}
+
+export function getActiveSystems(
+  config: AdvancedEsotericConfig,
+  opts: { cohort?: 'child' | 'teen' | 'adult' | 'elder' } = {}
+): AdvancedEsotericSystem[] {
+  const skip = new Set<string>();
+  if (opts.cohort === 'child') {
+    const skipSystems = config.automation?.childRules?.skipSystems || [];
+    for (const id of skipSystems) skip.add(id);
+  }
+  return config.systems.filter((system) => !skip.has(system.id));
+}
+
+export function describeSystemForPrompt(
+  system: AdvancedEsotericSystem,
+  opts: { cohort?: 'child' | 'teen' | 'adult' | 'elder' }
+): string {
+  const pieces = [system.narrative, system.integration, system.mediumship, system.rhythmTieIn];
+  if (opts.cohort === 'child' && system.childTone) {
+    pieces.push(system.childTone);
+  }
+  return pieces.filter(Boolean).join(' ');
+}
+
+export function summarizeMagicCodes(config: AdvancedEsotericConfig): string {
+  return config.magicCodes.icons
+    .map((icon) => `${icon.symbol} ${icon.label}: ${icon.meaning}`)
+    .join('; ');
+}
+
+export function findMissingSystems(
+  story: string,
+  systems: AdvancedEsotericSystem[]
+): AdvancedEsotericSystem[] {
+  const text = story.toLowerCase();
+  return systems.filter((system) => {
+    const tokens = system.mandatoryMentions?.length ? system.mandatoryMentions : [system.label];
+    return !tokens.some((token) => text.includes(token.toLowerCase()));
+  });
+}
+
+export function hasMagicCodesLegend(story: string, config: AdvancedEsotericConfig): boolean {
+  const lower = story.toLowerCase();
+  if (lower.includes(config.magicCodes.title.toLowerCase())) return true;
+  return config.magicCodes.icons.some((icon) => story.includes(icon.symbol));
+}
+
+export function buildMissingSystemsPrompt(
+  systems: AdvancedEsotericSystem[],
+  config: AdvancedEsotericConfig,
+  opts: {
+    cohort?: 'child' | 'teen' | 'adult' | 'elder';
+  } = {}
+): string {
+  const lines: string[] = [];
+  lines.push(
+    'Provide narrative paragraphs to cover the remaining advanced soul systems that still need to be woven into the reading. Keep the tone consistent with the existing Full Soul Blueprint voice.'
+  );
+  for (const system of systems) {
+    const desc = describeSystemForPrompt(system, { cohort: opts.cohort });
+    lines.push(`System: ${system.label}. ${desc}`);
+  }
+  if (config.section.mediumshipStyle) {
+    lines.push(`Mediumship style reminder: ${config.section.mediumshipStyle}`);
+  }
+  if (config.section.rhythmIntegration) {
+    lines.push(`Tie each insight back to rhythm guidance: ${config.section.rhythmIntegration}`);
+  }
+  return lines.join('\n');
+}
+
+export function buildMagicCodesPrompt(config: AdvancedEsotericConfig): string {
+  const legend = summarizeMagicCodes(config);
+  return `Create a concise "${config.magicCodes.title}" legend using the following cues: ${legend}. Keep it playful and easy to skim.`;
+}

--- a/src/fulfillment/types.ts
+++ b/src/fulfillment/types.ts
@@ -26,6 +26,14 @@ export interface NormalizedIntake {
   addOns: string[];
   prefs: Record<string, any>;
   customer: CustomerProfile;
+  /**
+   * Optional list of expansions to enable for this fulfillment run (e.g. advanced esoteric suite).
+   */
+  expansions?: string[];
+  /**
+   * Derived cohort from intake data so downstream modules can simplify language for younger clients.
+   */
+  ageCohort?: 'child' | 'teen' | 'adult' | 'elder';
   referenceId?: string;
   schedulePreferences?: string[];
   raw?: any;


### PR DESCRIPTION
## Summary
- add structured advanced esoteric expansion data for the full Soul Blueprint tier and expose helper utilities to load and filter it
- update intake, blueprint generation, and icon logic to enable the new Advanced Soul Systems section, child-aware handling, and automatic Magic Codes key creation
- expand the full-tier markdown template and validation rules to include Destiny Matrix, Advanced Soul Systems, and Magic Codes headings

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d41f12b2d4832780f7046c93a6dbab