### PR TITLE
Resolve Codex/Gemini learning sync merge conflicts

### DIFF
--- a/worker/lib/env.ts
+++ b/worker/lib/env.ts
@@ -17,12 +17,14 @@ export type Env = {
   CODEX_SYNC_URL?: string;
   CODEX_ENDPOINT?: string;
   CODEX_LEARN_URL?: string;
+  CODEX_API_URL?: string;
   CODEX_AUTH_TOKEN?: string;
   CODEX_API_KEY?: string;
   CODEX_TOKEN?: string;
   GEMINI_API_KEY?: string;
   GEMINI_MODEL?: string;
   GEMINI_API_BASE?: string;
+  GEMINI_LEARN_URL?: string;
   [k: string]: unknown;
 };
 


### PR DESCRIPTION
## Summary
- expose brain KV constants and consolidate Codex/Gemini learn helpers
- update /brain/learn route to accept payload-wrapped summaries and use shared sync configs
- add missing Codex/Gemini environment keys to the worker Env typings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e47158fd74832790208a3c29012f8c