### PR TITLE
Fix /ping route to send Telegram notification

### DIFF
--- a/worker/env.ts
+++ b/worker/env.ts
@@ -1,0 +1,19 @@
+const runtimeEnv: Record<string, any> =
+  (typeof globalThis !== "undefined" &&
+    ((globalThis as any).__ENV__ || (globalThis as any).ENV || (globalThis as any))) ||
+  {};
+
+export function getConfig(key: string) {
+  if (key in runtimeEnv) {
+    return runtimeEnv[key];
+  }
+
+  if (typeof process !== "undefined" && process.env && key in process.env) {
+    return process.env[key];
+  }
+
+  return undefined;
+}
+
+export const TELEGRAM_BOT_TOKEN = getConfig("TELEGRAM_BOT_TOKEN");
+export const TELEGRAM_CHAT_ID = getConfig("TELEGRAM_CHAT_ID");


### PR DESCRIPTION
## Summary
- add a Telegram helper to the worker so the /ping route sends the expected notification
- return consistent JSON and error handling with shared CORS headers for the /ping response
- provide env helpers for accessing Telegram configuration values

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d95dddd8f48327b7a3fdfd2dc4106b