### PR TITLE
Add router-based worker root and test endpoints

### DIFF
--- a/worker/index.ts
+++ b/worker/index.ts
@@ -10,11 +10,14 @@ import {
 } from './scheduler';
 import { maybeSendDailySummary } from './summary';
 import { buildDeploymentMessage, getWorkerRoutes, getWorkerVersion } from './lib/reporting';
+import { ensureCoreRouterRoutes } from './router';
 // @ts-ignore - worker bundles runtime helper from shared source
 import { getSendTelegram } from './lib/telegramBridge';
 
 const BOOT_WARMUP_LABEL = 'bootWarmupAt';
 const DEPLOY_PING_LABEL = 'lastDeployPing';
+
+ensureCoreRouterRoutes();
 
 async function markBoot(env: Env): Promise<void> {
   const state = await loadState(env);

--- a/worker/lib/reporting.ts
+++ b/worker/lib/reporting.ts
@@ -1,5 +1,6 @@
 import type { Env } from './env';
 import { loadState } from './state';
+import { listRouterPaths } from '../router';
 
 export const CORE_WORKER_ROUTES = [
   '/ping',
@@ -47,7 +48,9 @@ function resolveKvNamespace(env: Env): KvNamespaceLike | undefined {
 }
 
 export function getWorkerRoutes(): string[] {
-  return [...CORE_WORKER_ROUTES];
+  const routerRoutes = listRouterPaths();
+  const unique = new Set<string>([...CORE_WORKER_ROUTES, ...routerRoutes]);
+  return Array.from(unique);
 }
 
 export function getWorkerVersion(env: Env): string | null {

--- a/worker/router.ts
+++ b/worker/router.ts
@@ -1,0 +1,77 @@
+import type { Env } from './lib/env';
+
+type RouteHandler = (req: Request, env: Env, ctx: ExecutionContext) => Promise<Response> | Response;
+
+type RouteKey = `${Uppercase<string>}:${string}`;
+
+type Route = {
+  method: Uppercase<string>;
+  path: string;
+  handler: RouteHandler;
+};
+
+const routes: Route[] = [];
+const routeIndex = new Map<RouteKey, Route>();
+let coreRoutesRegistered = false;
+
+function makeKey(method: string, path: string): RouteKey {
+  return `${method.toUpperCase() as Uppercase<string>}:${path}`;
+}
+
+export function registerRoute(method: string, path: string, handler: RouteHandler): void {
+  const key = makeKey(method, path);
+  if (routeIndex.has(key)) return;
+
+  const route: Route = {
+    method: method.toUpperCase() as Uppercase<string>,
+    path,
+    handler,
+  };
+
+  routes.push(route);
+  routeIndex.set(key, route);
+}
+
+export function ensureCoreRouterRoutes(): void {
+  if (coreRoutesRegistered) return;
+
+  registerRoute('GET', '/', () =>
+    new Response('Maggie is online! 🌸 Welcome to Messy & Magnetic.', {
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+    }),
+  );
+
+  registerRoute('GET', '/test-telegram', () =>
+    new Response('Telegram test passed.', {
+      headers: { 'content-type': 'text/plain; charset=utf-8' },
+    }),
+  );
+
+  coreRoutesRegistered = true;
+}
+
+export async function handleRouter(
+  req: Request,
+  env: Env,
+  ctx: ExecutionContext,
+): Promise<Response | null> {
+  ensureCoreRouterRoutes();
+
+  const { pathname } = new URL(req.url);
+  const method = req.method.toUpperCase();
+  const key = makeKey(method, pathname);
+  const match = routeIndex.get(key);
+
+  if (!match) return null;
+
+  return await match.handler(req, env, ctx);
+}
+
+export function listRouterPaths(): string[] {
+  ensureCoreRouterRoutes();
+  const seen = new Set<string>();
+  for (const route of routes) {
+    if (!seen.has(route.path)) seen.add(route.path);
+  }
+  return Array.from(seen);
+}

--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -21,6 +21,7 @@ import {
   type DailyMetrics,
 } from './lib/reporting';
 import { getSendTelegram, type SendTelegramResult as TelegramHelperResult } from './lib/telegramBridge';
+import { handleRouter } from './router';
 // ---------------- CORS helpers ----------------
 const CORS_BASE: Record<string, string> = {
   "Access-Control-Allow-Origin": "*",
@@ -418,87 +419,12 @@ export default {
   async fetch(req: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url = new URL(req.url);
 
-    if (url.pathname === "/") {
-      const homepageHtml = `<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Messy &amp; Magnetic</title>
-    <style>
-      :root {
-        color-scheme: only light;
-        font-family: 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-        background: #fdf7ff;
-        color: #3b2f4a;
-      }
-      body {
-        margin: 0;
-        min-height: 100vh;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        background: linear-gradient(135deg, #fdf7ff, #f5fbff);
-      }
-      main {
-        padding: 3rem clamp(1.5rem, 5vw, 4rem);
-        border-radius: 24px;
-        background: rgba(255, 255, 255, 0.85);
-        box-shadow: 0 18px 45px rgba(59, 47, 74, 0.12);
-        max-width: 520px;
-        text-align: center;
-      }
-      h1 {
-        margin: 0 0 1rem;
-        font-size: clamp(2rem, 5vw, 2.75rem);
-        color: #6d46b8;
-      }
-      p {
-        margin: 0 0 2rem;
-        line-height: 1.6;
-        color: #56466f;
-      }
-      nav {
-        display: flex;
-        flex-direction: column;
-        gap: 0.75rem;
-      }
-      a {
-        text-decoration: none;
-        padding: 0.75rem 1rem;
-        border-radius: 999px;
-        background: #e6ddff;
-        color: #3b2f4a;
-        font-weight: 600;
-        transition: transform 160ms ease, box-shadow 160ms ease;
-      }
-      a:hover,
-      a:focus {
-        transform: translateY(-2px);
-        box-shadow: 0 10px 18px rgba(109, 70, 184, 0.18);
-      }
-    </style>
-  </head>
-  <body>
-    <main>
-      <h1>Messy &amp; Magnetic</h1>
-      <p>Welcome in! The full experience is arriving soon. For now, explore a few highlights while we finish weaving the magic.</p>
-      <nav>
-        <a href="/soul-blueprint">Explore the Soul Blueprint</a>
-        <a href="/donate">Support &amp; Donate</a>
-        <a href="/quiz">Take the Quiz</a>
-      </nav>
-    </main>
-  </body>
-</html>`;
-
-      return new Response(homepageHtml, {
-        headers: { "content-type": "text/html; charset=utf-8" },
-      });
-    }
-
     try {
       await bootstrapWorker(env, req, ctx);
+      const routerResponse = await handleRouter(req, env, ctx);
+      if (routerResponse) {
+        return routerResponse;
+      }
       const siteResponse = await serveStaticSite(req, env);
       if (siteResponse) {
         return siteResponse;


### PR DESCRIPTION
## Summary
- add a minimal router for the worker with GET `/` and `/test-telegram` responses
- register the router during worker bootstrap and expose routes through reporting metadata
- route worker fetch requests through the router before static site handling

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68e0586aad1883278dc650840ac0f460