### PR TITLE
Fix donor wall fetch handling

### DIFF
--- a/ui/src/components/DonorWall.tsx
+++ b/ui/src/components/DonorWall.tsx
@@ -5,7 +5,16 @@ interface Donation { name: string; amount: number; intent: string; createdAt: st
 export default function DonorWall() {
   const [list, setList] = useState<Donation[]>([]);
   useEffect(() => {
-    fetch('/donors/recent').then((r) => r.json()).then(setList).catch(() => {});
+    fetch('/donors/recent')
+      .then((r) => r.json())
+      .then((res) => {
+        if (Array.isArray(res)) {
+          setList(res);
+        } else if (Array.isArray(res?.donors)) {
+          setList(res.donors);
+        }
+      })
+      .catch(() => {});
   }, []);
   return (
     <div className="space-y-2">


### PR DESCRIPTION
## Summary
- update the DonorWall component to handle the updated /donors/recent response format
- default to the donors array when present to avoid runtime errors

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68dc73acf5808327bcf3a5811c4ec860