### PR TITLE
fix: align brain routes to use thread-state KV key

### DIFF
--- a/scripts/telegramStatus.ts
+++ b/scripts/telegramStatus.ts
@@ -188,20 +188,18 @@ function findTelegramCredentials(payload: Record<string, unknown>): {
 }
 
 async function loadThreadState(): Promise<Record<string, unknown> | null> {
-  const keys = ['PostQ:thread-state', 'thread-state'];
-  for (const key of keys) {
-    try {
-      const raw = await getConfigValue<string>(key as string);
-      if (typeof raw === 'string' && raw.trim().length) {
-        try {
-          return JSON.parse(raw) as Record<string, unknown>;
-        } catch (err) {
-          console.warn(`[telegram-status] Unable to parse ${key} payload as JSON:`, err);
-        }
+  const key = 'PostQ:thread-state';
+  try {
+    const raw = await getConfigValue<string>(key as string);
+    if (typeof raw === 'string' && raw.trim().length) {
+      try {
+        return JSON.parse(raw) as Record<string, unknown>;
+      } catch (err) {
+        console.warn(`[telegram-status] Unable to parse ${key} payload as JSON:`, err);
       }
-    } catch (err) {
-      console.warn(`[telegram-status] Failed to fetch ${key} from KV:`, err);
     }
+  } catch (err) {
+    console.warn(`[telegram-status] Failed to fetch ${key} from KV:`, err);
   }
   return null;
 }

--- a/worker/brain.ts
+++ b/worker/brain.ts
@@ -1,9 +1,15 @@
 import type { Env } from './lib/env';
 
-const RECENT_EVENTS_KEY = 'brain:recent';
-const CODEX_TAGS_KEY = 'brain:codex-tags';
-const GEMINI_SYNC_KEY = 'brain:gemini-sync';
+const THREAD_STATE_KEY = 'thread-state';
 const MAX_RECENT_EVENTS = 25;
+
+type PlainObject = Record<string, unknown>;
+
+type ThreadStateBrainSection = {
+  recentUpdates: BrainUpdateEntry[];
+  codexTags: string[];
+  geminiSync: GeminiSyncState | null;
+};
 
 export type BrainUpdateInput = {
   summary: string;
@@ -28,6 +34,10 @@ function hasKv(env: Env): env is Env & { BRAIN: KVNamespace } {
   return !!env?.BRAIN && typeof env.BRAIN.get === 'function' && typeof env.BRAIN.put === 'function';
 }
 
+function isPlainObject(value: unknown): value is PlainObject {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
 function coerceBrainUpdates(value: unknown): BrainUpdateEntry[] {
   if (!Array.isArray(value)) return [];
   return value
@@ -38,6 +48,116 @@ function coerceBrainUpdates(value: unknown): BrainUpdateEntry[] {
       if (typeof item.id !== 'string') return false;
       return true;
     });
+}
+
+function coerceGeminiSyncState(value: unknown): GeminiSyncState | null {
+  if (!isPlainObject(value)) return null;
+  if (typeof value.ok !== 'boolean' || typeof value.timestamp !== 'string') {
+    return null;
+  }
+  const state: GeminiSyncState = {
+    ok: value.ok,
+    timestamp: value.timestamp,
+  };
+  if (typeof value.summary === 'string') state.summary = value.summary;
+  if (typeof value.error === 'string') state.error = value.error;
+  return state;
+}
+
+function coerceBrainSection(value: unknown): ThreadStateBrainSection {
+  const base: ThreadStateBrainSection = {
+    recentUpdates: [],
+    codexTags: [],
+    geminiSync: null,
+  };
+
+  if (!isPlainObject(value)) {
+    return base;
+  }
+
+  const updatesSource = (value.recentUpdates ?? value.recentEvents ?? value.events) as unknown;
+  const updates = coerceBrainUpdates(updatesSource);
+  if (updates.length) {
+    base.recentUpdates = updates;
+  }
+
+  const tagsSource = (value.codexTags ?? value.tags ?? value.tagList) as unknown;
+  if (Array.isArray(tagsSource)) {
+    base.codexTags = tagsSource
+      .map((tag) => (typeof tag === 'string' ? tag.trim() : ''))
+      .filter((tag) => !!tag);
+  }
+
+  const gemini = coerceGeminiSyncState(value.geminiSync ?? value.gemini ?? value.lastGeminiSync);
+  if (gemini) {
+    base.geminiSync = gemini;
+  }
+
+  return base;
+}
+
+function clonePlainObject<T extends PlainObject>(value: T | undefined): PlainObject {
+  return value ? { ...value } : {};
+}
+
+async function readThreadStateDocument(env: Env): Promise<PlainObject> {
+  const stored = await readJsonFromKv<PlainObject>(env, THREAD_STATE_KEY);
+  if (isPlainObject(stored)) {
+    return { ...stored };
+  }
+  if (stored !== null) {
+    console.warn('[brain] Thread-state payload was not a JSON object; resetting brain section.');
+  }
+  return {};
+}
+
+async function readBrainSection(env: Env): Promise<{
+  document: PlainObject;
+  section: ThreadStateBrainSection;
+  container: PlainObject;
+}> {
+  const document = await readThreadStateDocument(env);
+  const containerCandidate = document.brain;
+  const container = isPlainObject(containerCandidate)
+    ? { ...containerCandidate }
+    : {};
+  const source = Object.keys(container).length > 0 ? container : document;
+  const section = coerceBrainSection(source);
+  return { document, section, container };
+}
+
+function buildBrainContainer(
+  base: PlainObject,
+  section: ThreadStateBrainSection
+): PlainObject {
+  return {
+    ...base,
+    recentUpdates: section.recentUpdates,
+    codexTags: section.codexTags,
+    geminiSync: section.geminiSync,
+  };
+}
+
+async function writeBrainSection(
+  env: Env,
+  current: { document: PlainObject; container: PlainObject },
+  next: ThreadStateBrainSection
+): Promise<void> {
+  const { document, container } = current;
+  const nextDocument: PlainObject = { ...document };
+  const nextContainer = buildBrainContainer(clonePlainObject(container), next);
+  nextDocument.brain = nextContainer;
+  await writeJsonToKv(env, THREAD_STATE_KEY, nextDocument);
+}
+
+async function mutateBrainSection(
+  env: Env,
+  mutate: (section: ThreadStateBrainSection) => ThreadStateBrainSection
+): Promise<ThreadStateBrainSection> {
+  const snapshot = await readBrainSection(env);
+  const next = mutate(snapshot.section);
+  await writeBrainSection(env, snapshot, next);
+  return next;
 }
 
 async function readJsonFromKv<T>(env: Env, key: string): Promise<T | null> {
@@ -65,9 +185,9 @@ async function writeJsonToKv(env: Env, key: string, value: unknown): Promise<voi
 }
 
 export async function getRecentBrainUpdates(env: Env): Promise<BrainUpdateEntry[]> {
-  const stored = await readJsonFromKv<BrainUpdateEntry[]>(env, RECENT_EVENTS_KEY);
-  if (!stored) return [];
-  return coerceBrainUpdates(stored);
+  if (!hasKv(env)) return [];
+  const { section } = await readBrainSection(env);
+  return section.recentUpdates;
 }
 
 export async function recordBrainUpdate(env: Env, input: BrainUpdateInput): Promise<BrainUpdateEntry> {
@@ -89,38 +209,55 @@ export async function recordBrainUpdate(env: Env, input: BrainUpdateInput): Prom
     return entry;
   }
 
-  const existing = await getRecentBrainUpdates(env);
-  const next = [...existing, entry];
-  const trimmed = next.slice(-MAX_RECENT_EVENTS);
-  await writeJsonToKv(env, RECENT_EVENTS_KEY, trimmed);
+  await mutateBrainSection(env, (section) => {
+    const nextUpdates = [...section.recentUpdates, entry].slice(-MAX_RECENT_EVENTS);
+    return {
+      ...section,
+      recentUpdates: nextUpdates,
+    };
+  });
 
   return entry;
 }
 
 export async function appendToBrainRecent(env: Env, event: BrainUpdateEntry): Promise<void> {
   if (!hasKv(env)) return;
-  const existing = await getRecentBrainUpdates(env);
-  const next = [...existing, event].slice(-MAX_RECENT_EVENTS);
-  await writeJsonToKv(env, RECENT_EVENTS_KEY, next);
+  await mutateBrainSection(env, (section) => {
+    const nextUpdates = [...section.recentUpdates, event].slice(-MAX_RECENT_EVENTS);
+    return {
+      ...section,
+      recentUpdates: nextUpdates,
+    };
+  });
 }
 
 export async function storeCodexTags(env: Env, tags: string[]): Promise<void> {
+  if (!hasKv(env)) return;
   const normalized = Array.from(new Set(tags.map((tag) => String(tag).trim()).filter(Boolean)));
-  await writeJsonToKv(env, CODEX_TAGS_KEY, normalized);
+  await mutateBrainSection(env, (section) => ({
+    ...section,
+    codexTags: normalized,
+  }));
 }
 
 export async function getCodexTags(env: Env): Promise<string[]> {
-  const stored = await readJsonFromKv<string[]>(env, CODEX_TAGS_KEY);
-  if (!stored) return [];
-  return stored.filter((tag) => typeof tag === 'string' && tag.trim()).map((tag) => tag.trim());
+  if (!hasKv(env)) return [];
+  const { section } = await readBrainSection(env);
+  return section.codexTags;
 }
 
 export async function setGeminiSyncState(env: Env, state: GeminiSyncState): Promise<void> {
-  await writeJsonToKv(env, GEMINI_SYNC_KEY, state);
+  if (!hasKv(env)) return;
+  await mutateBrainSection(env, (section) => ({
+    ...section,
+    geminiSync: state,
+  }));
 }
 
 export async function getGeminiSyncState(env: Env): Promise<GeminiSyncState | null> {
-  return (await readJsonFromKv<GeminiSyncState>(env, GEMINI_SYNC_KEY)) ?? null;
+  if (!hasKv(env)) return null;
+  const { section } = await readBrainSection(env);
+  return section.geminiSync ?? null;
 }
 
 export async function getBrainStateSnapshot(


### PR DESCRIPTION
## Summary
- persist Maggie brain events, tags, and sync status inside the shared `thread-state` document
- preserve the brain section when other services write the thread-state blob
- restrict the Telegram status helper to read configuration only from the PostQ brain key

## Testing
- pnpm tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e441a921d08327acf694646bb13530