### PR TITLE
feat(worker): add router bootstrap and telegram test route

### DIFF
--- a/worker/lib/reporting.ts
+++ b/worker/lib/reporting.ts
@@ -1,5 +1,6 @@
 import type { Env } from './env';
 import { loadState } from './state';
+import { getRouterRegisteredPaths } from '../router/router';
 
 export const CORE_WORKER_ROUTES = [
   '/ping',
@@ -47,7 +48,12 @@ function resolveKvNamespace(env: Env): KvNamespaceLike | undefined {
 }
 
 export function getWorkerRoutes(): string[] {
-  return [...CORE_WORKER_ROUTES];
+  const unique = new Set<string>(CORE_WORKER_ROUTES);
+  for (const path of getRouterRegisteredPaths()) {
+    unique.add(path);
+  }
+
+  return Array.from(unique);
 }
 
 export function getWorkerVersion(env: Env): string | null {

--- a/worker/router/router.ts
+++ b/worker/router/router.ts
@@ -1,0 +1,109 @@
+import type { Env } from '../lib/env';
+
+export type RouteHandler = (
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext
+) => Response | Promise<Response>;
+
+export type RouteStage = 'pre' | 'post';
+
+interface RouteRecord {
+  method: string;
+  path: string;
+  handler: RouteHandler;
+  stage: RouteStage;
+}
+
+const registeredRoutes: RouteRecord[] = [];
+const routePathSet = new Set<string>();
+
+function normalizeMethod(method: string): string {
+  return method.toUpperCase();
+}
+
+function registerRoute(
+  method: string,
+  path: string,
+  handler: RouteHandler,
+  stage: RouteStage
+): void {
+  registeredRoutes.push({ method: normalizeMethod(method), path, handler, stage });
+  routePathSet.add(path);
+}
+
+function matchesRoute(record: RouteRecord, request: Request, url: URL): boolean {
+  const method = request.method.toUpperCase();
+
+  if (record.method !== 'ALL' && method !== record.method) {
+    if (!(record.method === 'GET' && method === 'HEAD')) {
+      return false;
+    }
+  }
+
+  return url.pathname === record.path;
+}
+
+async function handleStage(
+  stage: RouteStage,
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext
+): Promise<Response | null> {
+  const url = new URL(request.url);
+  for (const record of registeredRoutes) {
+    if (record.stage !== stage) continue;
+    if (!matchesRoute(record, request, url)) continue;
+
+    return await record.handler(request, env, ctx);
+  }
+
+  return null;
+}
+
+export const router = {
+  get(
+    path: string,
+    handler: RouteHandler,
+    options?: { stage?: RouteStage }
+  ): void {
+    registerRoute('GET', path, handler, options?.stage ?? 'post');
+  },
+  post(
+    path: string,
+    handler: RouteHandler,
+    options?: { stage?: RouteStage }
+  ): void {
+    registerRoute('POST', path, handler, options?.stage ?? 'post');
+  },
+  all(
+    path: string,
+    handler: RouteHandler,
+    options?: { stage?: RouteStage }
+  ): void {
+    registerRoute('ALL', path, handler, options?.stage ?? 'post');
+  },
+  async handlePreBootstrap(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext
+  ): Promise<Response | null> {
+    return handleStage('pre', request, env, ctx);
+  },
+  async handlePostBootstrap(
+    request: Request,
+    env: Env,
+    ctx: ExecutionContext
+  ): Promise<Response | null> {
+    return handleStage('post', request, env, ctx);
+  },
+  getRegisteredPaths(): string[] {
+    return Array.from(routePathSet);
+  },
+};
+
+export type WorkerRouter = typeof router;
+
+export function getRouterRegisteredPaths(): string[] {
+  return router.getRegisteredPaths();
+}


### PR DESCRIPTION
## Summary
- add a lightweight worker router to track pre/post bootstrap routes and surface them to health reporting
- register the `/` welcome handler and a new `/test-telegram` diagnostics endpoint through the router while preserving existing logic
- include router-registered paths when computing the worker route list for telemetry

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e068fc3ab0832787b46862d5f843c0