### PR TITLE
Add magnet bundle personalization and library tracking

### DIFF
--- a/src/fulfillment/icons.ts
+++ b/src/fulfillment/icons.ts
@@ -88,6 +88,7 @@ function buildManifest(
       fileId: icon.fileId,
       url: icon.url,
       origin: icon.origin,
+      section: (plan.requests.find((req) => req.slug === icon.slug)?.section) || undefined,
     })),
   };
 }

--- a/src/fulfillment/types.ts
+++ b/src/fulfillment/types.ts
@@ -66,6 +66,7 @@ export interface IconAsset {
   url: string;
   fileId: string;
   origin: 'library' | 'generated';
+  section?: string;
 }
 
 export interface IconBundleResult {

--- a/tests/magnet-bundles.test.ts
+++ b/tests/magnet-bundles.test.ts
@@ -5,17 +5,19 @@ import os from 'os';
 import { resolveMagnetBundlePlan } from '../src/fulfillment/magnet-bundles';
 import type { NormalizedIntake } from '../src/fulfillment/types';
 
-async function tempRuntimeFile(name: string) {
+async function tempFile(name: string, initial: string) {
   const file = path.join(os.tmpdir(), name);
-  await fs.writeFile(file, '[]').catch(() => fs.writeFile(file, '[]'));
+  await fs.writeFile(file, initial).catch(() => fs.writeFile(file, initial));
   return file;
 }
 
 describe('magnet bundle plan', () => {
   let runtimePath: string;
+  let libraryPath: string;
 
   beforeEach(async () => {
-    runtimePath = await tempRuntimeFile(`magnet-test-${Date.now()}.json`);
+    runtimePath = await tempFile(`magnet-test-${Date.now()}.json`, '[]');
+    libraryPath = await tempFile(`magnet-library-${Date.now()}.json`, '[]');
   });
 
   function baseIntake(): NormalizedIntake {
@@ -38,7 +40,11 @@ describe('magnet bundle plan', () => {
       },
     };
 
-    const plan = await resolveMagnetBundlePlan(intake, { runtimePath, allowPersistence: false });
+    const plan = await resolveMagnetBundlePlan(intake, {
+      runtimePath,
+      allowPersistence: false,
+      trackLibrary: false,
+    });
 
     expect(plan.bundle.id).toBe('family-rhythm');
     expect(plan.requests.length).toBeGreaterThan(0);
@@ -55,7 +61,11 @@ describe('magnet bundle plan', () => {
       },
     };
 
-    const plan = await resolveMagnetBundlePlan(intake, { runtimePath, allowPersistence: false });
+    const plan = await resolveMagnetBundlePlan(intake, {
+      runtimePath,
+      allowPersistence: false,
+      trackLibrary: false,
+    });
 
     expect(plan.requests.length).toBeGreaterThan(0);
     expect(plan.source).toBe('fallback');
@@ -71,9 +81,106 @@ describe('magnet bundle plan', () => {
       },
     };
 
-    const plan = await resolveMagnetBundlePlan(intake, { runtimePath, allowPersistence: false });
+    const plan = await resolveMagnetBundlePlan(intake, {
+      runtimePath,
+      allowPersistence: false,
+      trackLibrary: false,
+    });
 
     const labels = plan.requests.map((req) => req.label.toLowerCase());
     expect(labels.some((label) => label.includes('garcia'))).toBe(true);
+  });
+
+  it('infuses soul trait language when blueprint traits are present', async () => {
+    const intake: NormalizedIntake = {
+      ...baseIntake(),
+      prefs: {
+        focus: 'Morning energy reset',
+        soul_traits: ['MG'],
+      },
+    };
+
+    const plan = await resolveMagnetBundlePlan(intake, {
+      runtimePath,
+      allowPersistence: false,
+      trackLibrary: false,
+    });
+
+    expect(plan.bundle.name).toMatch(/Move \+ Flow/i);
+    expect(plan.requests.some((req) => /Move \+ Flow/i.test(req.label))).toBe(true);
+  });
+
+  it('merges selected bundles into a combined sheet with sections', async () => {
+    const intake: NormalizedIntake = {
+      ...baseIntake(),
+      prefs: {
+        selected_bundles: ['Wellness Reset', 'Family Rhythm Balancer'],
+      },
+    };
+
+    const plan = await resolveMagnetBundlePlan(intake, {
+      runtimePath,
+      allowPersistence: false,
+      trackLibrary: false,
+    });
+
+    expect(plan.bundle.name).toMatch(/Custom Merge/i);
+    expect(plan.mergedFrom).toEqual(
+      expect.arrayContaining(['Wellness Reset', 'Family Rhythm Balancer'])
+    );
+    const sections = new Set(plan.requests.map((req) => req.section).filter(Boolean));
+    expect(sections.size).toBeGreaterThanOrEqual(2);
+  });
+
+  it('suggests reuse when a similar bundle exists in the library', async () => {
+    const existingEntry = [
+      {
+        id: 'morning-reset',
+        name: 'Morning Reset',
+        category: 'Wellness',
+        keywords: ['morning', 'reset'],
+        personaTags: ['wellness'],
+        format: 'printable',
+        source: 'stored',
+        createdAt: new Date().toISOString(),
+        email: 'test@example.com',
+      },
+    ];
+    await fs.writeFile(libraryPath, JSON.stringify(existingEntry));
+
+    const intake: NormalizedIntake = {
+      ...baseIntake(),
+      prefs: {
+        focus: 'Morning reset flow',
+      },
+    };
+
+    const plan = await resolveMagnetBundlePlan(intake, {
+      runtimePath,
+      allowPersistence: false,
+      libraryPath,
+    });
+
+    expect(plan.reuseSuggestion).toMatch(/Morning Reset/);
+  });
+
+  it('records bundle plans into the bundle library when tracking is enabled', async () => {
+    const intake: NormalizedIntake = {
+      ...baseIntake(),
+      prefs: {
+        focus: 'Household reset',
+      },
+    };
+
+    await resolveMagnetBundlePlan(intake, {
+      runtimePath,
+      allowPersistence: false,
+      libraryPath,
+    });
+
+    const stored = JSON.parse(await fs.readFile(libraryPath, 'utf8'));
+    expect(Array.isArray(stored)).toBe(true);
+    expect(stored.length).toBeGreaterThan(0);
+    expect(stored[0].email).toBe('test@example.com');
   });
 });


### PR DESCRIPTION
## Summary
- personalize stored and generated magnet bundles based on soul traits, pronouns, household details, and selected bundles
- add support for merging multiple bundles, suggesting reuse from the saved library, and tracking every plan version
- include icon section metadata and expand magnet bundle tests to cover personalization, merging, and library logging

## Testing
- npm test -- magnet-bundles

------
https://chatgpt.com/codex/tasks/task_e_68d6c1ce7dfc83279ce842d922098e52