### PR TITLE
Protect /test-telegram with admin auth

### DIFF
--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -378,7 +378,13 @@ router.get(
   { stage: 'pre' }
 );
 
-router.get('/test-telegram', async (_req, env) => {
+router.get('/test-telegram', async (req, env) => {
+  const unauthorized = requireAdminAuthorization(req, env);
+  if (unauthorized) {
+    console.error('[worker:/test-telegram] unauthorized access attempt');
+    return unauthorized;
+  }
+
   const { status, payload } = await performPing(env, 'route:/test-telegram', {
     path: '/test-telegram',
     message: 'Manual Telegram test triggered via /test-telegram',


### PR DESCRIPTION
## Summary
- require admin bearer authentication on the /test-telegram route before sending Telegram pings
- log unauthorized access attempts to the Telegram test endpoint

## Testing
- npm run deploy:public *(fails: OAuth login required in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e11fd2b42c8327a111fe059fd336c6