### PR TITLE
Fix homepage trend typing and donor validation

### DIFF
--- a/worker/routes/donors.ts
+++ b/worker/routes/donors.ts
@@ -1,8 +1,38 @@
+import type { DonationInput } from '../../src/donors/notion';
+
 function json(data: any, status = 200) {
   return new Response(JSON.stringify(data, null, 2), {
     status,
     headers: { 'content-type': 'application/json' },
   });
+}
+
+function parseDonationInput(raw: unknown): DonationInput | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const value = raw as Record<string, unknown>;
+
+  const name = typeof value.name === 'string' ? value.name.trim() : '';
+  const email = typeof value.email === 'string' ? value.email.trim() : '';
+  const intent = typeof value.intent === 'string' ? value.intent.trim() : '';
+
+  const amountValue = value.amount;
+  const amount =
+    typeof amountValue === 'number'
+      ? amountValue
+      : typeof amountValue === 'string' && amountValue.trim() !== ''
+        ? Number(amountValue)
+        : NaN;
+
+  if (!name || !email || !intent || !Number.isFinite(amount)) {
+    return null;
+  }
+
+  return {
+    name,
+    email,
+    amount,
+    intent,
+  } satisfies DonationInput;
 }
 
 export async function onRequestGet({ env, request }: { env: any; request: Request }) {
@@ -25,10 +55,14 @@ export async function onRequestPost({ env, request }: { env: any; request: Reque
     return json({ ok: false, error: 'unauthorized' }, 401);
   }
   const body = await request.json().catch(() => ({}));
+  const input = parseDonationInput(body);
+  if (!input) {
+    return json({ ok: false, error: 'invalid-input' }, 400);
+  }
   try {
     // @ts-ignore - donation helpers are sourced from shared application code
     const { recordDonation } = await import('../../src/' + 'donors/notion');
-    await recordDonation(body, env);
+    await recordDonation(input, env);
     return json({ ok: true });
   } catch (e: any) {
     return json({ ok: false, error: e.message }, 500);


### PR DESCRIPTION
## Summary
- add a typed `TrendEntry` helper for scheduler snapshots so homepage consumers only see fully-initialized trend records
- normalize donor submissions with runtime validation before invoking the Notion writer

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc450dfd5883278f7aaa9355870f4e