### PR TITLE
Validate Telegram ping response payload

### DIFF
--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -114,20 +114,26 @@ export default {
           body: JSON.stringify(payload),
         });
 
-        if (telegramResp.ok) {
-          return new Response(
-            JSON.stringify({ ok: true, message: "Ping sent" }),
-            { headers: cors({ "content-type": "application/json; charset=utf-8" }) }
-          );
-        }
-
-        return new Response(
-          JSON.stringify({ ok: false, error: "Telegram send failed" }),
-          {
+        let result: any;
+        try {
+          result = await telegramResp.json();
+        } catch {
+          return new Response(JSON.stringify({ ok: false }), {
             status: 500,
             headers: cors({ "content-type": "application/json; charset=utf-8" }),
-          }
-        );
+          });
+        }
+
+        if (result?.ok !== true) {
+          return new Response(JSON.stringify({ ok: false }), {
+            status: 500,
+            headers: cors({ "content-type": "application/json; charset=utf-8" }),
+          });
+        }
+
+        return new Response(JSON.stringify({ ok: true }), {
+          headers: cors({ "content-type": "application/json; charset=utf-8" }),
+        });
       }
 
       if (url.pathname === '/' || url.pathname === '/health') {


### PR DESCRIPTION
## Summary
- parse the Telegram sendMessage response in the /ping worker route
- return an error when the Telegram API indicates failure so bad credentials are caught

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8a6de8c1c8327b95049aa535ea545