### PR TITLE
Add webhook handlers for Tally and Stripe orders

### DIFF
--- a/app/api/webhook/stripe/route.ts
+++ b/app/api/webhook/stripe/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from 'next/server';
+import Stripe from 'stripe';
+
+import { logErrorToSheet } from '../../../../lib/maggieLogs';
+import { updateWebhookStatus } from '../../../../lib/statusStore';
+import { runOrder } from '../../../../src/fulfillment/runner';
+
+export const runtime = 'nodejs';
+
+export async function POST(req: NextRequest) {
+  const startedAt = new Date().toISOString();
+  const secret = process.env.STRIPE_WEBHOOK_SECRET;
+  const apiKey = process.env.STRIPE_SECRET_KEY;
+  if (!secret || !apiKey) {
+    await updateWebhookStatus('stripe', {
+      lastFailureAt: startedAt,
+      error: 'missing stripe configuration',
+    });
+    return NextResponse.json({ ok: false, error: 'missing stripe configuration' }, { status: 500 });
+  }
+
+  const payload = await req.text();
+  const signature = req.headers.get('stripe-signature') || '';
+  const stripe = new Stripe(apiKey, { apiVersion: '2023-10-16' });
+
+  let event: Stripe.Event;
+  try {
+    event = stripe.webhooks.constructEvent(payload, signature, secret);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await Promise.all([
+      logErrorToSheet({ module: 'StripeWebhook', error: message, timestamp: startedAt }),
+      updateWebhookStatus('stripe', {
+        lastFailureAt: startedAt,
+        error: `signature: ${message}`,
+      }),
+    ]);
+    return new NextResponse('invalid signature', { status: 400 });
+  }
+
+  if (event.type !== 'checkout.session.completed') {
+    return NextResponse.json({ ok: true, ignored: event.type });
+  }
+
+  const session = event.data.object as Stripe.Checkout.Session;
+  if (!session?.id) {
+    await updateWebhookStatus('stripe', {
+      lastFailureAt: startedAt,
+      error: 'missing session id',
+    });
+    return NextResponse.json({ ok: false, error: 'missing session id' }, { status: 400 });
+  }
+
+  try {
+    await runOrder({ kind: 'stripe-session', sessionId: session.id });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await Promise.all([
+      logErrorToSheet({ module: 'StripeWebhook', error: err, timestamp: startedAt }),
+      updateWebhookStatus('stripe', {
+        lastFailureAt: startedAt,
+        error: message,
+      }),
+    ]);
+    return NextResponse.json({ ok: false, error: 'fulfillment failed' }, { status: 500 });
+  }
+
+  await updateWebhookStatus('stripe', {
+    lastSuccessAt: new Date().toISOString(),
+    error: null,
+  });
+
+  return NextResponse.json({ ok: true, sessionId: session.id });
+}

--- a/app/api/webhook/tally/route.ts
+++ b/app/api/webhook/tally/route.ts
@@ -1,0 +1,177 @@
+import crypto from 'crypto';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { appendRows } from '../../../../lib/google';
+import { logErrorToSheet } from '../../../../lib/maggieLogs';
+import { updateWebhookStatus } from '../../../../lib/statusStore';
+import { normalizeFromTally } from '../../../../src/fulfillment/intake';
+import { runOrder } from '../../../../src/fulfillment/runner';
+
+export const runtime = 'nodejs';
+
+function parseSignatureHeader(header: string | null): { timestamp: string; signature: string } | null {
+  if (!header) return null;
+  let timestamp = '';
+  let signature = '';
+  for (const part of header.split(',')) {
+    const [key, value] = part.split('=');
+    if (key === 't') timestamp = value || '';
+    if (key === 'v1') signature = value || '';
+  }
+  if (!timestamp || !signature) return null;
+  return { timestamp, signature };
+}
+
+function verifyTallySignature(raw: string, header: string | null, secret: string): boolean {
+  const parsed = parseSignatureHeader(header);
+  if (!parsed) return false;
+  const hmac = crypto.createHmac('sha256', secret);
+  hmac.update(`${parsed.timestamp}.${raw}`);
+  const digest = hmac.digest('hex');
+  const received = Buffer.from(parsed.signature, 'hex');
+  const expected = Buffer.from(digest, 'hex');
+  if (received.length !== expected.length) return false;
+  return crypto.timingSafeEqual(received, expected);
+}
+
+async function forwardToAppsScript(raw: string, req: NextRequest): Promise<boolean> {
+  const url = process.env.GAS_INTAKE_URL;
+  if (!url) return false;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'content-type': req.headers.get('content-type') || 'application/json',
+        'x-maggie-forwarded': 'tally',
+      },
+      body: raw,
+    });
+    return res.ok;
+  } catch (err) {
+    console.warn('[webhook.tally] failed to forward to Apps Script:', err);
+    return false;
+  }
+}
+
+function pick(...values: Array<string | undefined | null>): string {
+  for (const value of values) {
+    if (value !== undefined && value !== null && value !== '') {
+      return value;
+    }
+  }
+  return '';
+}
+
+async function logToSheets(body: any): Promise<boolean> {
+  const sheetId =
+    process.env.TALLY_RESPONSE_SHEET_ID ||
+    process.env.MAGGIE_LOG_SHEET_ID ||
+    process.env.GOOGLE_SHEET_ID;
+  if (!sheetId) return false;
+  const data: Record<string, any> = body?.data || body || {};
+  const row = [
+    new Date().toISOString(),
+    body?.formId || body?.form_id || '',
+    body?.submissionId || body?.submission_id || '',
+    data.email || '',
+    pick(data.name, `${data.first_name || ''} ${data.last_name || ''}`.trim()),
+    pick(data.tier, data.package, data.selection, data.product_choice, data.productId),
+    pick(data.birthdate, data.birth_date, data.dob),
+    pick(data.birthtime, data.birth_time),
+    pick(data.birthplace, data.birth_place, data.location),
+    JSON.stringify(data),
+  ];
+  try {
+    await appendRows(sheetId, "'TallyResponses'!A:J", [row]);
+    return true;
+  } catch (err) {
+    console.warn('[webhook.tally] failed to append to sheet:', err);
+    return false;
+  }
+}
+
+function hasSoulData(intake: Awaited<ReturnType<typeof normalizeFromTally>>): boolean {
+  const birth = intake.customer?.birth || {};
+  return Boolean(intake.tier && birth.date);
+}
+
+export async function POST(req: NextRequest) {
+  const startedAt = new Date().toISOString();
+  const secret = process.env.TALLY_SIGNING_SECRET || process.env.TALLY_WEBHOOK_SECRET;
+  const raw = await req.text();
+
+  if (secret) {
+    const ok = verifyTallySignature(raw, req.headers.get('tally-signature'), secret);
+    if (!ok) {
+      await updateWebhookStatus('tally', {
+        lastFailureAt: startedAt,
+        error: 'invalid signature',
+      });
+      return new NextResponse('invalid signature', { status: 401 });
+    }
+  }
+
+  let body: any;
+  try {
+    body = raw ? JSON.parse(raw) : {};
+  } catch (err) {
+    await updateWebhookStatus('tally', {
+      lastFailureAt: startedAt,
+      error: 'invalid json',
+    });
+    return NextResponse.json({ ok: false, error: 'invalid json' }, { status: 400 });
+  }
+
+  const [forwarded, logged] = await Promise.all([
+    forwardToAppsScript(raw, req),
+    logToSheets(body),
+  ]);
+
+  let normalized;
+  try {
+    normalized = await normalizeFromTally(body);
+  } catch (err) {
+    await Promise.all([
+      logErrorToSheet({ module: 'TallyWebhook', error: err, timestamp: startedAt }),
+      updateWebhookStatus('tally', {
+        lastFailureAt: startedAt,
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    ]);
+    return NextResponse.json({ ok: false, error: 'normalization failed' }, { status: 500 });
+  }
+
+  let readingTriggered = false;
+  let readingSkippedReason: string | undefined;
+
+  if (hasSoulData(normalized)) {
+    try {
+      await runOrder({ kind: 'intake', intake: normalized });
+      readingTriggered = true;
+    } catch (err) {
+      await Promise.all([
+        logErrorToSheet({ module: 'TallyWebhook', error: err, timestamp: startedAt }),
+        updateWebhookStatus('tally', {
+          lastFailureAt: startedAt,
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      ]);
+      return NextResponse.json({ ok: false, error: 'fulfillment failed' }, { status: 500 });
+    }
+  } else {
+    readingSkippedReason = 'missing soul data';
+  }
+
+  await updateWebhookStatus('tally', {
+    lastSuccessAt: new Date().toISOString(),
+    error: null,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    forwarded,
+    logged,
+    readingTriggered,
+    readingSkippedReason,
+  });
+}

--- a/lib/gmail.ts
+++ b/lib/gmail.ts
@@ -2,25 +2,63 @@ import { google } from 'googleapis';
 import { requireEnv } from './env.js';
 import { fetchGoogleKey } from './google-key.js';
 
+interface GmailPayload {
+  to: string;
+  subject: string;
+  text?: string;
+  html?: string;
+}
+
 async function getAuth() {
   const client_email = requireEnv('GOOGLE_CLIENT_EMAIL');
   const private_key = (await fetchGoogleKey()).replace(/\\n/g, '\n');
   return new google.auth.JWT(client_email, undefined, private_key, [
-    'https://www.googleapis.com/auth/gmail.send'
+    'https://www.googleapis.com/auth/gmail.send',
   ]);
 }
 
-export async function sendEmail({ to, subject, text }: { to: string; subject: string; text: string }) {
+function buildMimeMessage({ to, subject, text, html }: GmailPayload): string {
+  const safeText = text ?? '';
+  const safeHtml = html ?? '';
+  const hasHtml = Boolean(html);
+
+  if (!hasHtml) {
+    return [
+      `To: ${to}`,
+      'Content-Type: text/plain; charset=utf-8',
+      'MIME-Version: 1.0',
+      `Subject: ${subject}`,
+      '',
+      safeText,
+    ].join('\n');
+  }
+
+  const boundary = 'mixed-boundary';
+  return [
+    `To: ${to}`,
+    `Subject: ${subject}`,
+    'MIME-Version: 1.0',
+    `Content-Type: multipart/alternative; boundary="${boundary}"`,
+    '',
+    `--${boundary}`,
+    'Content-Type: text/plain; charset="utf-8"',
+    '',
+    safeText,
+    '',
+    `--${boundary}`,
+    'Content-Type: text/html; charset="utf-8"',
+    '',
+    safeHtml,
+    '',
+    `--${boundary}--`,
+    '',
+  ].join('\n');
+}
+
+export async function sendEmail(payload: GmailPayload) {
   const auth = await getAuth();
   const gmail = google.gmail({ version: 'v1', auth });
-  const message = [
-    `To: ${to}`,
-    'Content-Type: text/plain; charset=utf-8',
-    'MIME-Version: 1.0',
-    `Subject: ${subject}`,
-    '',
-    text,
-  ].join('\n');
+  const message = buildMimeMessage(payload);
   const encodedMessage = Buffer.from(message)
     .toString('base64')
     .replace(/\+/g, '-')


### PR DESCRIPTION
## Summary
- add `/api/webhook/tally` handler that verifies Tally signatures, logs to Sheets, forwards to Apps Script, and triggers the fulfillment pipeline when soul data is present
- add `/api/webhook/stripe` handler that listens for `checkout.session.completed` events and runs the fulfillment workflow
- enhance Gmail delivery helper and fulfillment sender to prefer Gmail (with HTML support) before falling back to Resend

## Testing
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e0077c8988832797242d41467861ca