### PR TITLE
Fix donor route payload validation and response shape

### DIFF
--- a/worker/routes/donors.ts
+++ b/worker/routes/donors.ts
@@ -42,7 +42,7 @@ export async function onRequestGet({ env, request }: { env: any; request: Reques
     // @ts-ignore - donation helpers are sourced from shared application code
     const { listRecentDonations } = await import('../../src/' + 'donors/notion');
     const list = await listRecentDonations(10, env);
-    return json(list);
+    return json({ ok: true, donors: list });
   } catch (e: any) {
     return json({ ok: false, error: e.message }, 500);
   }
@@ -54,9 +54,9 @@ export async function onRequestPost({ env, request }: { env: any; request: Reque
   if (request.headers.get('x-api-key') !== env.POST_THREAD_SECRET) {
     return json({ ok: false, error: 'unauthorized' }, 401);
   }
-  const body = await request.json().catch(() => ({}));
+  const body: unknown = await request.json().catch(() => ({}));
   const input = parseDonationInput(body);
-  if (!input) {
+  if (input === null) {
     return json({ ok: false, error: 'invalid-input' }, 400);
   }
   try {


### PR DESCRIPTION
## Summary
- ensure the `/donors/recent` handler returns the `{ ok: true, donors: [...] }` shape expected by the frontend
- validate the donor submission payload before recording to satisfy the `DonationInput` type

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc7200a7c4832787ea45091f820255