### PR TITLE
fix: guard donor list rendering with Array.isArray to prevent crash

### DIFF
--- a/ui/src/components/DonorWall.tsx
+++ b/ui/src/components/DonorWall.tsx
@@ -7,7 +7,13 @@ export default function DonorWall() {
   useEffect(() => {
     fetch('/donors/recent')
       .then((r) => r.json())
-      .then((res) => setList(res.donors))
+      .then((res) => {
+        if (Array.isArray(res.donors)) {
+          setList(res.donors);
+        } else {
+          console.warn('Invalid donor list:', res);
+        }
+      })
       .catch(() => {});
   }, []);
   return (


### PR DESCRIPTION
## Summary
- guard donor list update in DonorWall so only arrays are rendered
- log a warning when the donor API response is malformed instead of crashing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd708bf9888327a9e7f5b98b55c5b8