### PR TITLE
feat: auto-notify telegram of deploy status

### DIFF
--- a/.github/workflows/notify-deploy-status.yml
+++ b/.github/workflows/notify-deploy-status.yml
@@ -1,0 +1,29 @@
+name: Notify Deploy Status
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 */6 * * *"  # every 6 hours
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node + Corepack
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+        env:
+          COREPACK_ENABLE_STRICT: '0'
+      - run: corepack enable && corepack prepare pnpm@latest --activate
+      - name: Install deps
+        run: pnpm install
+      - name: Run deploy notifier
+        run: pnpm tsx worker/scripts/checkDeployAndNotify.ts
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          TELEGRAM_CHAT_ID: ${{ secrets.TELEGRAM_CHAT_ID }}
+          TELEGRAM_BOT_TOKEN: ${{ secrets.TELEGRAM_BOT_TOKEN }}

--- a/worker/scripts/checkDeployAndNotify.ts
+++ b/worker/scripts/checkDeployAndNotify.ts
@@ -1,0 +1,67 @@
+const CLOUDFLARE_ACCOUNT_ID = process.env.CLOUDFLARE_ACCOUNT_ID!;
+const CLOUDFLARE_API_TOKEN = process.env.CLOUDFLARE_API_TOKEN!;
+const TELEGRAM_CHAT_ID = process.env.TELEGRAM_CHAT_ID!;
+const TELEGRAM_BOT_TOKEN = process.env.TELEGRAM_BOT_TOKEN!;
+const PROJECT_NAME = 'messyandmagnetic';
+const CLOUDFLARE_API = `https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/pages/projects/${PROJECT_NAME}/deployments`;
+
+async function checkDeployAndNotify() {
+  try {
+    const response = await fetch(CLOUDFLARE_API, {
+      headers: {
+        Authorization: `Bearer ${CLOUDFLARE_API_TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to fetch deployments: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+    const latest = data.result?.[0];
+
+    if (!latest) throw new Error('No deployments found.');
+
+    const status = latest?.latest_stage?.status || 'unknown';
+    const url = latest?.url;
+    const commitMessage = latest?.deployment_trigger?.metadata?.commit_message || 'Unknown commit';
+    const failureReason = latest?.latest_stage?.reason || latest?.fail_reason || 'No reason provided';
+
+    let message = '';
+
+    if (status === 'success') {
+      message = `✅ Website deployed successfully: ${url}`;
+    } else if (status === 'failed') {
+      message = `🚨 Deploy failed for messyandmagnetic.com\n\nReason: ${failureReason}\nCommit: ${commitMessage}`;
+    } else {
+      message = `⚠️ Deploy status: ${status}\nCheck: ${url}`;
+    }
+
+    await sendTelegramMessage(message);
+  } catch (err: any) {
+    console.error('Error checking deploy:', err.message);
+    await sendTelegramMessage(`⚠️ Error checking website deploy: ${err.message}`);
+  }
+}
+
+async function sendTelegramMessage(text: string) {
+  const telegramUrl = `https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage`;
+  const body = {
+    chat_id: TELEGRAM_CHAT_ID,
+    text,
+    parse_mode: 'Markdown',
+  };
+
+  const res = await fetch(telegramUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+  if (!res.ok) {
+    console.error('Failed to send Telegram message:', await res.text());
+  }
+}
+
+checkDeployAndNotify();


### PR DESCRIPTION
## Summary
- add a script to check the latest Cloudflare Pages deployment and send Telegram notifications
- wire up a scheduled and push-triggered GitHub Action to run the deploy notifier

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ddc43659cc8327862fbf5e22b1a4d4