### PR TITLE
Add Telegram self-healing helper scripts

### DIFF
--- a/brain/maggie.brain.md
+++ b/brain/maggie.brain.md
@@ -1,0 +1,31 @@
+# Maggie Self-Healing Protocol (Telegram)
+
+## Conflict auto-resolution
+- Run `pnpm telegram:auto-repair` when Git reports merge conflicts in any `telegram.ts` file.
+- The helper script will:
+  - Scan for Git conflict markers.
+  - Preserve the most complete handler logic (prioritizing slash commands like `/status`, `/repair telegram`, `/post`).
+  - Keep interfaces that use `snapshot`, `recordInput`, and `sendTelegram` helpers when available.
+  - Commit fixes automatically with the message `auto: resolved Telegram handler conflict`.
+  - Trigger tests before allowing deployment.
+
+## Deployment & restart routine
+- After conflict repair succeeds and tests pass, deploy the Cloudflare Worker (`pnpm run deploy:public` by default).
+- Optionally restart downstream services with `TELEGRAM_REPAIR_RESTART_COMMAND` when configured.
+- Confirm recovery in Telegram by sending `Maggie is fully back online 🚀`.
+
+## Logging
+- Every repair attempt is logged to:
+  - Notion database `Maggie System Events` (configure via `NOTION_TOKEN` + `NOTION_MAGGIE_EVENTS_DB`).
+  - Google Sheet `Maggie Telegram Auto-Fixes Log` (service account + `GOOGLE_MAGGIE_AUTOFIX_SHEET_ID`).
+- Logged fields include timestamp, action (`merge`, `deploy`, `restart`, `check`), trigger source, and success status.
+
+## Persistent watcher
+- Use `pnpm telegram:auto-repair:watch` to keep a watcher running every 10 minutes.
+- The watcher checks for merge conflicts, verifies the worker Telegram route, attempts repairs, deploys, logs results, and posts updates in Telegram.
+- The watcher can also be launched manually by running the script in response to `/repair telegram` or other triggers.
+
+## Offline safeguard
+- If conflicts are detected but the auto-resolver cannot apply a fix, immediately notify Telegram with `🧯 Maggie is offline. Auto-repair sequence initiated...` and log the failure.
+
+Configure environment variables for Notion, Google Sheets, deployment, restart commands, and Telegram credentials so that Maggie can operate autonomously.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "// --- Stripe ---": "-----------------------------------------------",
     "stripe:sync": "tsx scripts/stripe-sync.ts",
     "seed:stripe": "tsx scripts/seed/stripe.ts",
-    "seed:kv": "tsx scripts/seedKV.ts"
+    "seed:kv": "tsx scripts/seedKV.ts",
+    "telegram:auto-repair": "tsx scripts/telegram-auto-repair.ts",
+    "telegram:auto-repair:watch": "tsx scripts/telegram-auto-repair.ts --watch"
   },
   "dependencies": {
     "@notionhq/client": "^2.3.0",

--- a/scripts/self-healing/logging.ts
+++ b/scripts/self-healing/logging.ts
@@ -1,0 +1,128 @@
+import { google } from 'googleapis';
+import { Client as NotionClient } from '@notionhq/client';
+
+export type RepairTrigger = 'cron' | 'telegram' | 'manual';
+
+export interface RepairLogPayload {
+  action: 'merge' | 'restart' | 'deploy' | 'check';
+  trigger: RepairTrigger;
+  success: boolean;
+  message: string;
+  timestamp?: Date;
+  details?: Record<string, unknown>;
+}
+
+interface LogResult {
+  notion?: { ok: boolean; error?: string };
+  sheets?: { ok: boolean; error?: string };
+}
+
+function ensureDate(value?: Date): Date {
+  return value instanceof Date && !Number.isNaN(value.getTime()) ? value : new Date();
+}
+
+async function logToNotion(payload: RepairLogPayload): Promise<{ ok: boolean; error?: string }> {
+  const notionToken = process.env.NOTION_TOKEN || process.env.NOTION_API_TOKEN;
+  const notionDb = process.env.NOTION_MAGGIE_EVENTS_DB || process.env.NOTION_MAGGIE_SYSTEM_EVENTS_DB;
+
+  if (!notionToken || !notionDb) {
+    return { ok: false, error: 'Missing Notion env (NOTION_TOKEN + NOTION_MAGGIE_EVENTS_DB)' };
+  }
+
+  const notion = new NotionClient({ auth: notionToken });
+  const ts = ensureDate(payload.timestamp).toISOString();
+
+  try {
+    await notion.pages.create({
+      parent: { database_id: notionDb },
+      properties: {
+        Name: {
+          title: [
+            {
+              text: {
+                content: `${payload.action.toUpperCase()} • ${payload.success ? '✅' : '⚠️'} • ${new Date(ts).toLocaleString()}`,
+              },
+            },
+          ],
+        },
+        Action: {
+          select: { name: payload.action },
+        },
+        Trigger: {
+          select: { name: payload.trigger },
+        },
+        Status: {
+          select: { name: payload.success ? 'Success' : 'Failure' },
+        },
+        Timestamp: {
+          date: { start: ts },
+        },
+        Message: {
+          rich_text: [
+            {
+              text: { content: payload.message.slice(0, 1800) },
+            },
+          ],
+        },
+      },
+    });
+    return { ok: true };
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.warn('[self-healing] failed to log Notion event', errorMessage);
+    return { ok: false, error: errorMessage };
+  }
+}
+
+function getGoogleAuth() {
+  const clientEmail = process.env.GOOGLE_SERVICE_ACCOUNT_EMAIL;
+  const privateKey = (process.env.GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY || '').replace(/\\n/g, '\n');
+
+  if (!clientEmail || !privateKey) {
+    return null;
+  }
+
+  return new google.auth.JWT({
+    email: clientEmail,
+    key: privateKey,
+    scopes: ['https://www.googleapis.com/auth/spreadsheets'],
+  });
+}
+
+async function logToGoogleSheets(payload: RepairLogPayload): Promise<{ ok: boolean; error?: string }> {
+  const spreadsheetId = process.env.GOOGLE_MAGGIE_AUTOFIX_SHEET_ID || process.env.GOOGLE_SHEETS_MAGGIE_AUTOFIX_ID;
+  if (!spreadsheetId) {
+    return { ok: false, error: 'Missing Google Sheet ID env (GOOGLE_MAGGIE_AUTOFIX_SHEET_ID)' };
+  }
+
+  const auth = getGoogleAuth();
+  if (!auth) {
+    return { ok: false, error: 'Missing Google service account credentials' };
+  }
+
+  const sheets = google.sheets({ version: 'v4', auth });
+  const ts = ensureDate(payload.timestamp).toISOString();
+
+  try {
+    await sheets.spreadsheets.values.append({
+      spreadsheetId,
+      range: 'Sheet1!A:E',
+      valueInputOption: 'USER_ENTERED',
+      requestBody: {
+        values: [[ts, payload.action, payload.trigger, payload.success ? 'success' : 'failure', payload.message]],
+      },
+    });
+    return { ok: true };
+  } catch (err) {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+    console.warn('[self-healing] failed to log Google Sheets event', errorMessage);
+    return { ok: false, error: errorMessage };
+  }
+}
+
+export async function logRepairEvent(payload: RepairLogPayload): Promise<LogResult> {
+  const timestamp = ensureDate(payload.timestamp);
+  const enriched: RepairLogPayload = { ...payload, timestamp };
+  const [notion, sheets] = await Promise.all([logToNotion(enriched), logToGoogleSheets(enriched)]);
+  return { notion, sheets };
+}

--- a/scripts/self-healing/telegramConflictResolver.ts
+++ b/scripts/self-healing/telegramConflictResolver.ts
@@ -1,0 +1,164 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export interface ConflictResolutionDetail {
+  index: number;
+  selected: 'ours' | 'theirs';
+  oursScore: number;
+  theirsScore: number;
+  reason: string;
+}
+
+export interface ConflictResolutionResult {
+  filePath: string;
+  hadConflicts: boolean;
+  resolved: boolean;
+  details: ConflictResolutionDetail[];
+}
+
+function hasConflictMarkers(content: string): boolean {
+  return content.includes('<<<<<<<') && content.includes('=======') && content.includes('>>>>>>>');
+}
+
+const KEYWORD_SCORING: Array<{ pattern: RegExp; weight: number; description: string }> = [
+  { pattern: /\/status/g, weight: 4, description: 'status command' },
+  { pattern: /\/(repair|fix)\s+telegram/g, weight: 6, description: 'repair telegram command' },
+  { pattern: /\/(post|broadcast|announce)/g, weight: 3, description: 'post/broadcast command' },
+  { pattern: /handleTelegramMessage/g, weight: 8, description: 'main handler implementation' },
+  { pattern: /handleTelegramUpdate/g, weight: 5, description: 'update handler glue' },
+  { pattern: /recordInput/g, weight: 3, description: 'recordInput instrumentation' },
+  { pattern: /snapshot/g, weight: 2, description: 'scheduler snapshot usage' },
+  { pattern: /sendTelegram/g, weight: 2, description: 'sendTelegram helper usage' },
+  { pattern: /wakeSchedulers|stopSchedulers|tickScheduler/g, weight: 2, description: 'scheduler controls' },
+];
+
+function scoreSegment(segment: string): number {
+  let score = 0;
+  for (const entry of KEYWORD_SCORING) {
+    const matches = segment.match(entry.pattern);
+    if (matches) {
+      score += matches.length * entry.weight;
+    }
+  }
+  // Penalize unresolved markers
+  if (segment.includes('<<<<<<<') || segment.includes('>>>>>>>')) {
+    score -= 100;
+  }
+  // Slight preference for longer (assumed richer) implementations
+  score += Math.min(20, Math.floor(segment.trim().split(/\n+/).length / 5));
+  return score;
+}
+
+interface ParsedConflict {
+  start: number;
+  end: number;
+  ours: string;
+  theirs: string;
+}
+
+function parseConflicts(content: string): ParsedConflict[] {
+  const conflicts: ParsedConflict[] = [];
+  const regex = /<<<<<<<[^\n]*\n([\s\S]*?)=======\n([\s\S]*?)>>>>>>>[^\n]*\n/gm;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(content))) {
+    const [full, ours, theirs] = match;
+    const start = match.index;
+    const end = match.index + full.length;
+    conflicts.push({ start, end, ours, theirs });
+  }
+  return conflicts;
+}
+
+function applyResolutions(content: string, conflicts: ParsedConflict[]): { output: string; details: ConflictResolutionDetail[] } {
+  if (!conflicts.length) {
+    return { output: content, details: [] };
+  }
+
+  let cursor = 0;
+  let output = '';
+  const details: ConflictResolutionDetail[] = [];
+
+  for (let index = 0; index < conflicts.length; index++) {
+    const conflict = conflicts[index];
+    output += content.slice(cursor, conflict.start);
+
+    const oursScore = scoreSegment(conflict.ours);
+    const theirsScore = scoreSegment(conflict.theirs);
+
+    let selected: 'ours' | 'theirs';
+    let reason: string;
+
+    if (theirsScore > oursScore) {
+      selected = 'theirs';
+      reason = `Preferred remote changes (${theirsScore} > ${oursScore})`;
+    } else if (oursScore > theirsScore) {
+      selected = 'ours';
+      reason = `Kept local changes (${oursScore} > ${theirsScore})`;
+    } else {
+      // tie-breaker: prefer the version that mentions repair commands or handleTelegramMessage explicitly
+      if (/handleTelegramMessage|\/repair\s+telegram/.test(conflict.theirs) && !/handleTelegramMessage|\/repair\s+telegram/.test(conflict.ours)) {
+        selected = 'theirs';
+        reason = 'Tie-breaker: theirs keeps repair command/handler';
+      } else if (/handleTelegramMessage|\/repair\s+telegram/.test(conflict.ours) && !/handleTelegramMessage|\/repair\s+telegram/.test(conflict.theirs)) {
+        selected = 'ours';
+        reason = 'Tie-breaker: ours keeps repair command/handler';
+      } else {
+        selected = 'theirs';
+        reason = 'Tie-breaker: default to incoming changes';
+      }
+    }
+
+    const replacement = selected === 'ours' ? conflict.ours : conflict.theirs;
+    output += replacement;
+    cursor = conflict.end;
+
+    details.push({ index, selected, oursScore, theirsScore, reason });
+  }
+
+  output += content.slice(cursor);
+  return { output, details };
+}
+
+export async function resolveTelegramConflicts(filePath: string): Promise<ConflictResolutionResult> {
+  const absolutePath = path.resolve(filePath);
+  const raw = await fs.readFile(absolutePath, 'utf8');
+
+  if (!hasConflictMarkers(raw)) {
+    return { filePath: absolutePath, hadConflicts: false, resolved: false, details: [] };
+  }
+
+  const conflicts = parseConflicts(raw);
+  if (!conflicts.length) {
+    return { filePath: absolutePath, hadConflicts: true, resolved: false, details: [] };
+  }
+
+  const { output, details } = applyResolutions(raw, conflicts);
+  await fs.writeFile(absolutePath, output, 'utf8');
+
+  return { filePath: absolutePath, hadConflicts: true, resolved: true, details };
+}
+
+export async function resolveConflictsInRepo(rootDir = process.cwd()): Promise<ConflictResolutionResult[]> {
+  try {
+    const { spawnSync } = await import('node:child_process');
+    const ls = spawnSync('git', ['ls-files', '*telegram.ts'], { cwd: rootDir, encoding: 'utf8' });
+    if (ls.status !== 0) {
+      throw new Error(ls.stderr?.toString() || 'git ls-files failed');
+    }
+    const files = ls.stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => path.resolve(rootDir, line));
+
+    const results: ConflictResolutionResult[] = [];
+    for (const file of files) {
+      const resolved = await resolveTelegramConflicts(file);
+      results.push(resolved);
+    }
+    return results;
+  } catch (err) {
+    console.warn('[telegramConflictResolver] git ls-files failed', err);
+    return [];
+  }
+}

--- a/scripts/telegram-auto-repair.ts
+++ b/scripts/telegram-auto-repair.ts
@@ -1,0 +1,319 @@
+#!/usr/bin/env ts-node
+import { spawn, spawnSync } from 'node:child_process';
+import { setTimeout as wait } from 'node:timers/promises';
+import { resolveConflictsInRepo } from './self-healing/telegramConflictResolver';
+import { logRepairEvent, type RepairTrigger } from './self-healing/logging';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import cron from 'node-cron';
+
+interface RepairOptions {
+  trigger: RepairTrigger;
+  dryRun?: boolean;
+  verbose?: boolean;
+}
+
+interface RepairOutcome {
+  mergedFiles: string[];
+  hadConflicts: boolean;
+  ranTests: boolean;
+  testsPassed: boolean;
+  deployed: boolean;
+  restartRan: boolean;
+  telegramNotified: boolean;
+}
+
+function parseArgs(): { watch: boolean; trigger: RepairTrigger; dryRun: boolean; verbose: boolean } {
+  const args = new Set(process.argv.slice(2));
+  const watch = args.has('--watch');
+  const dryRun = args.has('--dry-run');
+  const verbose = args.has('--verbose');
+
+  const triggerArg = [...args]
+    .find((arg) => arg.startsWith('--trigger='))
+    ?.split('=')[1] as RepairTrigger | undefined;
+  const trigger: RepairTrigger = triggerArg && ['cron', 'telegram', 'manual'].includes(triggerArg)
+    ? triggerArg
+    : watch
+      ? 'cron'
+      : 'manual';
+
+  return { watch, trigger, dryRun, verbose };
+}
+
+async function ensureFileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function validateTelegramRoutes(): Promise<string[]> {
+  const problems: string[] = [];
+  const routeFile = path.resolve('worker/routes/telegram.ts');
+  if (!(await ensureFileExists(routeFile))) {
+    problems.push('worker/routes/telegram.ts missing');
+    return problems;
+  }
+
+  const contents = await fs.readFile(routeFile, 'utf8');
+  if (!contents.includes('handleTelegramUpdate')) {
+    problems.push('handleTelegramUpdate import missing from worker route');
+  }
+  if (!/onRequest(Post|Get)/.test(contents)) {
+    problems.push('worker telegram route missing Cloudflare entry point');
+  }
+  return problems;
+}
+
+function runCommand(command: string, options?: { cwd?: string; verbose?: boolean }): Promise<{ ok: boolean; code: number | null }> {
+  return new Promise((resolve) => {
+    const child = spawn(command, { shell: true, stdio: 'inherit', cwd: options?.cwd });
+    child.on('close', (code) => {
+      if (options?.verbose) {
+        console.log(`[self-healing] command ${command} exited with`, code);
+      }
+      resolve({ ok: code === 0, code });
+    });
+  });
+}
+
+async function runTests(verbose: boolean): Promise<boolean> {
+  const command = process.env.TELEGRAM_REPAIR_TEST_COMMAND || 'pnpm test';
+  if (verbose) {
+    console.log(`[self-healing] running tests via: ${command}`);
+  }
+  const result = await runCommand(command, { verbose });
+  return result.ok;
+}
+
+async function deployWorker(verbose: boolean): Promise<boolean> {
+  const command = process.env.TELEGRAM_REPAIR_DEPLOY_COMMAND || 'pnpm run deploy:public';
+  if (command === 'skip') {
+    if (verbose) {
+      console.log('[self-healing] skipping deploy per config');
+    }
+    return true;
+  }
+  if (verbose) {
+    console.log(`[self-healing] deploying worker via: ${command}`);
+  }
+  const result = await runCommand(command, { verbose });
+  return result.ok;
+}
+
+async function restartServices(verbose: boolean): Promise<boolean> {
+  const command = process.env.TELEGRAM_REPAIR_RESTART_COMMAND;
+  if (!command) {
+    if (verbose) {
+      console.log('[self-healing] no restart command configured');
+    }
+    return false;
+  }
+  if (verbose) {
+    console.log(`[self-healing] restarting services via: ${command}`);
+  }
+  const result = await runCommand(command, { verbose });
+  return result.ok;
+}
+
+async function sendTelegram(text: string, verbose: boolean): Promise<boolean> {
+  const token = process.env.TELEGRAM_BOT_TOKEN;
+  const chatId = process.env.TELEGRAM_CHAT_ID || process.env.TELEGRAM_DEFAULT_CHAT_ID;
+  if (!token || !chatId) {
+    if (verbose) {
+      console.warn('[self-healing] missing Telegram credentials, cannot send notification');
+    }
+    return false;
+  }
+
+  const url = `https://api.telegram.org/bot${token}/sendMessage`;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chat_id: chatId, text, parse_mode: 'Markdown' }),
+    });
+    if (!res.ok && verbose) {
+      console.warn('[self-healing] Telegram send failed', await res.text());
+    }
+    return res.ok;
+  } catch (err) {
+    if (verbose) {
+      console.warn('[self-healing] Telegram send error', err);
+    }
+    return false;
+  }
+}
+
+async function commitResolvedFiles(files: string[], verbose: boolean): Promise<boolean> {
+  if (!files.length) return false;
+  const add = spawnSync('git', ['add', ...files]);
+  if (add.status !== 0) {
+    console.warn('[self-healing] git add failed', add.stderr?.toString());
+    return false;
+  }
+  const status = spawnSync('git', ['status', '--porcelain']);
+  const hasChanges = Boolean(status.stdout?.toString().trim());
+  if (!hasChanges) {
+    if (verbose) {
+      console.log('[self-healing] nothing to commit');
+    }
+    return false;
+  }
+
+  const commit = spawnSync('git', ['commit', '-m', 'auto: resolved Telegram handler conflict']);
+  if (commit.status !== 0) {
+    console.warn('[self-healing] git commit failed', commit.stderr?.toString());
+    return false;
+  }
+  if (verbose) {
+    console.log('[self-healing] committed auto-merge results');
+  }
+  return true;
+}
+
+async function runSelfHealing(options: RepairOptions): Promise<RepairOutcome> {
+  const results = await resolveConflictsInRepo();
+  const conflicts = results.filter((r) => r.hadConflicts);
+  const resolvedFiles = conflicts.filter((r) => r.resolved).map((r) => r.filePath);
+  const hadConflicts = conflicts.length > 0;
+  const resolvedAny = resolvedFiles.length > 0;
+
+  if (options.verbose) {
+    console.log('[self-healing] conflict scan summary:', {
+      scanned: results.length,
+      conflicts: conflicts.length,
+      resolved: resolvedFiles.length,
+    });
+  }
+
+  if (!resolvedAny && !hadConflicts) {
+    await logRepairEvent({
+      action: 'check',
+      trigger: options.trigger,
+      success: true,
+      message: 'No telegram.ts conflicts detected',
+    });
+    return {
+      mergedFiles: [],
+      hadConflicts: false,
+      ranTests: false,
+      testsPassed: false,
+      deployed: false,
+      restartRan: false,
+      telegramNotified: false,
+    };
+  }
+
+  let testsPassed = false;
+  let deployed = false;
+  let restartRan = false;
+  let telegramNotified = false;
+
+  if (hadConflicts && !resolvedAny && !options.dryRun) {
+    await sendTelegram('🧯 Maggie is offline. Auto-repair sequence initiated...', options.verbose ?? false);
+    await logRepairEvent({
+      action: 'merge',
+      trigger: options.trigger,
+      success: false,
+      message: 'Conflicts detected but automatic resolver produced no changes',
+    });
+  }
+
+  if (resolvedAny && !options.dryRun) {
+    await commitResolvedFiles(resolvedFiles, options.verbose ?? false);
+  }
+
+  const problems = await validateTelegramRoutes();
+  if (problems.length) {
+    await logRepairEvent({
+      action: 'check',
+      trigger: options.trigger,
+      success: false,
+      message: `Route validation issues: ${problems.join(', ')}`,
+    });
+  }
+
+  if (!options.dryRun) {
+    testsPassed = await runTests(options.verbose ?? false);
+    await logRepairEvent({
+      action: 'merge',
+      trigger: options.trigger,
+      success: testsPassed,
+      message: testsPassed ? 'Conflicts resolved and tests passed' : 'Conflicts resolved but tests failed',
+    });
+
+    if (testsPassed) {
+      deployed = await deployWorker(options.verbose ?? false);
+      await logRepairEvent({
+        action: 'deploy',
+        trigger: options.trigger,
+        success: deployed,
+        message: deployed ? 'Worker deployment command executed' : 'Worker deploy command failed',
+      });
+
+      restartRan = await restartServices(options.verbose ?? false);
+      await logRepairEvent({
+        action: 'restart',
+        trigger: options.trigger,
+        success: restartRan,
+        message: restartRan ? 'Restart command executed' : 'Restart command missing or failed',
+      });
+
+      if (deployed) {
+        telegramNotified = await sendTelegram('Maggie is fully back online 🚀', options.verbose ?? false);
+      }
+    }
+  }
+
+  if (options.verbose) {
+    console.log('[self-healing] outcome', { resolvedFiles, testsPassed, deployed, restartRan, telegramNotified });
+  }
+
+  return {
+    mergedFiles: resolvedFiles,
+    hadConflicts,
+    ranTests: !options.dryRun,
+    testsPassed,
+    deployed,
+    restartRan,
+    telegramNotified,
+  };
+}
+
+async function runAndReport(options: RepairOptions): Promise<void> {
+  const outcome = await runSelfHealing(options);
+  if (options.verbose) {
+    console.log('[self-healing] finished run', outcome);
+  }
+}
+
+async function bootstrapWatcher(trigger: RepairTrigger, dryRun: boolean, verbose: boolean) {
+  console.log('[self-healing] watcher active, running every 10 minutes');
+  cron.schedule('*/10 * * * *', async () => {
+    console.log('[self-healing] cron tick');
+    try {
+      await runAndReport({ trigger, dryRun, verbose });
+    } catch (err) {
+      console.error('[self-healing] cron execution failed', err);
+      await logRepairEvent({ action: 'check', trigger, success: false, message: `Cron execution error: ${err}` });
+    }
+  });
+}
+
+(async () => {
+  const { watch, trigger, dryRun, verbose } = parseArgs();
+
+  if (watch) {
+    await bootstrapWatcher(trigger, dryRun, verbose);
+    // Keep process alive
+    while (true) {
+      await wait(60_000);
+    }
+  } else {
+    await runAndReport({ trigger, dryRun, verbose });
+  }
+})();


### PR DESCRIPTION
## Summary
- add a TypeScript self-healing CLI that scans for telegram.ts merge conflicts, auto-resolves them, runs tests, deploys, restarts, logs, and notifies Telegram
- add logging helpers for Notion and Google Sheets and document the workflow in maggie.brain.md
- expose new pnpm scripts for one-off runs and a recurring watcher

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68d6bc299094832797af7126c7ef7093