### PR TITLE
Add config health check for PostQ thread state

### DIFF
--- a/worker/diag.ts
+++ b/worker/diag.ts
@@ -1,42 +1,51 @@
-import { presenceReport, Env } from './lib/env';
+import { Env } from './lib/env';
+
+const REQUIRED_KEYS = [
+  'STRIPE_API_KEY',
+  'STRIPE_WEBHOOK_SECRET',
+  'TIKTOK_SESSION_MAIN',
+  'TIKTOK_SESSION_WILLOW',
+  'TIKTOK_SESSION_MAGGIE',
+  'TIKTOK_PROFILE_MAIN',
+  'TALLY_FORM_ID',
+  'NOTION_API_KEY',
+  'TELEGRAM_TOKEN',
+  'BROWSERLESS_API_KEY',
+];
+
+function jsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data, null, 2), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
 
 export async function handleDiagConfig(env: Env): Promise<Response> {
   try {
-    const report = presenceReport(env);
-
-    let brainDocBytes: number | null = null;
-    let secretBlobBytes: number | null = null;
-
-    if (report.bindings.BRAIN) {
-      if (env.BRAIN_DOC_KEY) {
-        const v = await env.BRAIN.get(env.BRAIN_DOC_KEY);
-        brainDocBytes = v ? new TextEncoder().encode(v).length : 0;
-      }
-      if (env.SECRET_BLOB) {
-        const s = await env.BRAIN.get(env.SECRET_BLOB);
-        secretBlobBytes = s ? new TextEncoder().encode(s).length : 0;
-      }
+    if (!env.PostQ || typeof env.PostQ.get !== 'function') {
+      return jsonResponse({ status: '❌ PostQ KV namespace is not configured.' }, 500);
     }
 
-    return new Response(
-      JSON.stringify({
-        ...report,
-        ok: true,
-        kv: {
-          probed: report.bindings.BRAIN,
-          brainDocKey: env.BRAIN_DOC_KEY || null,
-          brainDocBytes,
-          secretBlobKey: env.SECRET_BLOB || null,
-          secretBlobBytes,
-        },
-      }),
-      { headers: { 'content-type': 'application/json' } },
-    );
+    const state = (await env.PostQ.get('thread-state', { type: 'json' })) as
+      | Record<string, unknown>
+      | null;
+
+    if (!state || typeof state !== 'object') {
+      return jsonResponse({ status: '❌ Unable to load PostQ:thread-state configuration.' }, 500);
+    }
+
+    const missing = REQUIRED_KEYS.filter((key) => {
+      const value = state[key];
+      return value === undefined || value === null || value === '';
+    });
+
+    if (missing.length > 0) {
+      return jsonResponse({ status: '❌ Missing keys', missing });
+    }
+
+    return jsonResponse({ status: '✅ All required config keys are present and valid.' });
   } catch (err: any) {
     console.error('[/diag/config] crash:', err?.stack || err);
-    return new Response(JSON.stringify({ ok: false, error: 'diag-failed' }), {
-      status: 500,
-      headers: { 'content-type': 'application/json' },
-    });
+    return jsonResponse({ status: '❌ diag-failed' }, 500);
   }
 }


### PR DESCRIPTION
## Summary
- replace the /diag/config handler with a PostQ config health check
- load the PostQ:thread-state document and confirm all required secrets are present
- return a human-friendly JSON summary of any missing keys

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1cd4bf21483278fa1f314c6ffb94d