### PR TITLE
Add manual Cloudflare KV config sync workflow

### DIFF
--- a/.github/workflows/manual-kv-config-sync.yml
+++ b/.github/workflows/manual-kv-config-sync.yml
@@ -1,0 +1,96 @@
+name: Manual KV config sync
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        type: boolean
+        default: false
+        description: "Run in dry-run mode (no writes)"
+      min_writes_remaining:
+        type: number
+        default: 100
+        description: "Abort if estimated remaining writes drop below this threshold"
+      window_seconds:
+        type: number
+        default: 86400
+        description: "Usage window (seconds) for quota checks"
+      warn_at_writes:
+        type: number
+        default: 900
+        description: "Emit a workflow warning if writes in the window reach this value"
+      reason:
+        type: string
+        default: manual-trigger
+        description: "Why are we syncing the config now?"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      ALLOW_KV_WRITES: true
+      KV_SYNC_SAFE_MODE: true
+      KV_SYNC_ENFORCE_QUOTA: true
+      KV_SYNC_DAILY_LIMIT: 1000
+      KV_SYNC_USAGE_WINDOW: ${{ inputs.window_seconds }}
+      KV_SYNC_MIN_WRITES: ${{ inputs.min_writes_remaining }}
+      KV_SYNC_DRY_RUN: ${{ inputs.dry_run }}
+      KV_MANUAL_USAGE_WINDOW: ${{ inputs.window_seconds }}
+      KV_MANUAL_ABORT_REMAINING: ${{ inputs.min_writes_remaining }}
+      KV_MANUAL_WARN_WRITES: ${{ inputs.warn_at_writes }}
+      KV_SYNC_REASON: ${{ inputs.reason }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.12.0
+          run_install: false
+
+      - name: Enable Corepack
+        run: |
+          corepack enable
+          corepack prepare pnpm@9.12.0 --activate
+
+      - name: Enable PNPM cache
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Log sync reason
+        run: |
+          if [ -n "${KV_SYNC_REASON}" ]; then
+            echo "KV sync reason: ${KV_SYNC_REASON}" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Check KV usage (preflight)
+        id: usage
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_KV_POSTQ_NAMESPACE_ID: ${{ secrets.CF_KV_POSTQ_NAMESPACE_ID }}
+        run: pnpm exec tsx scripts/manualKvUsageCheck.ts
+
+      - name: Highlight high usage warning
+        if: steps.usage.outputs.warn == 'true'
+        run: echo "Cloudflare KV writes already exceeded the warning threshold; review the log above." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Sync config JSON to KV
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_KV_POSTQ_NAMESPACE_ID: ${{ secrets.CF_KV_POSTQ_NAMESPACE_ID }}
+          CF_KV_NAMESPACE_ID: ${{ secrets.CF_KV_POSTQ_NAMESPACE_ID }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+        run: pnpm run kv:sync

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Automatic KV writes are disabled by default because `isKvWriteAllowed` returns `
 calling `put`. To push updates:
 
 1. Refresh local artifacts with `pnpm updateBrain` after editing `brain/brain.md`.
-2. Run the manual GitHub Action [`.github/workflows/seed-kv.yml`](.github/workflows/seed-kv.yml) or execute `pnpm kv:sync --safe` locally.
+2. Run the manual GitHub Action [`.github/workflows/seed-kv.yml`](.github/workflows/seed-kv.yml), trigger the new [manual config sync workflow](.github/workflows/manual-kv-config-sync.yml), or execute `pnpm kv:sync --safe` locally.
    - Safe mode enforces quota checks (24h window by default) and refuses to write if fewer than 100 operations remain.
    - Supply the `dry_run` input (or pass `--dry-run`) to preview the writes without touching Cloudflare.
    - The script resolves both repo files and secrets referenced in `kv/worker-kv.json`, so missing environment variables simply skip keys.
@@ -73,6 +73,7 @@ Monitoring & guardrails:
 
 - `pnpm kv:usage` (and the scheduled workflow [`.github/workflows/kv-usage-monitor.yml`](.github/workflows/kv-usage-monitor.yml))
   fetch Cloudflare analytics, warn when fewer than 150 writes remain, and fail when under 100.
+- The [manual KV sync workflow](.github/workflows/manual-kv-config-sync.yml) adds a preflight analytics probe that warns when writes in the selected window pass 900 (configurable) and refuses to run if estimated remaining quota drops under your threshold. See [`docs/manual-kv-sync.md`](docs/manual-kv-sync.md) for details on the knobs it exposes.
 - Set `KV_USAGE_EXPECT_IDLE=true` (with an optional `KV_USAGE_IDLE_THRESHOLD`) to alert if any background job starts writing again.
 - For other scripts, you can toggle `ALLOW_KV_WRITES` / `DISABLE_KV_WRITES`, `KV_SYNC_MIN_WRITES`, `KV_SYNC_USAGE_WINDOW`, and
   `KV_SYNC_SAFE_MODE` to fine-tune the safety net. `BRAIN_SYNC_SKIP_DIRECT_KV=true` keeps `scripts/updateBrain.ts` in read-only mode.

--- a/docs/manual-kv-sync.md
+++ b/docs/manual-kv-sync.md
@@ -1,0 +1,61 @@
+# Manual Cloudflare KV config sync
+
+The workflow [`.github/workflows/manual-kv-config-sync.yml`](../.github/workflows/manual-kv-config-sync.yml) lets you push the
+repository's config JSON blobs into Cloudflare KV on demand. It wraps the existing `pnpm kv:sync` script with quota checks so you
+can safely update `PostQ:thread-state` (and related keys) without blowing through the 1,000 writes/day guardrail.
+
+## When to run it
+
+Trigger the workflow from the **Actions** tab whenever you need to promote changes in:
+
+- `config/thread-state.json`
+- `config/kv-state.json`
+- `brain/brain.json` or `brain/brain.md`
+- any extra mappings declared in `kv/worker-kv.json`
+
+Missing files or secrets are skipped automatically, so you can reuse the same workflow for partial updates.
+
+## Dispatch inputs
+
+| Input | Default | Purpose |
+| --- | --- | --- |
+| `dry_run` | `false` | Runs the sync in preview mode. The workflow still resolves payloads but does not write to KV. |
+| `min_writes_remaining` | `100` | Abort if the usage snapshot estimates fewer writes remaining than this threshold. |
+| `window_seconds` | `86400` | Time window (in seconds) for quota calculations. Use smaller windows when you're watching bursts. |
+| `warn_at_writes` | `900` | Emit a workflow warning (and summary note) when writes in the window meet/exceed this number. |
+| `reason` | `manual-trigger` | Optional note captured in the job summary so future audits know why the sync ran. |
+
+## Guardrails & environment flags
+
+The workflow sets the following environment variables before calling `pnpm kv:sync`:
+
+- `ALLOW_KV_WRITES=true` – opens the write gate for this job.
+- `KV_SYNC_SAFE_MODE=true` and `KV_SYNC_ENFORCE_QUOTA=true` – keep the script in quota-aware mode.
+- `KV_SYNC_DAILY_LIMIT=1000` – makes the sync use Cloudflare's default 1,000 writes/day allowance.
+- `KV_SYNC_USAGE_WINDOW` / `KV_MANUAL_USAGE_WINDOW` – share the selected analytics window with both the usage probe and the sync.
+- `KV_SYNC_MIN_WRITES` / `KV_MANUAL_ABORT_REMAINING` – abort the run if estimated remaining writes drop under the chosen threshold.
+- `KV_SYNC_DRY_RUN` – toggles dry-run behavior without editing the workflow itself.
+
+During the preflight check [`scripts/manualKvUsageCheck.ts`](../scripts/manualKvUsageCheck.ts) fetches analytics and will:
+
+1. Append a usage summary (writes, reads, deletes, remaining quota) to the job summary.
+2. Emit a GitHub Actions warning if the writes in the window meet the `warn_at_writes` threshold (default 900/day).
+3. Fail the workflow early when the remaining writes are at/below `min_writes_remaining` so the sync never starts.
+
+Because `pnpm kv:sync` reuses the same limits, you get a second quota check immediately before any writes occur.
+
+## Local equivalent
+
+To rehearse locally, export the same environment variables and run:
+
+```bash
+ALLOW_KV_WRITES=true \
+KV_SYNC_SAFE_MODE=true \
+KV_SYNC_ENFORCE_QUOTA=true \
+KV_SYNC_DAILY_LIMIT=1000 \
+KV_SYNC_MIN_WRITES=100 \
+KV_SYNC_USAGE_WINDOW=86400 \
+pnpm run kv:sync
+```
+
+Add `KV_SYNC_DRY_RUN=true` to preview changes without touching Cloudflare. The CLI honors the same guardrails as the workflow.

--- a/scripts/manualKvUsageCheck.ts
+++ b/scripts/manualKvUsageCheck.ts
@@ -1,0 +1,128 @@
+import { promises as fs } from 'node:fs';
+
+import {
+  DEFAULT_KV_DAILY_LIMIT,
+  estimateKvWritesRemaining,
+  fetchKvUsageSummary,
+} from '../lib/cloudflare/kvAnalytics';
+import { describeKvWriteState, isKvWriteAllowed } from '../shared/kvWrites';
+
+function parseNumber(value: unknown, fallback: number): number {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim().length > 0) {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return fallback;
+}
+
+function formatDuration(seconds?: number): string {
+  if (!seconds || !Number.isFinite(seconds)) {
+    return 'unknown window';
+  }
+  if (seconds >= 3600) {
+    const hours = (seconds / 3600).toFixed(1);
+    return `${hours}h`;
+  }
+  if (seconds >= 60) {
+    const minutes = Math.round(seconds / 60);
+    return `${minutes}m`;
+  }
+  return `${Math.round(seconds)}s`;
+}
+
+async function appendSummary(lines: string[]): Promise<void> {
+  const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+  if (!summaryPath) return;
+  try {
+    await fs.appendFile(summaryPath, `${lines.join('\n')}\n`, 'utf8');
+  } catch (error) {
+    console.warn('[kv-manual] Unable to append to GitHub summary:', error);
+  }
+}
+
+async function setOutputs(records: Record<string, string>): Promise<void> {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+  const serialized = Object.entries(records)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+  await fs.appendFile(outputPath, `${serialized}\n`, 'utf8');
+}
+
+async function main(): Promise<void> {
+  const windowSeconds = parseNumber(
+    process.env.KV_MANUAL_USAGE_WINDOW ?? process.env.KV_USAGE_WINDOW_SECONDS,
+    86400
+  );
+  const limit = Math.max(
+    1,
+    parseNumber(process.env.KV_MANUAL_DAILY_LIMIT ?? process.env.KV_SYNC_DAILY_LIMIT, DEFAULT_KV_DAILY_LIMIT)
+  );
+  const warnWrites = Math.max(0, parseNumber(process.env.KV_MANUAL_WARN_WRITES, 900));
+  const abortRemaining = Math.max(0, parseNumber(process.env.KV_MANUAL_ABORT_REMAINING, 50));
+
+  const allowed = isKvWriteAllowed(process.env);
+  const gateState = describeKvWriteState(process.env);
+  console.log(`[kv-manual] KV write gate is currently ${gateState}.`);
+  if (!allowed) {
+    console.warn('::warning::KV writes are disabled by configuration; sync will be skipped unless the gate is opened.');
+  }
+
+  const usage = await fetchKvUsageSummary({ sinceSeconds: windowSeconds });
+  const remaining = estimateKvWritesRemaining(usage, limit);
+  const windowLabel = formatDuration(usage.windowSeconds ?? windowSeconds);
+
+  console.log(
+    `[kv-manual] Usage window ${windowLabel}: writes=${usage.writes}, reads=${usage.reads}, deletes=${usage.deletes}, remaining≈${remaining} (limit=${limit}).`
+  );
+
+  const summaryLines = [
+    `### Manual KV sync usage (${windowLabel})`,
+    '',
+    `- Writes: **${usage.writes}**`,
+    `- Reads: ${usage.reads}`,
+    `- Deletes: ${usage.deletes}`,
+    `- Estimated remaining (limit ${limit}): ${remaining}`,
+    `- Gate state: ${gateState}`,
+  ];
+
+  let warn = false;
+  if (warnWrites > 0 && usage.writes >= warnWrites) {
+    warn = true;
+    console.warn(
+      `::warning::Cloudflare KV writes in the last ${windowLabel} reached ${usage.writes} (warn threshold ${warnWrites}).`
+    );
+    summaryLines.push('', `> ⚠️ Writes in window reached ${usage.writes} (warn at ${warnWrites}).`);
+  }
+
+  if (abortRemaining > 0 && remaining <= abortRemaining) {
+    summaryLines.push('', `> 🚫 Remaining writes ${remaining} at/below abort threshold ${abortRemaining}.`);
+    await appendSummary(summaryLines);
+    console.error(
+      `::error::Remaining KV writes (${remaining}) are at/below the safety threshold (${abortRemaining}). Refusing to continue.`
+    );
+    process.exit(1);
+    return;
+  }
+
+  await appendSummary(summaryLines);
+  await setOutputs({
+    writes: `${usage.writes}`,
+    reads: `${usage.reads}`,
+    deletes: `${usage.deletes}`,
+    remaining: `${remaining}`,
+    limit: `${limit}`,
+    window_seconds: `${usage.windowSeconds ?? windowSeconds}`,
+    warn: warn ? 'true' : 'false',
+  });
+}
+
+main().catch((error) => {
+  console.error('[kv-manual] Failed to collect KV usage:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add a workflow that manually syncs config JSON to Cloudflare KV with quota guardrails
- add a reusable usage check script that warns when writes exceed 900/day and aborts below the safety floor
- document the manual sync process, workflow inputs, and guardrail environment flags

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fc2c6ef3c88327805790103172b512