### PR TITLE
Ensure pnpm availability in sync brain workflow

### DIFF
--- a/.github/workflows/sync-brain.yml
+++ b/.github/workflows/sync-brain.yml
@@ -21,7 +21,131 @@ permissions:
 
 jobs:
   sync:
-    uses: ./.github/workflows/reusable-brain-sync.yml
-    secrets: inherit
-    with:
-      reason: ${{ inputs.reason || github.event.inputs.reason || '' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      EFFECTIVE_GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+      GH_PAT: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
+
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      CF_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CF_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+      KV_NAMESPACE_ID: ${{ secrets.KV_NAMESPACE_ID }}
+      CF_KV_POSTQ_NAMESPACE_ID: ${{ secrets.KV_NAMESPACE_ID }}
+      CF_KV_NAMESPACE_ID: ${{ secrets.KV_NAMESPACE_ID }}
+
+      SECRET_BLOB: thread-state
+      BRAIN_DOC_KEY: PostQ:thread-state
+
+    steps:
+      - name: Diagnostics
+        shell: bash
+        env:
+          GH_TOKEN: ${{ env.EFFECTIVE_GITHUB_TOKEN }}
+        run: |
+          echo "Actor: $GITHUB_ACTOR"
+          echo "Repository: $GITHUB_REPOSITORY"
+          gh auth status || true
+
+      - name: Log dispatch reason
+        env:
+          DISPATCH_REASON: ${{ inputs.reason || github.event.inputs.reason || '' }}
+          TRIGGER: ${{ github.event_name }}
+        run: |
+          if [ -n "$DISPATCH_REASON" ]; then
+            echo "Dispatch reason: $DISPATCH_REASON"
+          else
+            echo "Dispatch reason: (none provided; trigger=$TRIGGER)"
+          fi
+
+      - name: Check Cloudflare secrets
+        id: secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          for key in CLOUDFLARE_ACCOUNT_ID CLOUDFLARE_API_TOKEN KV_NAMESPACE_ID; do
+            if [ -z "${!key:-}" ]; then
+              missing+=("$key")
+            fi
+          done
+
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf 'missing=true\n' >> "$GITHUB_OUTPUT"
+            printf 'missing_list=%s\n' "${missing[*]}" >> "$GITHUB_OUTPUT"
+            echo "::warning::Brain sync skipped — missing secrets: ${missing[*]}"
+          else
+            printf 'missing=false\n' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Abort (missing secrets)
+        if: steps.secrets.outputs.missing == 'true'
+        run: |
+          echo "Skipping brain sync because required Cloudflare secrets are missing: ${{ steps.secrets.outputs.missing_list }}"
+
+      - name: Checkout repository
+        if: steps.secrets.outputs.missing == 'false'
+        uses: actions/checkout@v4
+        with:
+          token: ${{ env.EFFECTIVE_GITHUB_TOKEN || github.token }}
+
+      - name: Verify brain sources
+        if: steps.secrets.outputs.missing == 'false'
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f config/kv-state.json ]; then
+            echo 'config/kv-state.json missing; cannot continue.'
+            exit 1
+          fi
+
+          if [ -f docs/.brain.md ]; then
+            echo 'Found docs/.brain.md for context.'
+          elif [ -f brain/index.ts ]; then
+            echo 'Found brain/index.ts for context.'
+          else
+            echo '::warning::No docs/.brain.md or brain/index.ts found.'
+          fi
+
+      - name: Setup Node.js
+        if: steps.secrets.outputs.missing == 'false'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Enable Corepack and install pnpm
+        if: steps.secrets.outputs.missing == 'false'
+        run: |
+          corepack enable
+          corepack prepare pnpm@latest --activate
+
+      - name: Install dependencies
+        if: steps.secrets.outputs.missing == 'false'
+        run: pnpm install --frozen-lockfile
+
+      - name: Sync brain to KV
+        if: steps.secrets.outputs.missing == 'false'
+        run: pnpm updateBrain
+
+      - name: Verify remote brain payload
+        if: steps.secrets.outputs.missing == 'false'
+        run: pnpm exec tsx scripts/brainPing.ts
+
+      - name: Output brain sync log
+        if: steps.secrets.outputs.missing == 'false'
+        shell: bash
+        run: |
+          if [ -f brain-status.log ]; then
+            echo 'Brain sync log:'
+            cat brain-status.log
+          else
+            echo 'brain-status.log was not produced.'
+          fi


### PR DESCRIPTION
## Summary
- inline the brain sync workflow steps so we can manage pnpm setup directly
- enable Corepack and activate pnpm before installing dependencies to avoid install failures

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e59efc8af08327825463a13b3d74f6