### PR TITLE
Enable feedback QR logging in magnet kit PDFs

### DIFF
--- a/lib/magnet-kit.ts
+++ b/lib/magnet-kit.ts
@@ -1,6 +1,12 @@
 import path from 'path';
 import { promises as fs } from 'fs';
+import { Buffer } from 'buffer';
+
 import { createCustomIconSheet } from '../utils/icon-generator';
+import { appendRows } from './google';
+import { tgSend } from './telegram';
+
+type QRRecipient = { userId?: string; email?: string };
 
 export type MagnetFormat =
   | 'pdf'
@@ -11,28 +17,192 @@ export type MagnetFormat =
   | 'digital'
   | 'svg-sheet';
 
-interface MagnetKitOptions {
+interface MagnetKitOptions extends QRRecipient {
   userId: string;
   icons: string[];
   format: MagnetFormat;
+  bundleName?: string;
+  feedbackUrl?: string;
+}
+
+export interface BundlePdfLayout {
+  format: MagnetFormat;
+  icons: Array<{ slot: number; tag: string }>;
+  metadata: {
+    userId: string;
+    bundleName: string;
+    generatedAt: string;
+    sourceSheet?: string;
+  };
+  footer?: {
+    note?: string;
+    qr?: FeedbackQRBlock;
+  };
+  feedback?: FeedbackQRBlock;
+}
+
+export interface FeedbackQRBlock {
+  text: string;
+  url: string;
+  qrDataUrl: string;
+  createdAt: string;
+}
+
+export interface MagnetKitResult {
+  format: MagnetFormat;
+  link: string;
+  feedbackLink?: string | null;
+}
+
+interface AddFeedbackQROptions extends QRRecipient {
+  feedbackUrl: string;
+  text?: string;
+}
+
+function buildSvgQrPlaceholder(url: string) {
+  const escaped = url.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+  const svg = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="180" height="180" viewBox="0 0 180 180">
+  <rect width="180" height="180" fill="#0f172a" rx="16" />
+  <text x="90" y="96" text-anchor="middle" fill="#f8fafc" font-family="'Arial', 'Helvetica', sans-serif" font-size="14">
+    QR →
+  </text>
+  <text x="90" y="118" text-anchor="middle" fill="#f8fafc" font-family="'Arial', 'Helvetica', sans-serif" font-size="10">
+    ${escaped}
+  </text>
+</svg>`;
+  return `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
+}
+
+function decorateLink(baseUrl: string, { userId, email }: QRRecipient): string {
+  try {
+    const url = new URL(baseUrl);
+    if (userId) {
+      url.searchParams.set('user_id', userId);
+    } else if (email) {
+      url.searchParams.set('email', email);
+    }
+    return url.toString();
+  } catch {
+    // If the URL is invalid fall back to returning the raw string.
+    return baseUrl;
+  }
+}
+
+async function logFeedbackCreation(
+  sheetId: string | undefined,
+  bundleName: string,
+  userId: string,
+  feedbackUrl: string
+) {
+  if (!sheetId) return;
+  try {
+    await appendRows(sheetId, 'BundleFeedback_Log!A2:D', [
+      [new Date().toISOString(), bundleName, userId, feedbackUrl],
+    ]);
+  } catch (err) {
+    console.warn('[magnet-kit] failed to log bundle feedback QR:', err);
+  }
+}
+
+async function notifyFeedbackViaTelegram(feedbackUrl: string) {
+  try {
+    await tgSend(
+      `Here’s your rhythm bundle 🧲 If anything feels off, scan the QR to adjust.\n${feedbackUrl}`
+    );
+  } catch (err) {
+    console.warn('[magnet-kit] failed to send Telegram notification:', err);
+  }
+}
+
+export function addFeedbackQR(pdf: BundlePdfLayout, opts: AddFeedbackQROptions): BundlePdfLayout {
+  if (!opts.feedbackUrl) return pdf;
+  const finalUrl = decorateLink(opts.feedbackUrl, { userId: opts.userId, email: opts.email });
+  const qrDataUrl = buildSvgQrPlaceholder(finalUrl);
+  const text = opts.text ?? 'Scan to update your rhythm or request edits 🌀';
+  const block: FeedbackQRBlock = {
+    text,
+    url: finalUrl,
+    qrDataUrl,
+    createdAt: new Date().toISOString(),
+  };
+  return {
+    ...pdf,
+    feedback: block,
+    footer: {
+      ...(pdf.footer || {}),
+      note: text,
+      qr: { ...block },
+    },
+  };
+}
+
+function buildBaseLayout(opts: MagnetKitOptions, sheetLink: string): BundlePdfLayout {
+  const generatedAt = new Date().toISOString();
+  return {
+    format: opts.format,
+    icons: opts.icons.map((tag, idx) => ({ slot: idx + 1, tag })),
+    metadata: {
+      userId: opts.userId,
+      bundleName: opts.bundleName || 'Rhythm Bundle',
+      generatedAt,
+      sourceSheet: sheetLink || undefined,
+    },
+  };
+}
+
+function shouldEmbedFeedback(format: MagnetFormat) {
+  return format === 'pdf' || format === 'printable';
+}
+
+function resolveFeedbackUrl(opts: MagnetKitOptions): string | null {
+  const raw = opts.feedbackUrl || process.env.BUNDLE_FEEDBACK_URL || '';
+  return raw ? decorateLink(raw, { userId: opts.userId, email: opts.email }) : null;
 }
 
 /**
- * Create a full magnet kit for a user. This will generate an icon sheet
- * in the requested format and place the result in a user-specific folder.
+ * Create a full magnet kit for a user. Generates an icon sheet reference and
+ * produces a lightweight PDF layout representation including a feedback QR.
  */
-export async function createMagnetKit(opts: MagnetKitOptions) {
+export async function createMagnetKit(opts: MagnetKitOptions): Promise<MagnetKitResult> {
   const { userId, icons, format } = opts;
   const baseDir = path.join('/tmp', 'magnet-kits', userId);
   await fs.mkdir(baseDir, { recursive: true });
 
   const sheetLink = await createCustomIconSheet(userId, icons);
-  const ext = format === 'pdf' || format === 'printable' ? 'pdf' : 'svg';
-  const file = path.join(baseDir, `magnet-kit.${ext}`);
-  await fs.writeFile(file, `Generated from ${sheetLink}`);
+  let layout = buildBaseLayout(opts, sheetLink);
+  let feedbackLink: string | null = null;
+
+  if (shouldEmbedFeedback(format)) {
+    const resolved = resolveFeedbackUrl(opts);
+    if (resolved) {
+      feedbackLink = resolved;
+      layout = addFeedbackQR(layout, {
+        feedbackUrl: resolved,
+        userId: opts.userId,
+        email: opts.email,
+      });
+      await logFeedbackCreation(
+        process.env.BUNDLE_FEEDBACK_SHEET_ID,
+        layout.metadata.bundleName,
+        opts.userId,
+        resolved
+      );
+      await notifyFeedbackViaTelegram(resolved);
+    }
+  }
+
+  const file = path.join(baseDir, `magnet-kit.${format === 'pdf' || format === 'printable' ? 'json' : 'svg'}`);
+  const payload =
+    format === 'pdf' || format === 'printable'
+      ? JSON.stringify(layout, null, 2)
+      : `Generated from ${sheetLink}`;
+
+  await fs.writeFile(file, payload, 'utf8');
 
   return {
     format,
     link: `file://${file}`,
+    feedbackLink,
   };
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "lint": "eslint . --fix || echo lint ok",
     "format": "prettier --write .",
-    "test": "node -e \"const fs=require('fs');fs.mkdirSync('docs',{recursive:true});const p='docs/.brain.md';if(!fs.existsSync(p))fs.writeFileSync(p,'');\" && eslint src/fundraising --no-error-on-unmatched-pattern && vitest run tests/testBrain.test.ts tests/brain-watch.test.ts tests/fundraising.test.ts tests/magnet-bundles.test.ts",
+    "test": "node -e \"const fs=require('fs');fs.mkdirSync('docs',{recursive:true});const p='docs/.brain.md';if(!fs.existsSync(p))fs.writeFileSync(p,'');\" && eslint src/fundraising --no-error-on-unmatched-pattern && vitest run tests/testBrain.test.ts tests/brain-watch.test.ts tests/fundraising.test.ts tests/magnet-bundles.test.ts tests/feedback-qr.test.ts",
     "build": "echo build ok",
     "typecheck": "tsc -v || echo ok",
     "ci:build": "pnpm install --no-frozen-lockfile && pnpm run build",

--- a/tests/feedback-qr.test.ts
+++ b/tests/feedback-qr.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+
+import { addFeedbackQR, createMagnetKit, type BundlePdfLayout } from '../lib/magnet-kit';
+
+const appendRowsMock = vi.fn();
+const tgSendMock = vi.fn().mockResolvedValue({ ok: true });
+const sheetMock = vi.fn().mockResolvedValue('file://sheet');
+
+vi.mock('../lib/google', () => ({
+  appendRows: (...args: any[]) => appendRowsMock(...args),
+}));
+
+vi.mock('../lib/telegram', () => ({
+  tgSend: (...args: any[]) => tgSendMock(...args),
+}));
+
+vi.mock('../utils/icon-generator', () => ({
+  createCustomIconSheet: (...args: any[]) => sheetMock(...args),
+}));
+
+describe('bundle feedback QR integration', () => {
+  beforeEach(() => {
+    appendRowsMock.mockClear();
+    tgSendMock.mockClear();
+    sheetMock.mockClear();
+    process.env.BUNDLE_FEEDBACK_SHEET_ID = 'sheet-123';
+    process.env.BUNDLE_FEEDBACK_URL = 'https://feedback.example.com/form';
+  });
+
+  afterEach(async () => {
+    delete process.env.BUNDLE_FEEDBACK_SHEET_ID;
+    delete process.env.BUNDLE_FEEDBACK_URL;
+    await fs.rm(path.join('/tmp', 'magnet-kits', 'tester'), { recursive: true, force: true });
+  });
+
+  it('embeds a feedback QR block and logs creation when generating a PDF kit', async () => {
+    const result = await createMagnetKit({
+      userId: 'tester',
+      icons: ['rise', 'reset'],
+      format: 'pdf',
+      bundleName: 'Tester Bundle',
+      email: 'tester@example.com',
+    });
+
+    expect(result.feedbackLink).toMatch(/feedback\.example\.com/);
+    expect(tgSendMock).toHaveBeenCalledTimes(1);
+    expect(appendRowsMock).toHaveBeenCalledWith(
+      'sheet-123',
+      'BundleFeedback_Log!A2:D',
+      expect.any(Array)
+    );
+
+    const loggedValues = appendRowsMock.mock.calls[0][2] as string[][];
+    expect(loggedValues[0][1]).toBe('Tester Bundle');
+    expect(loggedValues[0][2]).toBe('tester');
+
+    const filePath = result.link.replace('file://', '');
+    const raw = await fs.readFile(filePath, 'utf8');
+    const layout = JSON.parse(raw) as BundlePdfLayout;
+    expect(layout.feedback?.text).toBe('Scan to update your rhythm or request edits 🌀');
+    expect(layout.feedback?.url).toMatch(/user_id=tester/);
+    expect(layout.footer?.qr?.qrDataUrl).toMatch(/^data:image\/svg\+xml;base64,/);
+  });
+
+  it('adds query parameters when injecting QR metadata', () => {
+    const base: BundlePdfLayout = {
+      format: 'pdf',
+      icons: [],
+      metadata: { userId: 'abc', bundleName: 'Demo', generatedAt: new Date().toISOString() },
+    };
+
+    const updated = addFeedbackQR(base, {
+      feedbackUrl: 'https://example.com/feedback',
+      userId: 'abc',
+    });
+
+    expect(updated.feedback?.url).toBe('https://example.com/feedback?user_id=abc');
+    expect(updated.footer?.note).toContain('Scan to update your rhythm');
+  });
+});


### PR DESCRIPTION
## Summary
- embed feedback QR metadata into magnet kit PDF layouts and add helper to generate placeholder QR artwork
- log created QR links to the BundleFeedback_Log sheet, notify Telegram, and return the personalised feedback link from createMagnetKit
- cover the new workflow with feedback-focused tests and add the suite to the default npm test command

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6c10095e483279b0933e243326e8f