### PR TITLE
feat: personalize magnet bundles per audience

### DIFF
--- a/config/magnet-bundles.json
+++ b/config/magnet-bundles.json
@@ -8,6 +8,8 @@
       "formats": ["svg", "printable", "cling", "digital"],
       "personaTags": ["solo mom", "adhd support", "household"],
       "keywords": ["laundry", "kitchen", "reset", "evening"],
+      "icon_size": "0.95in",
+      "style_level": "standard",
       "icons": [
         {
           "slug": "sunrise-anchor",
@@ -47,6 +49,8 @@
       "formats": ["svg", "printable", "vinyl", "digital"],
       "personaTags": ["neurodivergent child", "sensory", "calm"],
       "keywords": ["breath", "body", "hydrate"],
+      "icon_size": "1.1in",
+      "style_level": "neurodivergent_support",
       "icons": [
         {
           "slug": "sunrise-anchor",
@@ -82,6 +86,8 @@
       "formats": ["svg", "printable", "cling", "digital"],
       "personaTags": ["family", "homeschool", "toddler"],
       "keywords": ["morning basket", "play", "cleanup"],
+      "icon_size": "1.2in",
+      "style_level": "kid_friendly",
       "icons": [
         {
           "slug": "family-circle",
@@ -117,6 +123,8 @@
       "formats": ["svg", "printable", "vinyl", "digital"],
       "personaTags": ["premium", "full", "deep"],
       "keywords": ["all-in-one", "full kit", "deep dive"],
+      "icon_size": "0.9in",
+      "style_level": "standard",
       "icons": [
         {
           "slug": "sunrise-anchor",

--- a/src/fulfillment/icons.ts
+++ b/src/fulfillment/icons.ts
@@ -1,6 +1,14 @@
 import { Buffer } from 'buffer';
 import { ensureOrderWorkspace, ensureFolder, loadIconLibrary } from './common';
-import type { NormalizedIntake, IconBundleResult, IconAsset, FulfillmentWorkspace } from './types';
+import type {
+  NormalizedIntake,
+  IconBundleResult,
+  IconAsset,
+  FulfillmentWorkspace,
+  IconBundlePdfVariant,
+  IconStyleLevel,
+  IconAudienceProfile,
+} from './types';
 import {
   resolveMagnetBundlePlan,
   persistBundlePlanArtifacts,
@@ -31,7 +39,24 @@ function findLibraryMatch(request: MagnetIconRequest, library: LibraryMatch[]): 
   return looseMatch || null;
 }
 
-function paletteForTone(tone: MagnetIconRequest['tone']) {
+function paletteForTone(
+  tone: MagnetIconRequest['tone'],
+  styleLevel?: IconStyleLevel,
+  creativeTone?: boolean,
+  highContrast?: boolean
+) {
+  if (highContrast) {
+    return { bg: '#ffffff', accent: '#000000', detail: '#000000' };
+  }
+  if (styleLevel === 'kid_friendly') {
+    return { bg: '#ffe6b5', accent: '#ff8a65', detail: '#c25e2c' };
+  }
+  if (styleLevel === 'neurodivergent_support') {
+    return { bg: '#e5f6ff', accent: '#2196f3', detail: '#0d47a1' };
+  }
+  if (creativeTone) {
+    return { bg: '#f3e8ff', accent: '#bb86fc', detail: '#6200ee' };
+  }
   switch (tone) {
     case 'bright':
       return { bg: '#ffd8e5', accent: '#f26d9d', detail: '#8a3ffc' };
@@ -42,11 +67,30 @@ function paletteForTone(tone: MagnetIconRequest['tone']) {
   }
 }
 
+function escapeXml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 function generateSvgIcon(request: MagnetIconRequest): string {
-  const palette = paletteForTone(request.tone);
-  const text = request.label.replace(/[^a-zA-Z0-9 ]/g, '').slice(0, 18);
+  const palette = paletteForTone(request.tone, request.styleLevel, request.creativeTone, request.highContrast);
+  const text = request.label.replace(/[^a-zA-Z0-9 ]/g, '').slice(0, 20);
+  const fontSize =
+    request.styleLevel === 'kid_friendly'
+      ? 64
+      : request.styleLevel === 'elder_accessible'
+      ? 60
+      : request.styleLevel === 'neurodivergent_support'
+      ? 56
+      : 48;
+  const metadata = escapeXml(
+    JSON.stringify({ iconSize: request.iconSize, styleLevel: request.styleLevel, audience: request.audienceName || undefined })
+  );
+  const categoryText = request.emphasizeCategories && request.category ? request.category.toUpperCase().slice(0, 20) : '';
+  const categoryFont = Math.max(fontSize - 16, 30);
+  const accentOpacity = request.highContrast ? 0.4 : 0.75;
   return `<?xml version="1.0" encoding="UTF-8"?>
 <svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <metadata>${metadata}</metadata>
   <defs>
     <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="${palette.bg}" />
@@ -54,19 +98,152 @@ function generateSvgIcon(request: MagnetIconRequest): string {
     </linearGradient>
   </defs>
   <rect x="0" y="0" width="512" height="512" rx="64" fill="url(#bg)" />
-  <circle cx="256" cy="220" r="140" fill="${palette.accent}" opacity="0.75" />
+  <circle cx="256" cy="220" r="140" fill="${palette.accent}" opacity="${accentOpacity}" />
   <path d="M120 360 C180 300 332 300 392 360" stroke="${palette.detail}" stroke-width="22" fill="none" stroke-linecap="round" />
-  <text x="256" y="410" font-family="'Poppins', 'Arial', sans-serif" font-size="46" fill="${palette.detail}" text-anchor="middle">
-    ${text}
-  </text>
+  <text x="256" y="404" font-family="'Poppins', 'Arial', sans-serif" font-size="${fontSize}" fill="${palette.detail}" text-anchor="middle">${escapeXml(
+    text
+  )}</text>
+  ${
+    categoryText
+      ? `<text x="256" y="460" font-family="'Poppins', 'Arial', sans-serif" font-size="${categoryFont}" fill="${palette.detail}" text-anchor="middle" opacity="0.85">${escapeXml(
+          categoryText
+        )}</text>`
+      : ''
+  }
 </svg>`;
+}
+
+function pdfTextEscape(str: string): string {
+  return str.replace(/\\/g, '\\\\').replace(/\(/g, '\\(').replace(/\)/g, '\\)');
+}
+
+function buildPdfBuffer(audience: IconAudienceProfile, requests: MagnetIconRequest[]): Buffer {
+  const lines: string[] = [];
+  lines.push(`${audience.name}'s Magnet Bundle`);
+  lines.push(`Style: ${audience.styleLevel.replace(/_/g, ' ')}, icon size ${audience.iconSize}`);
+  if (audience.highContrast) lines.push('High contrast text and bold outlines recommended.');
+  if (audience.simplifyText) lines.push('Use simplified wording on shared boards.');
+  if (audience.needsRepetition) lines.push('Repeat key magnets for regulation cues.');
+  lines.push('');
+  lines.push('Icons:');
+  const iconLines = requests
+    .map((req) => `${req.label}${req.iconSize ? ` (${req.iconSize})` : ''}`)
+    .slice(0, 12);
+  lines.push(...iconLines);
+
+  const textOps: string[] = ['BT', '/F1 24 Tf', '1 0 0 1 72 720 Tm', '28 TL'];
+  lines.forEach((line, index) => {
+    const escaped = pdfTextEscape(line);
+    if (index === 0) {
+      textOps.push(`(${escaped}) Tj`);
+      textOps.push('/F1 18 Tf');
+      textOps.push('22 TL');
+    } else {
+      textOps.push('T*');
+      textOps.push(`(${escaped}) Tj`);
+    }
+  });
+  textOps.push('ET');
+
+  const content = textOps.join('\n');
+  const objects: string[] = [''];
+  objects.push('1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n');
+  objects.push('2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n');
+  objects.push(
+    '3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>\nendobj\n'
+  );
+  objects.push(`4 0 obj\n<< /Length ${Buffer.byteLength(content, 'utf8')} >>\nstream\n${content}\nendstream\nendobj\n`);
+  objects.push('5 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>\nendobj\n');
+
+  let pdf = '%PDF-1.4\n';
+  const offsets: number[] = [];
+  for (let i = 1; i < objects.length; i++) {
+    offsets[i] = Buffer.byteLength(pdf, 'utf8');
+    pdf += objects[i];
+  }
+  const xrefStart = Buffer.byteLength(pdf, 'utf8');
+  pdf += 'xref\n';
+  pdf += `0 ${objects.length}\n`;
+  pdf += '0000000000 65535 f \n';
+  for (let i = 1; i < objects.length; i++) {
+    pdf += `${offsets[i].toString().padStart(10, '0')} 00000 n \n`;
+  }
+  pdf += 'trailer\n';
+  pdf += `<< /Size ${objects.length} /Root 1 0 R >>\n`;
+  pdf += 'startxref\n';
+  pdf += `${xrefStart}\n`;
+  pdf += '%%EOF';
+
+  return Buffer.from(pdf, 'utf8');
+}
+
+async function createPdfVariants(
+  drive: FulfillmentWorkspace['drive'],
+  folderId: string,
+  plan: MagnetBundlePlan,
+  requests: MagnetIconRequest[]
+): Promise<IconBundlePdfVariant[]> {
+  const variants: IconBundlePdfVariant[] = [];
+  const audiences = plan.personalization.audiences?.length
+    ? plan.personalization.audiences
+    : [
+        {
+          name: plan.personalization.primaryAudienceName || 'Primary',
+          cohort: plan.personalization.cohort || 'adult',
+          iconSize: plan.personalization.iconSize,
+          styleLevel: plan.personalization.styleLevel,
+          simplifyText: plan.personalization.simplifyText,
+          highContrast: plan.personalization.highContrast,
+          needsRepetition: plan.personalization.needsRepetition,
+          emphasizeCategories: plan.personalization.emphasizeCategories,
+          creativeTone: plan.personalization.creativeTone,
+          version: 1,
+        },
+      ];
+
+  for (const audience of audiences) {
+    try {
+      const buffer = buildPdfBuffer(audience, requests);
+      const safeName = audience.name.replace(/[^a-z0-9]+/gi, '-').replace(/^-+|-+$/g, '') || 'bundle';
+      const version = audience.version || 1;
+      const fileName = `${safeName.toLowerCase()}-icons-v${version}.pdf`;
+      const created = await drive.files.create({
+        requestBody: {
+          name: fileName,
+          mimeType: 'application/pdf',
+          parents: [folderId],
+        },
+        media: { mimeType: 'application/pdf', body: buffer },
+        fields: 'id, webViewLink',
+      });
+      variants.push({
+        name: audience.name,
+        version,
+        fileId: created.data.id || '',
+        url: created.data.webViewLink || '',
+        iconSize: audience.iconSize,
+        styleLevel: audience.styleLevel,
+      });
+    } catch (err) {
+      console.warn('[icon-bundle] failed to create PDF variant:', err);
+    }
+  }
+
+  return variants;
 }
 
 function buildManifest(
   intake: NormalizedIntake,
   icons: IconAsset[],
-  plan: MagnetBundlePlan
+  plan: MagnetBundlePlan,
+  pdfVersions: IconBundlePdfVariant[]
 ) {
+  const requestKey = (req: Pick<MagnetIconRequest, 'slug' | 'label'>) => `${req.slug}:${req.label}`.toLowerCase();
+  const requestMap = new Map<string, MagnetIconRequest>();
+  for (const req of plan.requests) {
+    requestMap.set(requestKey(req), req);
+  }
+
   return {
     generatedAt: new Date().toISOString(),
     email: intake.email,
@@ -80,15 +257,37 @@ function buildManifest(
       helperBots: plan.helpers,
       keywords: plan.keywords,
       format: plan.format,
+      styleLevel: plan.bundle.styleLevel,
+      iconSize: plan.bundle.iconSize,
     },
-    icons: icons.map((icon) => ({
-      slug: icon.slug,
-      name: icon.name,
-      description: icon.description,
-      fileId: icon.fileId,
-      url: icon.url,
-      origin: icon.origin,
-    })),
+    styleProfile: {
+      iconSize: plan.personalization.iconSize,
+      styleLevel: plan.personalization.styleLevel,
+      simplifyText: plan.personalization.simplifyText,
+      highContrast: plan.personalization.highContrast,
+      needsRepetition: plan.personalization.needsRepetition,
+      emphasizeCategories: plan.personalization.emphasizeCategories,
+      audiences: plan.personalization.audiences,
+    },
+    pdfVersions,
+    icons: icons.map((icon) => {
+      const key = requestKey({ slug: icon.slug, label: icon.name });
+      const meta = requestMap.get(key) || plan.requests.find((req) => req.slug === icon.slug);
+      return {
+        slug: icon.slug,
+        name: icon.name,
+        description: icon.description,
+        fileId: icon.fileId,
+        url: icon.url,
+        origin: icon.origin,
+        iconSize: icon.iconSize || meta?.iconSize,
+        styleLevel: icon.styleLevel || meta?.styleLevel,
+        audience: icon.audience || meta?.audienceName,
+        highContrast: icon.highContrast ?? meta?.highContrast,
+        needsRepetition: icon.needsRepetition ?? false,
+        category: meta?.category,
+      };
+    }),
   };
 }
 
@@ -131,6 +330,11 @@ export async function buildIconBundle(
         url: copy.data.webViewLink || match.url || '',
         fileId: copy.data.id || '',
         origin: 'library',
+        iconSize: request.iconSize,
+        styleLevel: request.styleLevel,
+        audience: request.audienceName,
+        highContrast: request.highContrast,
+        needsRepetition: plan.personalization.needsRepetition,
       });
       continue;
     }
@@ -152,10 +356,16 @@ export async function buildIconBundle(
       url: created.data.webViewLink || '',
       fileId: created.data.id || '',
       origin: 'generated',
+      iconSize: request.iconSize,
+      styleLevel: request.styleLevel,
+      audience: request.audienceName,
+      highContrast: request.highContrast,
+      needsRepetition: plan.personalization.needsRepetition,
     });
   }
 
-  const manifest = buildManifest(intake, icons, plan);
+  const pdfVersions = await createPdfVariants(drive, iconFolder.id!, plan, requests);
+  const manifest = buildManifest(intake, icons, plan, pdfVersions);
   const manifestFile = await drive.files.create({
     requestBody: {
       name: 'manifest.json',
@@ -185,5 +395,6 @@ export async function buildIconBundle(
     helperBots: plan.helpers,
     keywords: plan.keywords,
     icons,
+    pdfVersions,
   };
 }

--- a/src/fulfillment/types.ts
+++ b/src/fulfillment/types.ts
@@ -2,6 +2,30 @@ import type { drive_v3, docs_v1 } from 'googleapis';
 
 export type FulfillmentTier = 'mini' | 'lite' | 'full';
 
+export type IconStyleLevel = 'kid_friendly' | 'elder_accessible' | 'standard' | 'neurodivergent_support';
+
+export interface IconAudienceProfile {
+  name: string;
+  cohort: 'child' | 'teen' | 'adult' | 'elder';
+  iconSize: string;
+  styleLevel: IconStyleLevel;
+  simplifyText: boolean;
+  highContrast: boolean;
+  needsRepetition: boolean;
+  emphasizeCategories: boolean;
+  creativeTone?: boolean;
+  version: number;
+}
+
+export interface IconBundlePdfVariant {
+  name: string;
+  version: number;
+  fileId: string;
+  url: string;
+  iconSize: string;
+  styleLevel: IconStyleLevel;
+}
+
 export interface BirthData {
   date?: string;
   time?: string;
@@ -66,6 +90,11 @@ export interface IconAsset {
   url: string;
   fileId: string;
   origin: 'library' | 'generated';
+  iconSize?: string;
+  styleLevel?: IconStyleLevel;
+  audience?: string;
+  highContrast?: boolean;
+  needsRepetition?: boolean;
 }
 
 export interface IconBundleResult {
@@ -80,6 +109,7 @@ export interface IconBundleResult {
   helperBots?: { name: string; instructions: string; payload?: Record<string, any> }[];
   keywords?: string[];
   icons: IconAsset[];
+  pdfVersions?: IconBundlePdfVariant[];
 }
 
 export interface ScheduleFile {


### PR DESCRIPTION
## Summary
- add style level and icon size metadata to stored bundles and manifest outputs
- personalize magnet planning to size icons and simplify text for kids, elders, and sensory profiles
- generate audience-specific PDF variants and extend icon metadata for downstream rendering

## Testing
- pnpm vitest tests/magnet-bundles.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d6c2275b208327b73374958087eb9d