### PR TITLE
fix: add root route handler for homepage

### DIFF
--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -417,6 +417,13 @@ export default {
   // ---------------- HTTP entry ----------------
   async fetch(req: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(req.url);
+
+    if (url.pathname === "/") {
+      return new Response("✅ Maggie is Live — Home route working!", {
+        headers: { "content-type": "text/plain" },
+      });
+    }
+
     try {
       await bootstrapWorker(env, req, ctx);
       const siteResponse = await serveStaticSite(req, env);


### PR DESCRIPTION
## Summary
- short-circuit the worker fetch handler when the root path is requested
- return a plain text success message for requests to /

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc4c42781c832785b379b15ab76096