### PR TITLE
Resolve Codex and Gemini sync merge conflicts

### DIFF
--- a/worker/brain.ts
+++ b/worker/brain.ts
@@ -2,7 +2,8 @@ import type { Env } from './lib/env';
 
 const RECENT_EVENTS_KEY = 'brain:recent';
 const CODEX_TAGS_KEY = 'brain:codex-tags';
-const GEMINI_SYNC_KEY = 'brain:gemini-sync';
+const GEMINI_SYNC_STATE_KEY = 'brain:gemini-sync-state';
+const LEGACY_GEMINI_SYNC_KEY = 'brain:gemini-sync';
 const MAX_RECENT_EVENTS = 25;
 
 export type BrainUpdateInput = {
@@ -116,11 +117,18 @@ export async function getCodexTags(env: Env): Promise<string[]> {
 }
 
 export async function setGeminiSyncState(env: Env, state: GeminiSyncState): Promise<void> {
-  await writeJsonToKv(env, GEMINI_SYNC_KEY, state);
+  await writeJsonToKv(env, GEMINI_SYNC_STATE_KEY, state);
+  await writeJsonToKv(env, LEGACY_GEMINI_SYNC_KEY, state);
 }
 
 export async function getGeminiSyncState(env: Env): Promise<GeminiSyncState | null> {
-  return (await readJsonFromKv<GeminiSyncState>(env, GEMINI_SYNC_KEY)) ?? null;
+  const current = await readJsonFromKv<GeminiSyncState>(env, GEMINI_SYNC_STATE_KEY);
+  if (current) return current;
+
+  const legacy = await readJsonFromKv<GeminiSyncState>(env, LEGACY_GEMINI_SYNC_KEY);
+  if (legacy) return legacy;
+
+  return null;
 }
 
 export async function getBrainStateSnapshot(

--- a/worker/lib/env.ts
+++ b/worker/lib/env.ts
@@ -20,6 +20,11 @@ export type Env = {
   CODEX_AUTH_TOKEN?: string;
   CODEX_API_KEY?: string;
   CODEX_TOKEN?: string;
+  CODEX_SYNC_KEY?: string;
+  CODEX_SYNC_TOKEN?: string;
+  CODEX_LEARN_KEY?: string;
+  SYNC_KEY?: string;
+  LEARN_URL?: string;
   GEMINI_API_KEY?: string;
   GEMINI_MODEL?: string;
   GEMINI_API_BASE?: string;

--- a/worker/worker.ts
+++ b/worker/worker.ts
@@ -172,6 +172,7 @@ function getCodexSyncUrl(env: Env): string | null {
     firstNonEmptyString(
       env.CODEX_SYNC_URL,
       env.CODEX_LEARN_URL,
+      env.LEARN_URL,
       env.CODEX_ENDPOINT,
       (env as Record<string, unknown>).CODEX_API_URL,
     ) ?? null
@@ -179,7 +180,18 @@ function getCodexSyncUrl(env: Env): string | null {
 }
 
 function getCodexAuthToken(env: Env): string | null {
-  return firstNonEmptyString(env.CODEX_AUTH_TOKEN, env.CODEX_TOKEN, env.CODEX_API_KEY);
+  return (
+    firstNonEmptyString(
+      env.CODEX_AUTH_TOKEN,
+      env.CODEX_TOKEN,
+      env.CODEX_API_KEY,
+      env.CODEX_SYNC_KEY,
+      env.CODEX_SYNC_TOKEN,
+      env.CODEX_LEARN_KEY,
+      env.SYNC_KEY,
+      (env as Record<string, unknown>).SYNC_KEY,
+    ) ?? null
+  );
 }
 
 function coerceTagList(value: unknown): string[] {


### PR DESCRIPTION
## Summary
- update the brain KV constants so Gemini sync state uses the new key while retaining legacy compatibility
- expand the worker env bindings and Codex auth-token resolution to include the new sync and learn keys
- allow Codex sync URLs to fall back to the LEARN_URL binding to keep integrations working

## Testing
- pnpm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68e44283ab588327b947e96a460c1466