### PR TITLE
Relock debug routes after KV + Telegram test phase

### DIFF
--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -207,12 +207,18 @@ function extractSecretToken(req: Request): string | null {
   return null;
 }
 
+const publicDebugRoutes = ['/health', '/diag/config'];
+
 function checkSecret(req: Request, env: Env): SecretCheckResult {
   const method = req.method.toUpperCase();
   const clientIp = getClientIp(req);
   const nodeEnv = (env as Record<string, unknown>).NODE_ENV;
+  const pathname = new URL(req.url).pathname;
 
-  if (method === 'GET') {
+  if (
+    publicDebugRoutes.includes(pathname) &&
+    (method === 'GET' || method === 'HEAD')
+  ) {
     return { authorized: true, clientIp };
   }
 


### PR DESCRIPTION
## Summary
- restrict the worker admin check to allow public access only for `/health` and `/diag/config`
- ensure all other debug routes require the configured admin secret when no credential is provided

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e40913f2f48327ad348273a4be2ec6