### PR TITLE
Improve ping endpoints and nightly checks

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -38,7 +38,7 @@ zone_name = "messyandmagnetic.com"
 
 # === Cron triggers ===
 [triggers]
-crons = ["*/5 * * * *"]
+crons = ["*/5 * * * *", "0 7 * * *"]
 
 # === Cloudflare Pages (UI app) ===
 [pages]


### PR DESCRIPTION
## Summary
- add centralized Telegram credential handling and reusable ping helpers for the worker
- update `/ping` and `/ping-debug` to send the required Telegram messages, capture API logs, and expose richer JSON payloads
- schedule a nightly cron run that reuses the ping routines and extend the Wrangler cron configuration for the worker domain

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9aa6c0b388327b48713e85994cdc5