### PR TITLE
Enhance fulfillment modes and logging

### DIFF
--- a/config/sku-map.json
+++ b/config/sku-map.json
@@ -3,6 +3,13 @@
   "price_lite": { "tier": "lite", "addOns": [] },
   "price_full": { "tier": "full", "addOns": [] },
   "price_schedule_addon": { "addOns": ["schedule"] },
-  "price_magnet_addon": { "addOns": ["magnet"] },
-  "price_bundle_full": { "tier": "full", "addOns": ["schedule", "magnet"] }
+  "price_magnet_addon": { "addOns": ["magnet"], "fulfillmentType": "physical" },
+  "price_bundle_full": { "tier": "full", "addOns": ["schedule", "magnet"], "fulfillmentType": "physical" },
+  "price_printable_download": { "fulfillmentType": "digital" },
+  "price_cricut_ready_bundle": { "fulfillmentType": "cricut-ready" },
+  "price_extra_icons_pack": { "addOns": ["extra_icons"] },
+  "price_bonus_system": { "addOns": ["bonus system"] },
+  "prod_physical_magnet_kit": { "fulfillmentType": "physical" },
+  "prod_printable_download": { "fulfillmentType": "digital" },
+  "prod_cricut_ready_files": { "fulfillmentType": "cricut-ready" }
 }

--- a/src/fulfillment/common.ts
+++ b/src/fulfillment/common.ts
@@ -4,11 +4,23 @@ import type { drive_v3 } from 'googleapis';
 import { getDrive, getDocs, getSheets } from '../../lib/google';
 import { getSecrets } from '../config';
 import { appendRows } from '../../lib/google';
-import { NormalizedIntake, FulfillmentConfig, FulfillmentWorkspace, OrderSummary } from './types';
+import {
+  NormalizedIntake,
+  FulfillmentConfig,
+  FulfillmentWorkspace,
+  OrderSummary,
+  FulfillmentMode,
+} from './types';
 import { tgSend } from '../lib/telegram';
 
 let cachedConfig: FulfillmentConfig | null = null;
-let cachedSkuMap: Record<string, { tier?: string; addOns?: string[] }> | null = null;
+export interface SkuDefinition {
+  tier?: string;
+  addOns?: string[];
+  fulfillmentType?: FulfillmentMode;
+}
+
+let cachedSkuMap: Record<string, SkuDefinition> | null = null;
 let cachedIconLibrary: IconLibraryEntry[] | null = null;
 
 interface IconLibraryEntry {
@@ -74,7 +86,7 @@ export async function loadFulfillmentConfig(opts: LoadOptions = {}): Promise<Ful
   return config;
 }
 
-export async function loadSkuMap(): Promise<Record<string, { tier?: string; addOns?: string[] }>> {
+export async function loadSkuMap(): Promise<Record<string, SkuDefinition>> {
   if (cachedSkuMap) return cachedSkuMap;
   const filePath = path.resolve(process.cwd(), 'config', 'sku-map.json');
   try {
@@ -189,8 +201,25 @@ export async function appendFulfillmentLog(
     const utc = new Date(summary.completedAt).toISOString();
     const local = new Date(summary.completedAt).toLocaleString('en-US', { timeZone: 'America/Denver' });
     const files = summary.files.join('\n');
-    await appendRows(config.sheetId, 'Fulfillment!A2:G', [
-      [utc, local, intake.email, intake.tier, summary.message, files, summary.status],
+    const fulfillmentType = summary.metadata?.fulfillment_type || intake.fulfillmentType || '';
+    const metadataAddOns = summary.metadata?.add_ons;
+    const addOns = Array.isArray(metadataAddOns)
+      ? metadataAddOns.join(', ')
+      : (intake.addOns || []).join(', ');
+    const fulfillmentStatus = summary.metadata?.bundle_fulfillment || '';
+    await appendRows(config.sheetId, 'Fulfillment!A2:J', [
+      [
+        utc,
+        local,
+        intake.email,
+        intake.tier,
+        summary.message,
+        files,
+        summary.status,
+        fulfillmentType,
+        addOns,
+        fulfillmentStatus,
+      ],
     ]);
   } catch (err) {
     console.warn('[fulfillment.log] failed to append to sheet:', err);
@@ -221,4 +250,4 @@ export async function recordOrderSummary(summary: OrderSummary): Promise<void> {
   } catch {}
 }
 
-export type { IconLibraryEntry };
+export type { IconLibraryEntry, SkuDefinition };

--- a/src/fulfillment/deliver.ts
+++ b/src/fulfillment/deliver.ts
@@ -1,8 +1,87 @@
 import { sendEmail } from '../../utils/email';
-import type { NormalizedIntake, BlueprintResult, IconBundleResult, ScheduleResult, DeliveryReceipt } from './types';
+import { loadFulfillmentConfig } from './common';
+import { tgSend } from '../lib/telegram';
+import type {
+  NormalizedIntake,
+  BlueprintResult,
+  IconBundleResult,
+  ScheduleResult,
+  DeliveryReceipt,
+  FulfillmentOutput,
+  FulfillmentWorkspace,
+  FulfillmentMode,
+} from './types';
 
 interface DeliverOptions {
   env?: any;
+  workspace?: FulfillmentWorkspace;
+}
+
+interface DeliveryResult {
+  receipts: DeliveryReceipt[];
+  outputs: FulfillmentOutput[];
+}
+
+function describeFulfillment(mode: FulfillmentMode | undefined): string {
+  switch (mode) {
+    case 'physical':
+      return 'print-ready magnet bundle';
+    case 'cricut-ready':
+      return 'Cricut-ready design kit';
+    default:
+      return 'digital bundle';
+  }
+}
+
+function buildOutputs(
+  intake: NormalizedIntake,
+  blueprint: BlueprintResult,
+  icons: IconBundleResult,
+  schedule: ScheduleResult
+): FulfillmentOutput[] {
+  const outputs: FulfillmentOutput[] = [];
+  if (blueprint.docUrl) {
+    outputs.push({ label: 'Story in Google Docs', url: blueprint.docUrl, type: 'document' });
+  }
+
+  const fulfillmentType = intake.fulfillmentType || 'digital';
+  const pdfLabel =
+    fulfillmentType === 'physical'
+      ? 'Print-ready magnet PDF'
+      : fulfillmentType === 'cricut-ready'
+      ? 'Cricut instructions PDF'
+      : 'Digital instructions PDF';
+  if (blueprint.pdfUrl) {
+    outputs.push({ label: pdfLabel, url: blueprint.pdfUrl, type: 'pdf' });
+  }
+
+  if (schedule.scheduleFolderUrl) {
+    outputs.push({ label: 'Rhythm templates', url: schedule.scheduleFolderUrl, type: 'schedule' });
+  }
+
+  if (icons.bundleFolderUrl) {
+    const iconLabel =
+      fulfillmentType === 'cricut-ready' ? 'SVG + PNG design bundle' : 'Icon bundle';
+    outputs.push({ label: iconLabel, url: icons.bundleFolderUrl, type: 'icons' });
+  }
+
+  if (fulfillmentType === 'cricut-ready' && icons.manifestUrl) {
+    outputs.push({ label: 'Cutting manifest', url: icons.manifestUrl, type: 'asset' });
+  }
+
+  return outputs;
+}
+
+function formatTextOutputs(outputs: FulfillmentOutput[]): string {
+  return outputs
+    .map((output) => `- ${output.label}: ${output.url}`)
+    .join('\n');
+}
+
+function formatHtmlOutputs(outputs: FulfillmentOutput[]): string {
+  return outputs
+    .map((output) => `<li><a href="${output.url}">${output.label}</a></li>`)
+    .join('');
 }
 
 export async function deliverFulfillment(
@@ -11,21 +90,30 @@ export async function deliverFulfillment(
   icons: IconBundleResult,
   schedule: ScheduleResult,
   opts: DeliverOptions = {}
-): Promise<DeliveryReceipt[]> {
+): Promise<DeliveryResult> {
   if (!intake.email) {
     throw new Error('Cannot deliver fulfillment without customer email');
   }
 
-  const subject = `Your ${intake.tier === 'full' ? 'Full' : intake.tier === 'lite' ? 'Lite' : 'Mini'} Soul Blueprint is here`;
+  let config = opts.workspace?.config;
+  if (!config) {
+    try {
+      config = await loadFulfillmentConfig({ env: opts.env });
+    } catch (err) {
+      console.warn('[fulfillment.deliver] unable to load config for delivery:', err);
+    }
+  }
+  const outputs = buildOutputs(intake, blueprint, icons, schedule);
+  const fulfillmentLabel = describeFulfillment(intake.fulfillmentType);
+  const addOnSummary = intake.addOns?.length ? intake.addOns.join(', ') : 'None';
+  const subject = `Your ${fulfillmentLabel} is ready`;
   const greeting = intake.customer.firstName || intake.customer.name || 'Hi friend';
-  const bundleLine = icons.bundleName ? `- Icon bundle (${icons.bundleName}): ${icons.bundleFolderUrl}` : `- Icon bundle: ${icons.bundleFolderUrl}`;
   const textBody = `${greeting},
 
-Your reading and rhythm kit are ready. Here is everything in one place:
-- Story in Google Docs: ${blueprint.docUrl}
-- Downloadable PDF: ${blueprint.pdfUrl}
-- Rhythm templates: ${schedule.scheduleFolderUrl}
-${bundleLine}
+Your ${fulfillmentLabel} is ready. Here is everything in one place:
+${formatTextOutputs(outputs)}
+
+Add-ons: ${addOnSummary}
 
 Take your time, sip some tea, and let this settle in. Reply if anything feels off or if you want an adjustment.
 
@@ -34,13 +122,11 @@ Maggie`;
 
   const htmlBody = `
   <p>${greeting},</p>
-  <p>Your reading and rhythm kit are ready. Here is everything in one place:</p>
+  <p>Your ${fulfillmentLabel} is ready. Here is everything in one place:</p>
   <ul>
-    <li><a href="${blueprint.docUrl}">Story in Google Docs</a></li>
-    <li><a href="${blueprint.pdfUrl}">Downloadable PDF</a></li>
-    <li><a href="${schedule.scheduleFolderUrl}">Rhythm templates</a></li>
-    <li><a href="${icons.bundleFolderUrl}">Icon bundle${icons.bundleName ? ` (${icons.bundleName})` : ''}</a></li>
+    ${formatHtmlOutputs(outputs)}
   </ul>
+  <p>Add-ons: <strong>${addOnSummary}</strong></p>
   <p>Take your time, sip some tea, and let this settle in. Reply if anything feels off or if you want an adjustment.</p>
   <p>With warmth,<br/>Maggie</p>
   `;
@@ -55,5 +141,17 @@ Maggie`;
     opts.env
   );
 
-  return [{ channel: 'email', id: result.id }];
+  const receipts: DeliveryReceipt[] = [{ channel: 'email', id: result.id }];
+
+  if (config?.telegramChatId && config.telegramBotToken) {
+    const telegramMessage = `✨ ${fulfillmentLabel} sent to ${intake.email}\nAdd-ons: ${addOnSummary}\n${formatTextOutputs(outputs)}`;
+    try {
+      await tgSend(telegramMessage, config.telegramChatId);
+      receipts.push({ channel: 'telegram', target: config.telegramChatId });
+    } catch (err) {
+      console.warn('[fulfillment.deliver] failed to notify via Telegram:', err);
+    }
+  }
+
+  return { receipts, outputs };
 }

--- a/src/fulfillment/types.ts
+++ b/src/fulfillment/types.ts
@@ -19,11 +19,14 @@ export interface CustomerProfile {
   householdMembers?: string[];
 }
 
+export type FulfillmentMode = 'digital' | 'physical' | 'cricut-ready';
+
 export interface NormalizedIntake {
   source: 'stripe' | 'tally';
   email: string;
   tier: FulfillmentTier;
   addOns: string[];
+  fulfillmentType?: FulfillmentMode;
   prefs: Record<string, any>;
   customer: CustomerProfile;
   /**
@@ -98,8 +101,17 @@ export interface ScheduleResult {
 }
 
 export interface DeliveryReceipt {
-  channel: 'email' | 'zoho';
+  channel: 'email' | 'zoho' | 'telegram';
   id?: string;
+  target?: string;
+}
+
+export type FulfillmentOutputType = 'document' | 'pdf' | 'icons' | 'schedule' | 'asset';
+
+export interface FulfillmentOutput {
+  label: string;
+  url: string;
+  type: FulfillmentOutputType;
 }
 
 export interface FulfillmentWorkspace {
@@ -136,6 +148,7 @@ export interface FulfillmentRecord {
   icons: IconBundleResult;
   schedule: ScheduleResult;
   delivery: DeliveryReceipt[];
+  outputs: FulfillmentOutput[];
   workspace: FulfillmentWorkspace;
 }
 
@@ -146,4 +159,5 @@ export interface OrderSummary {
   message: string;
   completedAt: string;
   files: string[];
+  metadata?: Record<string, any>;
 }


### PR DESCRIPTION
## Summary
- map Stripe and Tally inputs to structured fulfillment modes, add-ons, and SKU metadata for automation
- deliver tailored output bundles with updated email/Telegram notifications and persist outputs in summaries and sheets
- extend fulfillment records, logging, and configuration helpers to track fulfillment status and extra artifacts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6c256e9808327b6550c3742ba850b