### PR TITLE
Update Cloudflare API token fallback

### DIFF
--- a/utils/loadSecretsFromBlob.ts
+++ b/utils/loadSecretsFromBlob.ts
@@ -4,7 +4,7 @@ import { Buffer } from 'buffer';
 // Optional: Cloudflare fallback values
 const CLOUDFLARE_ACCOUNT_ID = '5ff52dc210a86ff34a0dd3664bacb237';
 const CLOUDFLARE_NAMESPACE_ID = '1b8cbbc4a2f8426194368cb39baded79';
-const CLOUDFLARE_API_TOKEN = process.env.CLOUDFLARE_API_TOKEN || 'vMfaaWOMCYy6KHiaH-xy_vkTDxOaSpiznS0aSR0I';
+const CLOUDFLARE_API_TOKEN = process.env.CLOUDFLARE_API_TOKEN || 'VN6bJbdN5WWlKWtnF50BGuTVdX8Twxx4WwJYtKqF';
 
 export async function loadSecretsFromBlob(): Promise<void> {
   let blob = process.env.SECRETS_BLOB;


### PR DESCRIPTION
## Summary
- update the fallback Cloudflare API token used when loading secrets from the KV blob

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e149a96030832785306431f94e24b1