### PR TITLE
feat: add config diagnostic route

### DIFF
--- a/routes/diag/config.ts
+++ b/routes/diag/config.ts
@@ -1,0 +1,6 @@
+import type { Env } from '../../worker/lib/env';
+import { handleDiagConfig } from '../../worker/diag';
+
+export async function onRequestGet({ env }: { env: Env }) {
+  return handleDiagConfig(env);
+}


### PR DESCRIPTION
## Summary
- add a diagnostic handler that reads the PostQ thread-state blob and verifies required secrets
- expose the handler via a Cloudflare route module for /diag/config requests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1cdfd17d08327a429df232cd826df