### PR TITLE
feat: stripe+tally health checks + completion pings

### DIFF
--- a/.github/workflows/daily-summary.yml
+++ b/.github/workflows/daily-summary.yml
@@ -22,12 +22,23 @@ jobs:
           echo "text<<EOF" >> $GITHUB_OUTPUT
           jq -r '
             def n(x): if x==null then "0" else (x|tostring) end;
+            def status(entry):
+              if entry == null then "⚪️ pending" else
+                (if entry.ok == true then "✅" elif entry.ok == false then "❌" else "⚪️" end) + " " +
+                (if ((entry.issues // []) | length) > 0 then (entry.issues // [])[0]
+                 elif ((entry.warnings // []) | length) > 0 then (entry.warnings // [])[0]
+                 elif (entry.detail//"") != "" then entry.detail
+                 elif (entry.checkedAt//"") != "" then "checked " + entry.checkedAt
+                 else "pending" end)
+              end;
             "📒 Maggie Daily Summary\n" +
             "⏰ " + (.time // "unknown") + "\n" +
             "🧩 Tasks: " + ((.currentTasks // ["idle"]) | join(", ")) + "\n" +
-            "🌐 Website: " + (.website // "https://messyandmagnetic.com") + "\n" +
-            "📅 Scheduled: " + n(.socialQueue.scheduled) + " | 🔁 Retries: " + n(.socialQueue.flopsRetry) + "\n" +
-            "➡️ Next Post: " + ((.socialQueue.nextPost // "none")|tostring) + "\n" +
+            "🌐 Website: " + status(.health.website) + "\n" +
+            "🧠 Tally quiz: " + status(.health.tally) + "\n" +
+            "💸 Stripe: " + status(.health.stripe) + "\n" +
+            "🎵 TikTok: " + n(.socialQueue.scheduled) + " scheduled | " + n(.socialQueue.flopsRetry) + " retries\n" +
+            "♻️ Flops recovered: " + n(.metrics.flopsRecovered) + "\n" +
             (if .topTrends then "🔥 Top Trends: " + (.topTrends | map(.title) | join(", ")) else "" end)
           ' summary.json >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/stripe-tally-health.yml
+++ b/.github/workflows/stripe-tally-health.yml
@@ -1,0 +1,32 @@
+name: Stripe + Tally Health
+
+on:
+  schedule:
+    - cron: '15 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm install --prefer-offline --no-audit
+      - name: Run Stripe + Tally health check
+        run: npx tsx scripts/health/stripeTallyCheck.ts
+        env:
+          STRIPE_SECRET_KEY: ${{ secrets.STRIPE_SECRET_KEY }}
+          STRIPE_API_KEY: ${{ secrets.STRIPE_API_KEY }}
+          TALLY_API_KEY: ${{ secrets.TALLY_API_KEY }}
+          WORKER_URL: ${{ secrets.WORKER_URL }}
+          WORKER_KEY: ${{ secrets.WORKER_KEY }}
+          POST_THREAD_SECRET: ${{ secrets.POST_THREAD_SECRET }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          WEBSITE_URL: ${{ secrets.WEBSITE_URL }}

--- a/app/api/stripe/sync/run/route.ts
+++ b/app/api/stripe/sync/run/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { checkAuth } from '../../../../../lib/auth';
 import { runStripeSync } from '../../../../../lib/stripe-sync';
 import { env } from '../../../../../lib/env.js';
+import { sendCompletionPing } from '../../../../../lib/telegram';
 
 function checkWorker(req: NextRequest) {
   const key = req.headers.get('x-worker-key');
@@ -20,6 +21,9 @@ export async function POST(req: NextRequest) {
   } catch {}
   try {
     const result = await runStripeSync({ dry, names: body.names });
+    if (!dry) {
+      await sendCompletionPing('Stripe product sync');
+    }
     return NextResponse.json(result);
   } catch (e: any) {
     return NextResponse.json({ ok: false, error: e?.message || 'run-failed' }, { status: 500 });

--- a/lib/telegram.ts
+++ b/lib/telegram.ts
@@ -51,3 +51,11 @@ export async function tgSend(text: string, customChatId?: string) {
 
 // Alias for semantic clarity
 export const sendTelegramMessage = tgSend;
+
+/**
+ * Convenience helper for Maggie task completion pings.
+ */
+export async function sendCompletionPing(taskName: string): Promise<void> {
+  const label = taskName?.trim() || 'Task';
+  await tgSend(`✅ Task finished: ${label} — you can test it now.`);
+}

--- a/scripts/health/stripeTallyCheck.ts
+++ b/scripts/health/stripeTallyCheck.ts
@@ -1,0 +1,326 @@
+import Stripe from 'stripe';
+import process from 'node:process';
+
+import { DEFAULT_PRODUCTS } from '../../config/products';
+
+interface HealthEntry {
+  ok: boolean;
+  checkedAt: string;
+  detail?: string;
+  issues: string[];
+  warnings: string[];
+}
+
+interface HealthPayload {
+  website?: HealthEntry;
+  stripe?: HealthEntry;
+  tally?: HealthEntry;
+}
+
+interface WorkerUpdatePayload extends HealthPayload {
+  metrics?: {
+    flopsRecovered?: number;
+  };
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+async function sendTelegramAlert(text: string): Promise<void> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.TELEGRAM_CHAT_ID;
+  if (!token || !chatId) return;
+  try {
+    await fetch(`https://api.telegram.org/bot${token}/sendMessage`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: chatId, text, parse_mode: 'HTML', disable_web_page_preview: true }),
+    });
+  } catch (err) {
+    console.warn('[health] telegram send failed:', err);
+  }
+}
+
+function summarizeIssues(entry: HealthEntry): string {
+  const issues = Array.isArray(entry.issues) ? entry.issues : [];
+  const warnings = Array.isArray(entry.warnings) ? entry.warnings : [];
+  const problems = issues.concat(warnings);
+  return problems.length ? problems.join('\n- ') : 'all good';
+}
+
+async function runWebsiteCheck(): Promise<HealthEntry> {
+  const url =
+    process.env.WEBSITE_URL ||
+    process.env.SITE_URL ||
+    process.env.WEBSITE ||
+    'https://messyandmagnetic.com';
+
+  const entry: HealthEntry = { ok: false, checkedAt: nowIso(), issues: [], warnings: [] };
+
+  try {
+    const res = await fetch(url, { method: 'GET' });
+    entry.detail = `HTTP ${res.status}`;
+    entry.ok = res.ok;
+    if (!res.ok) {
+      entry.issues.push(`Website responded with status ${res.status}`);
+    }
+  } catch (err) {
+    entry.detail = err instanceof Error ? err.message : String(err);
+    entry.issues.push(`Website fetch failed: ${entry.detail}`);
+  }
+
+  return entry;
+}
+
+async function runStripeCheck(): Promise<HealthEntry> {
+  const key =
+    process.env.STRIPE_SECRET_KEY ||
+    process.env.STRIPE_API_KEY ||
+    process.env.STRIPE_SECRET ||
+    process.env.STRIPE_TOKEN;
+
+  const entry: HealthEntry = { ok: false, checkedAt: nowIso(), issues: [], warnings: [] };
+
+  if (!key) {
+    entry.detail = 'STRIPE_SECRET_KEY missing';
+    entry.issues.push('Stripe credentials are not configured');
+    return entry;
+  }
+
+  try {
+    const stripe = new Stripe(key, { apiVersion: '2023-10-16' });
+    const products = await stripe.products.list({ limit: 100, active: true });
+    const prices = await stripe.prices.list({ limit: 100, active: true });
+
+    const productCount = products.data.length;
+    const priceCount = prices.data.length;
+
+    const productByName = new Map<string, Stripe.Product>();
+    for (const product of products.data) {
+      productByName.set(product.name.toLowerCase(), product);
+      if (!product.unit_label || product.unit_label.length > 12) {
+        entry.warnings.push(
+          `Product ${product.name} missing unit label or exceeds 12 chars (current: ${product.unit_label || 'none'})`,
+        );
+      }
+    }
+
+    for (const expected of DEFAULT_PRODUCTS) {
+      const match = productByName.get(expected.name.toLowerCase());
+      if (!match) {
+        entry.issues.push(`Missing Stripe product for ${expected.name}`);
+        continue;
+      }
+      const productPrices = prices.data.filter((price) => price.product === match.id && price.active);
+      if (!productPrices.length) {
+        entry.issues.push(`No active prices for ${match.name}`);
+        continue;
+      }
+      if (expected.defaultPriceUsd && expected.defaultPriceUsd > 0) {
+        const cents = Math.round(expected.defaultPriceUsd * 100);
+        const found = productPrices.some((price) => price.unit_amount === cents);
+        if (!found) {
+          entry.issues.push(`Active price mismatch for ${match.name} (missing $${expected.defaultPriceUsd})`);
+        }
+      }
+    }
+
+    entry.ok = entry.issues.length === 0;
+    entry.detail = `Fetched ${productCount} product(s) and ${priceCount} price(s)`;
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    entry.detail = message;
+    entry.issues.push(`Stripe API error: ${message}`);
+  }
+
+  return entry;
+}
+
+interface TallyFormSummary {
+  id: string;
+  title: string;
+  status?: string;
+}
+
+interface TallyResponseSummary {
+  submittedAt?: string;
+}
+
+async function fetchJson<T>(input: RequestInfo, init?: RequestInit): Promise<T | null> {
+  const res = await fetch(input, init);
+  if (!res.ok) {
+    throw new Error(`HTTP ${res.status}`);
+  }
+  return (await res.json().catch(() => null)) as T | null;
+}
+
+function findTargetForm(forms: any[]): TallyFormSummary | null {
+  if (!Array.isArray(forms)) return null;
+  const targets = [
+    'Create My Soul Flow System – Maggie',
+    'Create My Soul Flow System - Maggie',
+  ];
+  for (const form of forms) {
+    const title = (form?.title || form?.name || '').trim();
+    if (!title) continue;
+    if (targets.some((target) => title.toLowerCase() === target.toLowerCase())) {
+      return { id: form.id || form.formId || form.slug, title, status: form.status };
+    }
+  }
+  return null;
+}
+
+function normalizeSubmittedAt(response: any): string | undefined {
+  const raw = response?.submittedAt || response?.createdAt || response?.created_at;
+  if (typeof raw !== 'string') return undefined;
+  const ts = new Date(raw);
+  if (Number.isNaN(ts.getTime())) return undefined;
+  return ts.toISOString();
+}
+
+async function runTallyCheck(): Promise<HealthEntry> {
+  const apiKey =
+    process.env.TALLY_API_KEY ||
+    process.env.TALLY_API_TOKEN ||
+    process.env.TALLY_SECRET_MAIN ||
+    process.env.TALLY_SIGNING_SECRET;
+
+  const entry: HealthEntry = { ok: false, checkedAt: nowIso(), issues: [], warnings: [] };
+
+  if (!apiKey) {
+    entry.detail = 'TALLY_API_KEY missing';
+    entry.issues.push('Tally credentials are not configured');
+    return entry;
+  }
+
+  try {
+    const formsPayload = await fetchJson<{ data: any[] }>('https://api.tally.so/api/v1/forms', {
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    const form = findTargetForm(formsPayload?.data ?? []);
+    if (!form || !form.id) {
+      entry.issues.push('Quiz form not found in Tally workspace');
+      entry.detail = 'Unable to locate quiz form';
+      return entry;
+    }
+
+    if (form.status && form.status.toLowerCase() !== 'active') {
+      entry.issues.push(`Quiz form is not active (status: ${form.status})`);
+    }
+
+    const responsesPayload = await fetchJson<{ data?: any[] }>(
+      `https://api.tally.so/api/v1/forms/${form.id}/responses?limit=1`,
+      {
+        headers: { Authorization: `Bearer ${apiKey}` },
+      },
+    );
+    const lastResponse = responsesPayload?.data?.[0] as TallyResponseSummary | undefined;
+    const submittedAt = lastResponse ? normalizeSubmittedAt(lastResponse) : undefined;
+
+    if (!submittedAt) {
+      entry.warnings.push('No recent responses found for quiz');
+    } else {
+      entry.detail = `Last response at ${submittedAt}`;
+    }
+
+    const workerUrl = process.env.WORKER_URL;
+    if (workerUrl) {
+      try {
+        const recentSummary = await fetchJson<{ summary?: { source?: string; status?: string; completedAt?: string } | null }>(
+          `${workerUrl.replace(/\/?$/, '')}/ops/recent-order`,
+        );
+        const summary = recentSummary?.summary;
+        if (!summary || summary.source !== 'tally') {
+          entry.warnings.push('Worker recent-order endpoint has no Tally-derived summary');
+        } else if (summary.status !== 'success') {
+          entry.issues.push(`Latest Tally order in queue is marked ${summary.status}`);
+        } else if (summary.completedAt) {
+          const completedAt = new Date(summary.completedAt);
+          if (Number.isNaN(completedAt.getTime())) {
+            entry.warnings.push('Latest Tally order completion timestamp invalid');
+          } else {
+            const hours = (Date.now() - completedAt.getTime()) / (1000 * 60 * 60);
+            if (hours > 72) {
+              entry.warnings.push('No successful Tally fulfillment in the last 72 hours');
+            }
+          }
+        }
+      } catch (err) {
+        entry.warnings.push(`Worker recent-order check failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+
+    entry.ok = entry.issues.length === 0;
+    if (!entry.detail) {
+      entry.detail = form ? `Form ${form.id}` : 'Form lookup complete';
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    entry.detail = message;
+    entry.issues.push(`Tally API error: ${message}`);
+  }
+
+  return entry;
+}
+
+async function pushWorkerUpdate(payload: WorkerUpdatePayload): Promise<void> {
+  const base = process.env.WORKER_URL;
+  if (!base) return;
+  const token = process.env.WORKER_KEY || process.env.POST_THREAD_SECRET || process.env.MAGGIE_WORKER_KEY;
+  if (!token) {
+    console.warn('[health] Missing WORKER_KEY/POST_THREAD_SECRET for health update.');
+    return;
+  }
+  const url = `${base.replace(/\/?$/, '')}/ops/health`;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      console.warn('[health] Worker update failed:', res.status, text);
+    }
+  } catch (err) {
+    console.warn('[health] Unable to update worker health state:', err);
+  }
+}
+
+async function main(): Promise<void> {
+  const website = await runWebsiteCheck();
+  const stripe = await runStripeCheck();
+  const tally = await runTallyCheck();
+
+  const payload: WorkerUpdatePayload = {
+    website,
+    stripe,
+    tally,
+  };
+
+  await pushWorkerUpdate(payload);
+
+  const anyFailure = !website.ok || !stripe.ok || !tally.ok;
+  const summary = [
+    `Website: ${website.ok ? 'ok' : 'fail'} (${website.detail ?? 'n/a'})`,
+    `Stripe: ${stripe.ok ? 'ok' : 'fail'} (${stripe.detail ?? 'n/a'})`,
+    `Tally: ${tally.ok ? 'ok' : 'fail'} (${tally.detail ?? 'n/a'})`,
+  ].join(' | ');
+  console.log('[health] Summary:', summary);
+
+  if (anyFailure) {
+    const alert =
+      '⚠️ Health check alert\n' +
+      `Stripe → ${stripe.ok ? '✅' : '❌'}\n${summarizeIssues(stripe)}\n\n` +
+      `Tally → ${tally.ok ? '✅' : '❌'}\n${summarizeIssues(tally)}\n\n` +
+      `Website → ${website.ok ? '✅' : '❌'}\n${summarizeIssues(website)}`;
+    await sendTelegramAlert(alert);
+    process.exitCode = 1;
+  }
+}
+
+await main();

--- a/scripts/publishSite.ts
+++ b/scripts/publishSite.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import crypto from 'node:crypto';
 import process from 'node:process';
 import { sendTelegramMessage } from './lib/telegramClient';
+import { sendCompletionPing } from '../lib/telegram';
 
 const SITE_PREFIX = 'site:';
 const RESERVED_KEYS = new Set([`${SITE_PREFIX}manifest`]);
@@ -311,6 +312,7 @@ export async function publishSite(options: PublishSiteOptions = {}): Promise<Pub
   const summary = `🚀 <b>Site deployed</b>\n• Files: <code>${records.length}</code>\n• Removed: <code>${removed.length}</code>\n• Triggered by: <b>${options.triggeredBy || 'manual'}</b>`;
   if (options.notify !== false) {
     await sendTelegramMessage(summary).catch(() => undefined);
+    await sendCompletionPing('Website deploy');
   }
 
   return { manifest, removedKeys: removed };

--- a/shared/maggieState.ts
+++ b/shared/maggieState.ts
@@ -49,6 +49,19 @@ export interface AutonomyMetadata {
   lastQuietWindow?: AutonomyRunLogEntry['quiet'];
 }
 
+export interface HealthCheckStatus {
+  ok?: boolean;
+  checkedAt?: string;
+  detail?: string;
+  issues?: string[];
+  warnings?: string[];
+}
+
+export interface MaggieMetrics {
+  flopsRecovered?: number;
+  [key: string]: unknown;
+}
+
 export interface MaggieState {
   currentTasks?: string[];
   lastCheck?: string;
@@ -57,6 +70,13 @@ export interface MaggieState {
   topTrends?: MaggieTrend[];
   website?: string;
   autonomy?: AutonomyMetadata;
+  health?: {
+    website?: HealthCheckStatus;
+    stripe?: HealthCheckStatus;
+    tally?: HealthCheckStatus;
+    [key: string]: HealthCheckStatus | undefined;
+  };
+  metrics?: MaggieMetrics;
   [key: string]: unknown;
 }
 

--- a/src/fulfillment/runner.ts
+++ b/src/fulfillment/runner.ts
@@ -95,12 +95,17 @@ export async function runOrder(ref: OrderReference, opts: RunOptions = {}): Prom
         message: 'Delivered',
         completedAt: new Date().toISOString(),
         files: formatFiles(record),
+        source: intake.source,
       };
 
       await appendFulfillmentLog(intake, summary, workspace.config);
       await recordOrderSummary(summary);
       await setLastOrderSummary(summary, opts.env);
       await updateNotion(record, opts.env);
+      await notifyOpsChannel(
+        `✅ Task finished: Soul blueprint bundle for ${intake.email} — you can test it now.`,
+        workspace.config,
+      );
       return record;
     } catch (err) {
       lastError = err;
@@ -121,6 +126,7 @@ export async function runOrder(ref: OrderReference, opts: RunOptions = {}): Prom
     message: lastError?.message || 'Unknown failure',
     completedAt: new Date().toISOString(),
     files: [],
+    source: intake.source,
   };
   await appendFulfillmentLog(intake, summary, config);
   await recordOrderSummary(summary);

--- a/src/fulfillment/types.ts
+++ b/src/fulfillment/types.ts
@@ -140,4 +140,5 @@ export interface OrderSummary {
   message: string;
   completedAt: string;
   files: string[];
+  source?: 'stripe' | 'tally';
 }

--- a/worker/routes/opsHealth.ts
+++ b/worker/routes/opsHealth.ts
@@ -1,0 +1,103 @@
+import type { Env } from '../lib/env';
+import { loadState, saveState } from '../lib/state';
+
+interface HealthEntry {
+  ok?: boolean;
+  checkedAt?: string;
+  detail?: string;
+  issues?: string[];
+  warnings?: string[];
+}
+
+interface HealthUpdateBody {
+  website?: HealthEntry;
+  stripe?: HealthEntry;
+  tally?: HealthEntry;
+  metrics?: {
+    flopsRecovered?: number;
+  };
+}
+
+function json(data: any, status = 200): Response {
+  return new Response(JSON.stringify(data, null, 2), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function normalizeEntry(entry: HealthEntry | undefined): HealthEntry | undefined {
+  if (!entry || typeof entry !== 'object') return undefined;
+  const normalized: HealthEntry = {
+    ok: entry.ok ?? undefined,
+    checkedAt: typeof entry.checkedAt === 'string' ? entry.checkedAt : undefined,
+    detail: typeof entry.detail === 'string' ? entry.detail : undefined,
+    issues: Array.isArray(entry.issues) ? entry.issues.map(String) : undefined,
+    warnings: Array.isArray(entry.warnings) ? entry.warnings.map(String) : undefined,
+  };
+  return normalized;
+}
+
+function mergeEntry(target: any, key: string, entry: HealthEntry | undefined) {
+  if (!entry) return;
+  if (!target[key] || typeof target[key] !== 'object') {
+    target[key] = {};
+  }
+  const bucket = target[key] as Record<string, unknown>;
+  if (entry.ok !== undefined) bucket.ok = entry.ok;
+  if (entry.checkedAt) bucket.checkedAt = entry.checkedAt;
+  if (entry.detail) bucket.detail = entry.detail;
+  if (entry.issues) bucket.issues = entry.issues;
+  if (entry.warnings) bucket.warnings = entry.warnings;
+}
+
+function authorize(request: Request, env: Env): boolean {
+  const header = request.headers.get('authorization') || '';
+  const token = header.startsWith('Bearer ') ? header.slice(7).trim() : '';
+  const expected =
+    (env as any).WORKER_KEY ||
+    (env as any).POST_THREAD_SECRET ||
+    (env as any).MAGGIE_WORKER_KEY ||
+    (env as any).CF_WORKER_KEY;
+  if (!expected) return false;
+  return token && token === expected;
+}
+
+export async function onRequestGet({ env }: { env: Env }) {
+  const state = await loadState(env);
+  const health = (state as any)?.health ?? {};
+  const metrics = (state as any)?.metrics ?? {};
+  return json({ ok: true, health, metrics });
+}
+
+export async function onRequestPost({ request, env }: { request: Request; env: Env }) {
+  if (!authorize(request, env)) {
+    return json({ ok: false, error: 'unauthorized' }, 401);
+  }
+
+  const body = (await request.json().catch(() => null)) as HealthUpdateBody | null;
+  if (!body || typeof body !== 'object') {
+    return json({ ok: false, error: 'invalid-body' }, 400);
+  }
+
+  const state = await loadState(env);
+  if (!state || typeof state !== 'object') {
+    return json({ ok: false, error: 'state-unavailable' }, 500);
+  }
+
+  const health = (state as any).health || {};
+  mergeEntry(health, 'website', normalizeEntry(body.website));
+  mergeEntry(health, 'stripe', normalizeEntry(body.stripe));
+  mergeEntry(health, 'tally', normalizeEntry(body.tally));
+  (state as any).health = health;
+
+  if (body.metrics && typeof body.metrics === 'object') {
+    const metrics = (state as any).metrics || {};
+    if (typeof body.metrics.flopsRecovered === 'number' && Number.isFinite(body.metrics.flopsRecovered)) {
+      metrics.flopsRecovered = body.metrics.flopsRecovered;
+    }
+    (state as any).metrics = metrics;
+  }
+
+  await saveState(env, state);
+  return json({ ok: true });
+}

--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -130,6 +130,8 @@ export default {
           topTrends: snapshot.topTrends,
           paused: snapshot.paused,
           scheduler: snapshot.runtime,
+          health: (state as any).health || {},
+          metrics: (state as any).metrics || {},
         };
         return new Response(JSON.stringify(status, null, 2), {
           headers: { 'Content-Type': 'application/json' },
@@ -151,6 +153,8 @@ export default {
           socialQueue,
           topTrends: snapshot.topTrends,
           paused: snapshot.paused,
+          health: (state as any).health || {},
+          metrics: (state as any).metrics || {},
         };
         return new Response(JSON.stringify(summary, null, 2), {
           headers: { 'Content-Type': 'application/json' },
@@ -283,6 +287,11 @@ export default {
       }
       if (url.pathname === "/webhooks/tally") {
         const r = await tryRoute("/webhooks/tally", "./orders/tally", null, req, env, ctx);
+        if (r && r.status !== 404) return r;
+      }
+
+      if (url.pathname === "/ops/health") {
+        const r = await tryRoute("/ops/health", "./routes/opsHealth", null, req, env, ctx);
         if (r && r.status !== 404) return r;
       }
 


### PR DESCRIPTION
- Adds automatic Stripe + Tally monitoring.
- Expands Telegram daily summary with health checks.
- Sends completion pings after each finished task.

------
https://chatgpt.com/codex/tasks/task_e_68d6ae7e8ec0832785c76521e6ea7462