### PR TITLE
Fix: finalize magnet bundle placeholders and layout

### DIFF
--- a/src/fulfillment/icons.ts
+++ b/src/fulfillment/icons.ts
@@ -20,6 +20,7 @@ interface LibraryMatch {
 }
 
 function findLibraryMatch(request: MagnetIconRequest, library: LibraryMatch[]): LibraryMatch | null {
+  if (request.isBlank) return null;
   const slugMatch = library.find((icon) => icon.slug === request.slug);
   if (slugMatch) return slugMatch;
   const tagMatch = library.find((icon) => {
@@ -89,6 +90,7 @@ function buildManifest(
       fileId: icon.fileId,
       url: icon.url,
       origin: icon.origin,
+      isBlank: icon.isBlank || false,
     })),
   };
 }
@@ -115,6 +117,19 @@ export async function buildIconBundle(
   const icons: IconAsset[] = [];
 
   for (const request of requests) {
+    if (request.isBlank) {
+      icons.push({
+        slug: request.slug,
+        name: request.label,
+        description: request.description,
+        url: '',
+        fileId: '',
+        origin: 'blank',
+        isBlank: true,
+      });
+      continue;
+    }
+
     const match = findLibraryMatch(request, library);
     if (match?.fileId) {
       const copy = await drive.files.copy({
@@ -132,6 +147,7 @@ export async function buildIconBundle(
         url: copy.data.webViewLink || match.url || '',
         fileId: copy.data.id || '',
         origin: 'library',
+        isBlank: false,
       });
       continue;
     }
@@ -153,6 +169,7 @@ export async function buildIconBundle(
       url: created.data.webViewLink || '',
       fileId: created.data.id || '',
       origin: 'generated',
+      isBlank: false,
     });
   }
 

--- a/src/fulfillment/types.ts
+++ b/src/fulfillment/types.ts
@@ -65,7 +65,8 @@ export interface IconAsset {
   description: string;
   url: string;
   fileId: string;
-  origin: 'library' | 'generated';
+  origin: 'library' | 'generated' | 'blank';
+  isBlank?: boolean;
 }
 
 export interface IconBundleResult {

--- a/tests/magnet-bundles.test.ts
+++ b/tests/magnet-bundles.test.ts
@@ -104,6 +104,27 @@ describe('magnet bundle plan', () => {
     expect(labels.some((label) => label.includes('garcia'))).toBe(true);
   });
 
+  it('includes blank magnet placeholders when requested', async () => {
+    const intake: NormalizedIntake = {
+      ...baseIntake(),
+      prefs: {
+        blank_magnets: 2,
+      },
+    };
+
+    const plan = await resolveMagnetBundlePlan(intake, {
+      runtimePath,
+      allowPersistence: false,
+      libraryPath,
+    });
+
+    const blanks = plan.requests.filter((req) => req.isBlank);
+    expect(blanks.length).toBe(2);
+    expect(plan.placeholders.length).toBeGreaterThan(0);
+    expect(plan.layout).toBeDefined();
+    expect(plan.layout?.sections.some((section) => /blank/i.test(section.title))).toBe(true);
+  });
+
   it('personalizes a bundle name with soul traits and household summary', () => {
     const bundle = {
       id: 'morning-reset',


### PR DESCRIPTION
## Summary
- add shared blank magnet placeholder normalization, request expansion, and bundle layout generation utilities
- extend magnet bundle planning to persist placeholders, AI-generated or fallback layouts, and updated helper instructions
- update icon fulfillment to respect blank requests, expand manifest metadata, and cover the workflow with tests

## Testing
- `pnpm vitest run tests/magnet-bundles.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68d6c69e0d5483278bc0ac9656fa029a